### PR TITLE
Add appium_lib to dependencies

### DIFF
--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rake", "~> 12.3.0"
   spec.add_dependency "curb", "~> 0.9.6"
   spec.add_dependency "selenium-webdriver", "~> 3.11"
+  spec.add_dependency "appium_lib", "~> 10.2"
 end


### PR DESCRIPTION
## Goal

Adds `appium_lib` to the dependencies, allowing mobile interaction on via `selenium-webdriver`.