### PR TITLE
Coerce thread id/name to a string, allowing comparison on cocoa

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -210,7 +210,7 @@ def validate_error_reporting_thread(payload_key, payload_value, request_index)
   count = 0
 
   threads.each do |thread|
-    if thread[payload_key] == payload_value && thread["errorReportingThread"] == true
+    if thread[payload_key].to_s == payload_value && thread["errorReportingThread"] == true
       count += 1
     end
   end


### PR DESCRIPTION
## Goal

Cocoa serialises the thread ID as an integer, not a string, which means `the thread with id "(.+)"` step failed.

## Changeset

Coerced object to a string.

## Tests

- Ran the mazerunner scenario on CI (pointed to this branch), ensuring that it now passes: https://travis-ci.org/bugsnag/bugsnag-cocoa/jobs/419114160#L951
- Ran the Android mazerunner scenario locally to ensure the `thread with name` step is not affected.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
