### PR TITLE
Adapt assertion steps to support multiple requests

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -5,7 +5,7 @@ require 'json'
 
 include Test::Unit::Assertions
 
-def find_request(request_index) request_index
+def find_request(request_index)
   request_index ||= 0
   return stored_requests[request_index]
 end


### PR DESCRIPTION
Updates the assertion steps to support scenarios where multiple requests are sent. An optional parameter which takes an index into stored requests is added to all the request_assertion steps.

E.g., the following syntax can now be used:

`And the "Content-Type" header equals "application/json"`
`And the "Content-Type" header equals "application/json" for request 2`