### PR TITLE
Add step for validating build api

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -38,8 +38,6 @@ Then(/^the request (\d+) is valid for the Build API$/) do |request_index|
   assert_not_nil(read_key_path(body, "appVersion"))
 end
 
-
-
 Then(/^the request (\d+) is valid for the Android Mapping API$/) do |request_index|
   parts = find_request(request_index)[:body]
   assert_equal(6, parts.size)


### PR DESCRIPTION
Validates that a payload matches the [build API](https://bugsnagbuildapi.docs.apiary.io/#introduction/updating-build-data) schema