### PR TITLE
Improve ENV variable setting

### DIFF
--- a/lib/features/support/docker.rb
+++ b/lib/features/support/docker.rb
@@ -71,8 +71,8 @@ def run_service_with_command(service, command, compose_file=$docker_compose_file
 end
 
 def run_docker_compose_command(file, command, must_pass=true)
-  environment = @script_env.inject('') {|curr,(k,v)| curr + "#{k}=#{v} "} unless @script_env.nil?
-  run_command("#{environment} docker-compose -f #{file} #{command}", must_pass)
+  command = "docker-compose -f #{file} #{command}"
+  run_command(@script_env || {}, command, must_pass: must_pass)
 end
 
 at_exit do

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -96,6 +96,8 @@ def run_command(*cmd, must_pass: true)
   STDOUT.puts stderr if ENV['VERBOSE']
 
   assert_true(status.success?) if must_pass
+
+  stdout.split("\n")
 end
 
 def set_script_env key, value

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -89,25 +89,13 @@ def encode_query_params hash
   URI.encode_www_form hash
 end
 
-def run_command(cmd, must_pass=true)
-  command_status = nil
-  command_out = Set.new
+def run_command(*cmd, must_pass: true)
   STDOUT.puts cmd if ENV['VERBOSE']
-  Open3.popen3(cmd) do |stdin, stdout, stderr, thread|
-    { :out => stdout, :err => stderr }.each do |key, stream|
-      Thread.new do
-        until (output = stream.gets).nil? do
-          command_out << output
-          STDOUT.puts output if ENV['VERBOSE']
-        end
-      end
-    end
+  stdout, stderr, status = Open3.capture3(*cmd)
+  STDOUT.puts stdout if ENV['VERBOSE']
+  STDOUT.puts stderr if ENV['VERBOSE']
 
-    thread.join
-    command_status = thread.value
-  end
-  assert_true(command_status.success?) if must_pass
-  command_out
+  assert_true(status.success?) if must_pass
 end
 
 def set_script_env key, value


### PR DESCRIPTION
This method of setting ENV variables does not work on windows. 

We can let ruby set the env variables as part of the command so that we don't need to worry about the formatting of them for cross platform compatibility in the same way that `run_script` does