### PR TITLE
Check that only 1 thread uses the errorReportingThread flag

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -195,3 +195,16 @@ Then(/^each element in payload field "(.+)" has "(.+)"(?: for request (\d+))?$/)
            "Each element in '#{key_path}' must have '#{element_key_path}'")
   end
 end
+
+Then(/^the thread "(.+)" contains the error reporting flag?(?: for request (\d+))?$/) do |thread_id, request_index|
+  threads = read_key_path(find_request(request_index)[:body], "events.0.threads")
+  assert_kind_of Array, threads
+  count = 0
+
+  threads.each do |thread|
+    if thread["name"] == thread_id && thread["errorReportingThread"] == true
+      count += 1
+    end
+  end
+  assert_equal(1, count)
+end


### PR DESCRIPTION
Adds a step to check that only 1 thread trace contains the 'errorReportingThread' boolean flag.