### PR TITLE
feature: parsable time in seconds/timestamps

### DIFF
--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -37,6 +37,13 @@ end
 Then(/^the event "(.+)" ends with "(.+)"$/) do |field, string_value|
   step "the payload field \"events.0.#{field}\" ends with \"#{string_value}\""
 end
+Then(/^the event "(.+)" is a timestamp$/) do |field|
+  timestamp_regex = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
+  step "the payload field \"events.0.#{field}\" matches the regex \"#{timestamp_regex}\""
+end
+Then(/^the event "(.+)" is a parsable timestamp in seconds$/) do |field|
+  step "the payload field \"events.0.#{field}\" is a parsable timestamp in seconds"
+end
 
 Then(/^the exception "(.+)" starts with "(.+)"$/) do |field, string_value|
   step "the payload field \"events.0.exceptions.0.#{field}\" starts with \"#{string_value}\""

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -124,6 +124,20 @@ Then(/^the payload field "(.+)" is a non-empty array(?: for request (\d+))?$/) d
   assert_kind_of Array, value
   assert(value.length > 0, "the field '#{field}' must be a non-empty array")
 end
+Then(/^the payload field "(.+)" matches the regex "(.+)"(?: for request(\d+))?$/) do |field, regex, request_index|
+  value = read_key_path(find_request(request_index)[:body], field)
+  assert_match(regex, value)
+end
+Then(/^the payload field "(.+)" is a parsable timestamp in seconds(?: for request(\d+))?$/) do |field, request_index|
+  value = read_key_path(find_request(request_index)[:body], field)
+  begin
+    int = value.to_i
+    parsed_time = Time.at(int)
+  rescue => exception
+  end
+  assert_not_nil(parsed_time)
+end
+
 Then(/^each element in payload field "(.+)" has "(.+)"(?: for request (\d+))?$/) do |key_path, element_key_path, request_index|
   value = read_key_path(find_request(request_index)[:body], key_path)
   assert_kind_of Array, value

--- a/test/fixtures/sinatra-app/features/error_reporting.feature
+++ b/test/fixtures/sinatra-app/features/error_reporting.feature
@@ -38,3 +38,12 @@ Scenario: Sinatra override context
     And I navigate to the route "/notify?context=foo"
     Then I should receive a request
     And the event "context" equals "foo"
+
+Scenario: Sinatra handles metadata
+    # Tests the timestamp comparison
+    When I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And I start a Sinatra app
+    And I navigate to the route "/metadata"
+    Then I should receive a request
+    And the event "metaData.cake.cake_type" equals "Carrot"
+    And the event "metaData.cake.went_bad" is a parsable timestamp in seconds

--- a/test/fixtures/sinatra-app/features/fixtures/run_sinatra_app.sh
+++ b/test/fixtures/sinatra-app/features/fixtures/run_sinatra_app.sh
@@ -26,6 +26,10 @@ get '/notify' do
   send_manual_notify
 end
 
+get '/metadata' do
+  send_metadata_notification
+end
+
 def send_manual_notify
   if context = params[:context]
     Bugsnag.before_notify_callbacks << lambda do |report|
@@ -37,4 +41,13 @@ end
 
 def make_a_syntax_error
   rt()
+end
+
+def send_metadata_notification
+  Bugsnag.notify(InvariantException.new("The cake was really badly rotten")) do |report|
+    report.add_tab(:cake, {
+      :went_bad => Time.now.strftime("%s"),
+      :cake_type => "Carrot"
+    })
+  end
 end


### PR DESCRIPTION
	- Adds steps to verify that a given event parameter is a parsable time-in-seconds string
	- Adds support for regex comparisons to be made
	- Adds step for timestamp regex validation on payload parameters