### PR TITLE
AppAutomateDriver: Better handling of Timeout errors

### DIFF
--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -2,7 +2,8 @@
 #
 # @param element_id [String] The locator id
 Given("the element {string} is present") do |element_id|
-  $driver.wait_for_element(element_id)
+  present = $driver.wait_for_element(element_id)
+  assert(present, "The element #{element_id} could not be found")
 end
 
 # Clicks a given element

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -53,12 +53,20 @@ class AppAutomateDriver < Appium::Driver
   #
   # @param element_id [String] the element to search for using the @element_locator strategy
   # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
-  def wait_for_element(element_id, timeout=15)
+  # @param retry_if_stale [Boolean] enables the method to retry acquiring the element if a StaleObjectException occurs
+  def wait_for_element(element_id, timeout=15, retry_if_stale=true)
     begin
       wait = Selenium::WebDriver::Wait.new(:timeout => timeout)
       wait.until { find_element(@element_locator, element_id).displayed? }
     rescue Selenium::WebDriver::Error::TimeoutError
       false
+    rescue Selenium::WebDriver::Error::StaleElementReferenceError => stale_error
+      if retry_if_stale
+        wait_for_element(element_id, timeout, false)
+      else
+        $logger.warn "StaleElementReferenceError occurred: #{stale_error}"
+        false
+      end
     else
       true
     end

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -54,8 +54,14 @@ class AppAutomateDriver < Appium::Driver
   # @param element_id [String] the element to search for using the @element_locator strategy
   # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
   def wait_for_element(element_id, timeout=15)
-    wait = Selenium::WebDriver::Wait.new(:timeout => timeout)
-    wait.until { find_element(@element_locator, element_id).displayed? }
+    begin
+      wait = Selenium::WebDriver::Wait.new(:timeout => timeout)
+      wait.until { find_element(@element_locator, element_id).displayed? }
+    rescue Selenium::WebDriver::Error::TimeoutError
+      false
+    else
+      true
+    end
   end
 
   # Clicks a given element

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -92,9 +92,9 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION)
 
     mocked_element = mock('element')
-    mocked_element.expects(:displayed?).returns(true).at_least_once
+    mocked_element.expects(:displayed?).returns(true)
 
-    driver.expects(:find_element).with(:id, "test_button").returns(mocked_element).at_least_once
+    driver.expects(:find_element).with(:id, "test_button").returns(mocked_element)
 
     response = driver.wait_for_element("test_button")
     assert(response, "The driver must return true if it finds an element")
@@ -105,9 +105,9 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION, :accessibility_id)
 
     mocked_element = mock('element')
-    mocked_element.expects(:displayed?).returns(true).at_least_once
+    mocked_element.expects(:displayed?).returns(true)
 
-    driver.expects(:find_element).with(:accessibility_id, "test_button").returns(mocked_element).at_least_once
+    driver.expects(:find_element).with(:accessibility_id, "test_button").returns(mocked_element)
 
     response = driver.wait_for_element("test_button")
     assert(response, "The driver must return true if it finds an element")

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -92,11 +92,12 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION)
 
     mocked_element = mock('element')
-    mocked_element.expects(:displayed?).returns(true)
+    mocked_element.expects(:displayed?).returns(true).at_least_once
 
-    driver.expects(:find_element).with(:id, "test_button").returns(mocked_element)
+    driver.expects(:find_element).with(:id, "test_button").returns(mocked_element).at_least_once
 
-    driver.wait_for_element("test_button")
+    response = driver.wait_for_element("test_button")
+    assert(response, "The driver must return true if it finds an element")
   end
 
   def test_wait_for_element_locator
@@ -104,11 +105,25 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION, :accessibility_id)
 
     mocked_element = mock('element')
-    mocked_element.expects(:displayed?).returns(true)
+    mocked_element.expects(:displayed?).returns(true).at_least_once
 
-    driver.expects(:find_element).with(:accessibility_id, "test_button").returns(mocked_element)
+    driver.expects(:find_element).with(:accessibility_id, "test_button").returns(mocked_element).at_least_once
 
-    driver.wait_for_element("test_button")
+    response = driver.wait_for_element("test_button")
+    assert(response, "The driver must return true if it finds an element")
+  end
+
+  def test_wait_for_element_failure
+    AppAutomateDriver.any_instance.stubs(:upload_app).returns(TEST_APP_URL)
+    driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION, :accessibility_id)
+
+    mocked_element = mock('element')
+    mocked_element.expects(:displayed?).returns(false).at_least_once
+
+    driver.expects(:find_element).with(:accessibility_id, "test_button").returns(mocked_element).at_least_once
+
+    response = driver.wait_for_element("test_button")
+    assert_false(response, "The driver must return false if it does not find an element")
   end
 
   def test_send_keys_to_element_defaults

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -131,9 +131,9 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION, :accessibility_id)
 
     mocked_element = mock('element')
-    mocked_element.expects(:displayed?).at_least(2).at_most(2).raises(Selenium::WebDriver::Error::StaleElementReferenceError, 'Element is stale').then.returns(true)
+    mocked_element.expects(:displayed?).times(2).raises(Selenium::WebDriver::Error::StaleElementReferenceError, 'Element is stale').then.returns(true)
 
-    driver.expects(:find_element).with(:accessibility_id, "test_button").returns(mocked_element).at_least(2).at_most(2)
+    driver.expects(:find_element).with(:accessibility_id, "test_button").returns(mocked_element).times(2)
 
     response = driver.wait_for_element("test_button")
     assert(response, "The driver must return true if it finds an element")
@@ -169,9 +169,9 @@ class AppAutomateDriverTest < Test::Unit::TestCase
 
     stale_error = Selenium::WebDriver::Error::StaleElementReferenceError.new("Element is stale")
     mocked_element = mock('element')
-    mocked_element.expects(:displayed?).at_least(2).at_most(2).raises(stale_error)
+    mocked_element.expects(:displayed?).once.raises(stale_error)
 
-    driver.expects(:find_element).with(:accessibility_id, "test_button").returns(mocked_element).at_least(2).at_most(2)
+    driver.expects(:find_element).with(:accessibility_id, "test_button").returns(mocked_element).once
 
     logger_mock.expects(:warn).with("StaleElementReferenceError occurred: #{stale_error}")
 


### PR DESCRIPTION
## Goal

Provides easier extending of the `wait_for_element` app automate method by returning `true` or `false` when waiting for an element and allowing the caller to determine how to handle the response, rather than raising a TimeoutError.