### PR TITLE
Enabled starting a docker service without building first

### DIFF
--- a/lib/features/steps/docker_steps.rb
+++ b/lib/features/steps/docker_steps.rb
@@ -11,11 +11,15 @@ Given("I have built the service {string} from the stack {string}") do |service, 
 end
 
 When("I start the service {string}") do |service|
-  start_service service
+  start_service(service, true)
+end
+
+When("I start the service {string} without building") do |service|
+  start_service(service, false)
 end
 
 When("I start the service {string} from the stack {string}") do |service, filename|
-  start_service(service, filename)
+  start_service(service, true, filename)
 end
 
 When("I stop the service {string}") do |service|

--- a/lib/features/support/docker.rb
+++ b/lib/features/support/docker.rb
@@ -102,5 +102,4 @@ end
 
 at_exit do
   $docker_stack.each { |filename| stop_stack(filename) }
-  $docker_services.each { |service| stop_service(service[:service], service[:file])}
 end

--- a/lib/features/support/docker.rb
+++ b/lib/features/support/docker.rb
@@ -40,8 +40,8 @@ def build_service(service, compose_file=$docker_compose_file)
     :file => compose_file,
     :service => service
   }
-  unless docker_built_services.include?(reference)
-    docker_built_services << reference
+  unless $docker_built_services.include?(reference)
+    $docker_built_services << reference
     run_docker_compose_command(compose_file, "build #{service}")
   end
 end

--- a/lib/features/support/docker.rb
+++ b/lib/features/support/docker.rb
@@ -38,12 +38,12 @@ def build_service(service, compose_file=$docker_compose_file)
   run_docker_compose_command(compose_file, "build #{service}")
 end
 
-def start_service(service, compose_file=$docker_compose_file)
+def start_service(service, build=true, compose_file=$docker_compose_file)
   $docker_services << {
     :file => compose_file,
     :service => service
   }
-  run_docker_compose_command(compose_file, "up -d --build #{service}")
+  run_docker_compose_command(compose_file, "up -d #{build ? "--build" : ""} #{service}")
 end
 
 def stop_service(service, compose_file=$docker_compose_file)


### PR DESCRIPTION
## Goal
Adds support for starting a service without building it first.  While the steps aren't exactly idiomatic atm, there are multiple repositories relying on the current functionality, that would break if functionality was changed in the existing functions.

This is QoL, and isn't necessary for any docker-using maze tests, but would speed up tests where the docker build takes a long time, such as the upcoming Laravel tests.