### PR TITLE
Fix /dev/null output on windows

### DIFF
--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -6,7 +6,7 @@ require 'json'
 MOCK_API_PORT = 19291
 SCRIPT_PATH = File.expand_path(File.join(File.dirname(__FILE__), "..", "scripts"))
 FAILED_SCENARIO_OUTPUT_PATH = File.join(Dir.pwd, 'maze_output')
-DEV_NULL = Gem.win_platform? ? 'NUL:' : '/dev/null'
+DEV_NULL = Gem.win_platform? ? 'NUL' : '/dev/null'
 
 Before do
   stored_requests.clear

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -6,6 +6,8 @@ require 'json'
 MOCK_API_PORT = 19291
 SCRIPT_PATH = File.expand_path(File.join(File.dirname(__FILE__), "..", "scripts"))
 FAILED_SCENARIO_OUTPUT_PATH = File.join(Dir.pwd, 'maze_output')
+WINDOWS = RUBY_PLATFORM =~ /(mingw|bccwin|wince|mswin32)/i
+DEV_NULL = WINDOWS ? 'NUL:' : '/dev/null'
 
 Before do
   stored_requests.clear
@@ -110,7 +112,7 @@ def run_script script_path
     puts "Running '#{load_path}'"
     pid = Process.spawn(@script_env, load_path)
   else
-    pid = Process.spawn(@script_env, load_path, :out => '/dev/null', :err => '/dev/null')
+    pid = Process.spawn(@script_env, load_path, :out => DEV_NULL, :err => DEV_NULL)
   end
   Process.detach(pid)
   @pids << pid
@@ -183,7 +185,7 @@ def start_server
   @thread = Thread.new do
     server = WEBrick::HTTPServer.new(
       :Port => MOCK_API_PORT,
-      Logger: WEBrick::Log.new("/dev/null"),
+      Logger: WEBrick::Log.new(DEV_NULL),
       AccessLog: [],
     )
     server.mount '/', Servlet

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -6,8 +6,7 @@ require 'json'
 MOCK_API_PORT = 19291
 SCRIPT_PATH = File.expand_path(File.join(File.dirname(__FILE__), "..", "scripts"))
 FAILED_SCENARIO_OUTPUT_PATH = File.join(Dir.pwd, 'maze_output')
-WINDOWS = RUBY_PLATFORM =~ /(mingw|bccwin|wince|mswin32)/i
-DEV_NULL = WINDOWS ? 'NUL:' : '/dev/null'
+DEV_NULL = Gem.win_platform? ? 'NUL:' : '/dev/null'
 
 Before do
   stored_requests.clear


### PR DESCRIPTION
The first of probably a few PRs to get `maze-runner` running on Windows.

`/dev/null` is not a valid path on windows, this seems to be the equivalent.