### PR TITLE
Extend payloadVersion matching for different notifiers

### DIFF
--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -1,9 +1,13 @@
+# Verifies that generic elements of the payload should be present
+#
+# @param payload_version [String] The payload version expected
+# @param notifier_name [String] The expected name of the notifier
 Then("the request is valid for the error reporting API version {string} for the {string} notifier") do |payload_version, notifier_name|
   steps %Q{
     Then the "Bugsnag-Api-Key" header equals "#{$api_key}"
     And the payload field "apiKey" equals "#{$api_key}"
     And the "Bugsnag-Payload-Version" header equals "#{payload_version}"
-    And the payload field "events.0.payloadVersion" equals "#{payload_version}"
+    And the payload contains the payloadVersion "#{payload_version}"
     And the "Content-Type" header equals "application/json"
     And the "Bugsnag-Sent-At" header is a timestamp
 
@@ -17,6 +21,17 @@ Then("the request is valid for the error reporting API version {string} for the 
     And each element in payload field "events" has "unhandled"
     And each element in payload field "events" has "exceptions"
   }
+end
+
+# Checks the payloadVersion is set correctly in the payload body in the Javascript or regular place
+#
+# @param payload_version [String] The payload version expected
+Then("the payload contains the payloadVersion {string}") do |payload_version|
+  body_version = read_key_path(Server.current_request[:body], "payloadVersion")
+  body_set = payloadVersion == body_version
+  event_version = read_key_path(Server.current_request[:body], "events.0.payloadVersion")
+  event_set = payloadVersion == event_version
+  assert_true(body_set || event_set, "The payloadVersion was not the expected value of #{payload_version}. #{body_version} found in body, #{event_version} found in event")
 end
 
 ## EVENT FIELD ASSERTIONS

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -158,7 +158,7 @@ Then("the payload field {string} ends with {string}") do |field_path, string_val
   assert_kind_of String, value
   assert(value.end_with? string_value, "Field '#{field_path}' does not end with '#{string_value}'")
 end
-Then("the payload field {string} is an array with {int} elements?") do |field, count|
+Then("the payload field {string} is an array with {int} elements") do |field, count|
   value = read_key_path(Server.current_request[:body], field)
   assert_kind_of Array, value
   assert_equal(count, value.length)

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -145,13 +145,25 @@ end
 Then("the payload field {string} equals {int}") do |field_path, int_value|
   assert_equal(int_value, read_key_path(Server.current_request[:body], field_path))
 end
+
+# Checks a given payload field contains a number larger than a given value
+#
+# @param field_path [String] The payload element to check
+# @param int_value [Integer] The value to compare against
 Then("the payload field {String} is greater than {int}") do |field_path, int_value|
   value = read_key_path(Server.current_request[:body], field_path)
-  assert_true(value > int_value, "The payload field '#{field_path}' is not greater than '#{int_value}'")
+  assert_kind_of Integer, value
+  assert(value > int_value, "The payload field '#{field_path}' is not greater than '#{int_value}'")
 end
-Then("the payload field {String} is lesser than {int}") do |field_path, int_value|
+
+# Checks a given payload field contains a number smaller than a given value
+#
+# @param field_path [String] The payload element to check
+# @param int_value [Integer] The value to compare against
+Then("the payload field {String} is less than {int}") do |field_path, int_value|
   value = read_key_path(Server.current_request[:body], field_path)
-  assert_true(value < int_value, "The payload field '#{field_path}' is not lesser than '#{int_value}'")
+  assert_kind_of Integer, value
+  assert(value < int_value, "The payload field '#{field_path}' is not less than '#{int_value}'")
 end
 Then("the payload field {string} equals {string}") do |field_path, string_value|
   assert_equal(string_value, read_key_path(Server.current_request[:body], field_path))
@@ -166,6 +178,11 @@ Then("the payload field {string} ends with {string}") do |field_path, string_val
   assert_kind_of String, value
   assert(value.end_with? string_value, "Field '#{field_path}' does not end with '#{string_value}'")
 end
+
+# Checks a given payload field is an array with at a certain element count
+#
+# @param field [String] The payload element to check
+# @param count [Integer] The value expected
 Then("the payload field {string} is an array with {int} elements") do |field, count|
   value = read_key_path(Server.current_request[:body], field)
   assert_kind_of Array, value

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -145,6 +145,14 @@ end
 Then("the payload field {string} equals {int}") do |field_path, int_value|
   assert_equal(int_value, read_key_path(Server.current_request[:body], field_path))
 end
+Then("the payload field {String} is greater than {int}") do |field_path, int_value|
+  value = read_key_path(Server.current_request[:body], field_path)
+  assert_true(value > int_value, "The payload field '#{field_path}' is not greater than '#{int_value}'")
+end
+Then("the payload field {String} is lesser than {int}") do |field_path, int_value|
+  value = read_key_path(Server.current_request[:body], field_path)
+  assert_true(value < int_value, "The payload field '#{field_path}' is not lesser than '#{int_value}'")
+end
 Then("the payload field {string} equals {string}") do |field_path, string_value|
   assert_equal(string_value, read_key_path(Server.current_request[:body], field_path))
 end


### PR DESCRIPTION
## Goal

It's been found that the `payloadVersion` location in the body of an error payload isn't consistent across notifiers (and isn't supposed to be).

In JS notifiers each event should contain its own `payloadVersion`, which is reflected in the existing check and Error reporting API document on APIary.

In other notifiers, the `payloadVersion` should be a top level key in the payload, which is what all the other notifiers currently do.

This change enables the testing of either of these positions in the same step, and updates the error reporting API validation step to work on the Android (and other) notifiers.