### PR TITLE
Default server wait time to 10s if not running in Buildkite

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -40,7 +40,8 @@ Then("I wait to receive a request") do
   step "I wait to receive 1 request"
 end
 Then("I wait to receive {int} request(s)") do |request_count|
-  max_attempts = 300
+  # Wait for 30 seconds on Buildkite, 10 seconds locally
+  max_attempts = ENV['BUILDKITE'] ? 300 : 100
   attempts = 0
   received = false
   until (attempts >= max_attempts) || received
@@ -48,7 +49,7 @@ Then("I wait to receive {int} request(s)") do |request_count|
     received = (Server.stored_requests.size >= request_count)
     sleep 0.1
   end
-  raise "Requests not received in 30s (received #{Server.stored_requests.size})" unless received
+  raise "Requests not received in #{max_attempts/10}s (received #{Server.stored_requests.size})" unless received
   unless Server.stored_requests.size == request_count
     $logger.warn Server.stored_requests.inspect
   end


### PR DESCRIPTION
## Goal
Enable faster local test runs by using different wait times on Buildkite vs locally.

This is risky as reducing the time waiting for responses to arrive may cause test failures and flakiness downstream, even if this should only effect local runs.

The other option would be to keep the default as 30s and enable that to be overridden by an environment variable - which would be more flexible but require more thought when running locally.