### PR TITLE
fix(docker): Disable TTY connection when using exec

### DIFF
--- a/lib/features/support/docker.rb
+++ b/lib/features/support/docker.rb
@@ -63,7 +63,7 @@ def stop_stack(compose_file=$docker_compose_file)
 end
 
 def run_command_on_service(command, service, compose_file=$docker_compose_file)
-  run_docker_compose_command(compose_file, "exec #{service} #{command}")
+  run_docker_compose_command(compose_file, "exec -T #{service} #{command}")
 end
 
 def run_service_with_command(service, command, compose_file=$docker_compose_file)


### PR DESCRIPTION
- Adds -T flag to docker-compose exec calls to stop TTY related errors

This fixes an issue with docker-compose failing exec commands with the message `the input device is not a TTY`.  While I don't believe we need to worry about `tty` commands as any `execs` on containers should be running commands, not opening terminals.

Let me know if there may be a circumstance we won't want this flag and I can arg it out.