### PR TITLE
feat: Add "is {false|true|null|not null}" assertions to stack frame utils

### DIFF
--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -86,3 +86,7 @@ Then(/^the "(.+)" of stack frame (\d+) ends with "(.+)"$/) do |key, num, value|
   field = "events.0.exceptions.0.stacktrace.#{num}.#{key}"
   step "the payload field \"#{field}\" ends with \"#{value}\""
 end
+Then(/^the "(.+)" of stack frame (\d+) is (true|false|null|not null)$/) do |key, num, literal|
+  field = "events.0.exceptions.0.stacktrace.#{num}.#{key}"
+  step "the payload field \"#{field}\" is #{literal}"
+end


### PR DESCRIPTION
We can already do:

```cucumber
And the "file" of stack frame 1 equals "/usr/src/app/node_modules/lodash/lodash.js"
```

This adds the ability to do:

```cucumber
And the "inProject" of stack frame 1 is false
And the "inProject" of stack frame 1 is true
And the "inProject" of stack frame 1 is null
And the "inProject" of stack frame 1 is not null
```