### PR TITLE
Session payload request index assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,12 @@ This request will match:
 { "fruit": { "apple": "some nonsense" } }
 ```
 
+# On dealing with multiple requests
 
-
+Most payload assertion steps have optional suffix of `for request n` where `n` is a
+zero-based index into chronologically ordered collection of requests received by the
+mock server. If you leave off this suffix, the default behaviour is to run the step
+against request `0`, i.e. the first (and perhaps only) request.
 
 ## Running features
 

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -1,56 +1,48 @@
-Then("the request is a valid for the session tracking API") do
-  steps %Q{
-    Then the "Bugsnag-API-Key" header is not null
-    And the "Content-Type" header equals "application/json"
-    And the "Bugsnag-Payload-Version" header equals "1.0"
-    And the "Bugsnag-Sent-At" header is a timestamp
+def optional_request_index (request_index)
+  request_index.nil? ? "" : " for request #{request_index}"
+end
 
-    And the payload field "app" is not null
-    And the payload field "device" is not null
-    And the payload field "notifier.name" is not null
-    And the payload field "notifier.url" is not null
-    And the payload field "notifier.version" is not null
-    And the payload has a valid sessions array
+Then(/^(?:the )?request(?: (\d+))? is(?: a)? valid for the session tracking API$/) do |request_index|
+  steps %Q{
+    Then the "Bugsnag-API-Key" header is not null#{optional_request_index(request_index)}
+    And the "Content-Type" header equals "application/json"#{optional_request_index(request_index)}
+    And the "Bugsnag-Payload-Version" header equals "1.0"#{optional_request_index(request_index)}
+    And the "Bugsnag-Sent-At" header is a timestamp#{optional_request_index(request_index)}
+
+    And the payload field "app" is not null#{optional_request_index(request_index)}
+    And the payload field "device" is not null#{optional_request_index(request_index)}
+    And the payload field "notifier.name" is not null#{optional_request_index(request_index)}
+    And the payload field "notifier.url" is not null#{optional_request_index(request_index)}
+    And the payload field "notifier.version" is not null#{optional_request_index(request_index)}
+    And the payload has a valid sessions array#{optional_request_index(request_index)}
   }
 end
-Then("the session {string} is true") do |field|
-  step "the payload field \"sessions.0.#{field}\" is true"
+Then(/^the session "(.+)" is (true|false|null|not null)(?: for request (\d+))?$/) do |field, literal, request_index|
+  step "the payload field \"sessions.0.#{field}\" is #{literal}#{optional_request_index(request_index)}"
 end
-Then("the session {string} is false") do |field|
-  step "the payload field \"sessions.0.#{field}\" is false"
+Then(/^the session "(.+)" equals "(.+)"(?: for request (\d+))?$/) do |field, string_value, request_index|
+  step "the payload field \"sessions.0.#{field}\" equals \"#{string_value}\" for #{optional_request_index(request_index)}"
 end
-Then(/^the session "(.+)" equals "(.+)"$/) do |field, string_value|
-  step "the payload field \"sessions.0.#{field}\" equals \"#{string_value}\""
-end
-Then(/^the session "(.+)" is not null$/) do |field|
-  step "the payload field \"sessions.0.#{field}\" is not null"
-end
-Then(/^the session "(.+)" is null$/) do |field|
-  step "the payload field \"sessions.0.#{field}\" is null"
-end
-Then(/^the session "(.+)" is a timestamp$/) do |field|
+Then(/^the session "(.+)" is a timestamp(?: for request (\d+))?$/) do |field, request_index|
   timestamp_regex = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
-  step "the payload field \"sessions.0.#{field}\" matches the regex \"#{timestamp_regex}\""
+  step "the payload field \"sessions.0.#{field}\" matches the regex \"#{timestamp_regex}\"#{optional_request_index(request_index)}"
 end
-Then("the sessionCount {string} is true") do |field|
-  step "the payload field \"sessionCounts.0.#{field}\" is true"
+Then(/^the sessionCount "(.+)" is (true|false|null|not null)$/) do |field, literal, request_index|
+  step "the payload field \"sessionCounts.0.#{field}\" is false#{optional_request_index(request_index)}"
 end
-Then("the sessionCount {string} is false") do |field|
-  step "the payload field \"sessionCounts.0.#{field}\" is false"
+Then(/^the sessionCount "(.+)" equals "(.+)"(?: for request (\d+))?$/) do |field, string_value, request_index|
+  step "the payload field \"sessionCounts.0.#{field}\" equals \"#{string_value}\"#{optional_request_index(request_index)}"
 end
-Then(/^the sessionCount "(.+)" equals "(.+)"$/) do |field, string_value|
-  step "the payload field \"sessionCounts.0.#{field}\" equals \"#{string_value}\""
+Then(/^the sessionCount "(.+)" equals (\d+)(?: for request (\d+))?$/) do |field, int_value, request_index|
+  step "the payload field \"sessionCounts.0.#{field}\" equals #{int_value}#{optional_request_index(request_index)}"
 end
-Then(/^the sessionCount "(.+)" equals (\d+)$/) do |field, int_value|
-  step "the payload field \"sessionCounts.0.#{field}\" equals #{int_value}"
+Then(/^the sessionCount "(.+)" is not null(?: for request (\d+))?$/) do |field, request_index|
+  step "the payload field \"sessionCounts.0.#{field}\" is not null#{optional_request_index(request_index)}"
 end
-Then(/^the sessionCount "(.+)" is not null$/) do |field|
-  step "the payload field \"sessionCounts.0.#{field}\" is not null"
+Then(/^the sessionCount "(.+)" is null(?: for request (\d+))?$/) do |field, request_index|
+  step "the payload field \"sessionCounts.0.#{field}\" is null#{optional_request_index(request_index)}"
 end
-Then(/^the sessionCount "(.+)" is null$/) do |field|
-  step "the payload field \"sessionCounts.0.#{field}\" is null"
-end
-Then(/^the sessionCount "(.+)" is a timestamp$/) do |field|
+Then(/^the sessionCount "(.+)" is a timestamp(?: for request (\d+))?$/) do |field, request_index|
   timestamp_regex = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
-  step "the payload field \"sessionCounts.0.#{field}\" matches the regex \"#{timestamp_regex}\""
+  step "the payload field \"sessionCounts.0.#{field}\" matches the regex \"#{timestamp_regex}\"#{optional_request_index(request_index)}"
 end

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -21,7 +21,7 @@ Then(/^the session "(.+)" is (true|false|null|not null)(?: for request (\d+))?$/
   step "the payload field \"sessions.0.#{field}\" is #{literal}#{optional_request_index(request_index)}"
 end
 Then(/^the session "(.+)" equals "(.+)"(?: for request (\d+))?$/) do |field, string_value, request_index|
-  step "the payload field \"sessions.0.#{field}\" equals \"#{string_value}\" for #{optional_request_index(request_index)}"
+  step "the payload field \"sessions.0.#{field}\" equals \"#{string_value}\"#{optional_request_index(request_index)}"
 end
 Then(/^the session "(.+)" is a timestamp(?: for request (\d+))?$/) do |field, request_index|
   timestamp_regex = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/


### PR DESCRIPTION
In order to address https://github.com/bugsnag/bugsnag-js/pull/381#discussion_r208255754 I needed to make assertions against multiple session payloads in the same test. To do so, the session payload assertions needed the "for request n" suffix, so I added it to them all. It needed a little helper in the case were it wasn't passed in.

I also added this to the readme, as it wasn't mentioned there at all yet.

I used this branch with both the @bugsnag/node and @bugsnag/browser test suites, and they pass.