### PR TITLE
run_command needs assert_true so explicitly require it

### DIFF
--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -2,6 +2,8 @@ require 'rack'
 require 'open3'
 require 'webrick'
 require 'json'
+require 'test/unit'
+include Test::Unit::Assertions
 
 # This port number is semi-arbitrary. It doesn't matter for the sake of
 # the application what it is, but there are some constraints due to some


### PR DESCRIPTION
These dependencies get loaded later on by the `request_assertion_steps.rb` but my code calls the `run_command` function before that is loaded, causing a the following error:

```
undefined method `assert_true' for main:Object (NoMethodError)
```

One question, I don't know whether this should then be removed from `request_assertion_steps.rb`?