### PR TITLE
Fix signal usage

### DIFF
--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -119,7 +119,7 @@ end
 def kill_script
   @pids.each {|p|
     begin
-    Process.kill("HUP", p)
+    Process.kill("KILL", p)
     rescue Errno::ESRCH
     end
   }


### PR DESCRIPTION
I'm not sure if there is a reason for using SIGHUP but this is not supported on windows. It doesn't seem like we need to care if the process gets a chance to clean up as it is just our test scripts running and is only called after the scenario.

Another potential solution for this is to split based on the OS and use `taskkill` or similar on windows