### PR TITLE
Add event metadata flag

### DIFF
--- a/lib/features/scripts/launch-android-app.sh
+++ b/lib/features/scripts/launch-android-app.sh
@@ -15,6 +15,10 @@ if [ -z "$EVENT_TYPE" ]; then
     exit 1
 fi
 
+if [ -z "$EVENT_METADATA" ]; then
+    EVENT_METADATA="none"
+fi
+
 if [ -z "$MOCK_API_PORT" ]; then
     echo MOCK_API_PORT environment variable is not set
     exit 1
@@ -27,6 +31,7 @@ fi
 echo "Launching MainActivity with '$EVENT_TYPE'"
 adb shell am start -n "$APP_BUNDLE/$APP_ACTIVITY" \
     --es EVENT_TYPE "$EVENT_TYPE" \
+    --es EVENT_METADATA "$EVENT_METADATA" \
     --es BUGSNAG_PORT "$MOCK_API_PORT" \
     --es BUGSNAG_API_KEY "$BUGSNAG_API_KEY"
 


### PR DESCRIPTION
Adds a metadata flag which is passed to scenarios via ADB, allowing for multiple paths when running the same Scenario class