### PR TITLE
Fix typo in request error_reporting_steps.rb

### DIFF
--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -1,4 +1,4 @@
-Then("the request is a valid for the error reporting API") do
+Then(/^the request is(?: a)? valid for the error reporting API$/) do
   steps %Q{
     Then the "Bugsnag-API-Key" header is not null
     And the "Content-Type" header equals "application/json"


### PR DESCRIPTION
I made this change backwards compatible so that it doesn't break anyone's tests.

Ruby didn't like this change though, until I added an argument for the regex capture, even though I knew I would never use it. I called it `_`  – is that idiomatic (or idotic 😂) Ruby? Or is there a better way in the regex to declare a sequence of characters as optional without capturing them?