### PR TITLE
Fix test setup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,14 +3,16 @@ PATH
   specs:
     bugsnag-maze-runner (1.0.0)
       cucumber (~> 3.1.0)
+      cucumber-expressions (= 5.0.15)
       minitest (~> 5.0)
       rack (~> 2.0.0)
+      rake (~> 12.3.0)
       test-unit (~> 3.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.11.1)
+    backports (3.11.3)
     builder (3.2.3)
     cucumber (3.1.0)
       builder (>= 2.1.2)
@@ -25,7 +27,7 @@ GEM
       backports (>= 3.8.0)
       cucumber-tag_expressions (~> 1.1.0)
       gherkin (>= 5.0.0)
-    cucumber-expressions (5.0.13)
+    cucumber-expressions (5.0.15)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
@@ -34,15 +36,17 @@ GEM
     multi_json (1.13.1)
     multi_test (0.1.2)
     power_assert (1.1.1)
-    rack (2.0.3)
+    rack (2.0.5)
+    rake (12.3.1)
     test-unit (3.2.7)
       power_assert
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   bugsnag-maze-runner!
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -264,4 +264,4 @@ If steps would be useful for different projects running the maze, add the to
 ### Running the tests
 
 bugsnag-maze-runner uses test-unit and minunit to bootstrap itself and run the
-sample app suites in the test fixtures. Run `rake test` to run the suite.
+sample app suites in the test fixtures. Run `bundle exec rake` to run the suite.

--- a/Rakefile
+++ b/Rakefile
@@ -16,4 +16,4 @@ namespace :test do
   task :all => [:unit, :integration]
 end
 
-task :default => :test
+task :default => ["test:unit"]

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -45,4 +45,5 @@ Gem::Specification.new do |spec|
 
   # Pinned due to issues with 5.0.16-5.0.17
   spec.add_dependency "cucumber-expressions", "5.0.15"
+  spec.add_dependency "rake", "~> 12.3.0"
 end


### PR DESCRIPTION
While adding changes to maze-runner I noticed that some of our setup is a little busted. This adds the following:

- Add rake dependency so that we can run the rake file
- Fix the rake file so that the default task works
- Update the readme to specify the right command to run the tests