### PR TITLE
Remove restriction on api part count for mapping api

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -40,7 +40,6 @@ end
 
 Then(/^the request (\d+) is valid for the Android Mapping API$/) do |request_index|
   parts = find_request(request_index)[:body]
-  assert_equal(6, parts.size)
   assert_not_nil(parts["proguard"])
   assert_not_nil(parts["apiKey"])
   assert_not_nil(parts["appId"])


### PR DESCRIPTION
The Android mapping API request body does not necessarily have 6 parts (the overwrite flag can be conditionally included)