### PR TITLE
Rescue Reset: Add ECONNRESET to rescue

### DIFF
--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -112,7 +112,7 @@ def wait_for_response(port)
       uri = URI("http://localhost:#{port}/")
       response = Net::HTTP.get_response(uri)
       up = (response.code == "200")
-    rescue EOFError
+    rescue EOFError, Errno::ECONNRESET
     end
     sleep 1
   end


### PR DESCRIPTION
## Goal
Enable the `wait_for_response` method to deal with the `Errno::ECONNRESET` error caused when trying to access a docker container too early.