### PR TITLE
Server steps: Add required commands for Ruby & Laravel server tests

### DIFF
--- a/lib/features/steps/automation_steps.rb
+++ b/lib/features/steps/automation_steps.rb
@@ -37,3 +37,6 @@ end
 When(/^I wait for (\d+) seconds?$/) do |seconds|
   sleep(seconds)
 end
+When(/^I wait for the app to respond on port "(.*)"$/) do |port|
+  wait_for_response(port)
+end

--- a/lib/features/steps/compound_steps.rb
+++ b/lib/features/steps/compound_steps.rb
@@ -1,0 +1,31 @@
+When(/^I configure the bugsnag endpoint$/) do
+  steps %Q{
+    When I set environment variable "BUGSNAG_ENDPOINT" to "http://#{current_ip}:#{MOCK_API_PORT}"
+  }
+end
+When(/^I navigate to the route "(.*)" on port "(\d*)"/) do |route, port|
+  steps %Q{
+    When I open the URL "http://localhost:#{port}#{route}"
+    And I wait for 1 second
+  }
+end
+Then(/^the request used payload v4 headers$/) do
+  steps %Q{
+    Then the "bugsnag-api-key" header is not null
+    And the "bugsnag-payload-version" header equals "4.0"
+    And the "bugsnag-sent-at" header is a timestamp
+  }
+end
+Then(/^the request contained the api key "(.*)"$/) do |api_key|
+  steps %Q{
+    Then the "bugsnag-api-key" header equals "#{api_key}"
+    And the payload field "apiKey" equals "#{api_key}"
+  }
+end
+Then(/^the request used the "(.*)" notifier$/) do |notifier_name|
+  bugsnag_regex = /^http(s?):\/\/www.bugsnag.com/
+  steps %Q{
+    Then the payload field "notifier.name" equals "#{notifier_name}"
+    And the payload field "notifier.url" matches the regex "#{bugsnag_regex}"
+  }
+end

--- a/lib/features/steps/compound_steps.rb
+++ b/lib/features/steps/compound_steps.rb
@@ -23,9 +23,8 @@ Then(/^the request contained the api key "(.*)"$/) do |api_key|
   }
 end
 Then(/^the request used the "(.*)" notifier$/) do |notifier_name|
-  bugsnag_regex = /^http(s?):\/\/www.bugsnag.com/
   steps %Q{
     Then the payload field "notifier.name" equals "#{notifier_name}"
-    And the payload field "notifier.url" matches the regex "#{bugsnag_regex}"
+    And the payload field "notifier.url" is not null
   }
 end

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -91,6 +91,17 @@ def run_required_commands command_arrays
   end
 end
 
+def current_ip
+  if OS.mac?
+    'host.docker.internal'
+  else
+    ip_addr = `ifconfig | grep -Eo 'inet (addr:)?([0-9]*\\\.){3}[0-9]*' | grep -v '127.0.0.1'`
+    ip_list = /((?:[0-9]*\.){3}[0-9]*)/.match(ip_addr)
+    ip_list.captures.first
+  end
+end
+
+
 def encode_query_params hash
   URI.encode_www_form hash
 end

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -1,5 +1,6 @@
 require 'rack'
 require 'open3'
+require 'net/http'
 require 'webrick'
 require 'json'
 require 'test/unit'
@@ -101,6 +102,22 @@ def current_ip
   end
 end
 
+def wait_for_response(port)
+  max_attempts = ENV.include?('MAX_MAZE_CONNECT_ATTEMPTS')? ENV['MAX_MAZE_CONNECT_ATTEMPTS'].to_i : 10
+  attempts = 0
+  up = false
+  until (attempts >= max_attempts) || up
+    attempts += 1
+    begin
+      uri = URI("http://localhost:#{port}/")
+      response = Net::HTTP.get_response(uri)
+      up = (response.code == "200")
+    rescue EOFError
+    end
+    sleep 1
+  end
+  raise "App not ready in time!" unless up
+end
 
 def encode_query_params hash
   URI.encode_www_form hash


### PR DESCRIPTION
- Adds in compound steps used in several of the Server maze-tests, such as Ruby, Laravel & Python.
- Adds in `current_ip` support, that gives the current server host for allowing docker-containers to communicate.