### PR TITLE
feature(Sessions): Include sessionCounts in check for valid sessions

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -137,6 +137,14 @@ Then(/^the payload field "(.+)" is a parsable timestamp in seconds(?: for reques
   assert_not_nil(parsed_time)
 end
 
+Then(/^the payload has a valid sessions array(?: for request (\d+))?$/) do
+  sessions = read_key_path(find_request(request_index)[:body], "sessions")
+  sessionCounts = read_key_path(find_request(request_index)[:body], "sessions")
+  value = sessions || sessionCounts
+  assert_kind_of Array, value
+  assert(value.length > 0, "the payload must contain a non empty sessions or sessionCounts array")
+end
+
 Then(/^each element in payload field "(.+)" has "(.+)"(?: for request (\d+))?$/) do |key_path, element_key_path, request_index|
   value = read_key_path(find_request(request_index)[:body], key_path)
   assert_kind_of Array, value

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -10,7 +10,7 @@ Then("the request is a valid for the session tracking API") do
     And the payload field "notifier.name" is not null
     And the payload field "notifier.url" is not null
     And the payload field "notifier.version" is not null
-    And the payload field "sessions" is a non-empty array
+    And the payload has a valid sessions array
 
     And the session "id" is not null
     And the session "startedAt" is not null
@@ -31,3 +31,19 @@ end
 Then(/^the session "(.+)" is null$/) do |field|
   step "the payload field \"sessions.0.#{field}\" is null"
 end
+Then("the sessionCount {string} is true") do |field|
+  step "the payload field \"sessionCounts.0.#{field}\" is true"
+end
+Then("the sessionCount {string} is false") do |field|
+  step "the payload field \"sessionCounts.0.#{field}\" is false"
+end
+Then(/^the sessionCount "(.+)" equals "(.+)"$/) do |field, string_value|
+  step "the payload field \"sessionCounts.0.#{field}\" equals \"#{string_value}\""
+end
+Then(/^the sessionCount "(.+)" is not null$/) do |field|
+  step "the payload field \"sessionCounts.0.#{field}\" is not null"
+end
+Then(/^the sessionCount "(.+)" is null$/) do |field|
+  step "the payload field \"sessionCounts.0.#{field}\" is null"
+end
+


### PR DESCRIPTION
In order to allow testing of server-side session tracking, this needs to be able to handle both sessions and sessionCounts arrays.