### PR TITLE
fix(payload regex): Ensure payload field regex checks work correctly

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -123,7 +123,8 @@ Then(/^the payload field "(.+)" is a non-empty array(?: for request (\d+))?$/) d
   assert_kind_of Array, value
   assert(value.length > 0, "the field '#{field}' must be a non-empty array")
 end
-Then(/^the payload field "(.+)" matches the regex "(.+)"(?: for request(\d+))?$/) do |field, regex, request_index|
+Then(/^the payload field "(.+)" matches the regex "(.+)"(?: for request(\d+))?$/) do |field, regex_string, request_index|
+  regex = Regexp.new(regex_string)
   value = read_key_path(find_request(request_index)[:body], field)
   assert_match(regex, value)
 end


### PR DESCRIPTION
The regex was too mangled to work correctly, so this converts the string back into a regex before calling `assert_match`