### PR TITLE
Check BrowserStack devices available

### DIFF
--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -26,8 +26,8 @@ class AppAutomateDriver < Appium::Driver
   def initialize(username, access_key, local_id, target_device, app_location, locator=:id)
     @device_type = target_device
     @element_locator = locator
-    @username = username
-    @access_key = access_key
+    @browser_stack_username = username
+    @browser_stack_access_key = access_key
     @local_id = local_id
     app_url = upload_app(username, access_key, app_location)
     capabilities = {
@@ -64,7 +64,7 @@ class AppAutomateDriver < Appium::Driver
   #
   # @return [Boolean] whether any devices are available
   def browser_stack_available
-    res = `curl -q -u "#{@username}:#{@access_key}" "#{BROWSER_STACK_PLAN_STATUS_URI}"`
+    res = `curl -q -u "#{@browser_stack_username}:#{@browser_stack_access_key}" "#{BROWSER_STACK_PLAN_STATUS_URI}"`
     response = JSON.parse(res)
     pp response
     raise "BrowserStack status check failed due to error: #{response['error']}" if response.include?('error')

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -59,6 +59,7 @@ class AppAutomateDriver < Appium::Driver
       super
     rescue Exception => e
       pp e
+      pp e.inspect
       raise e
     end
     true

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -55,7 +55,12 @@ class AppAutomateDriver < Appium::Driver
     pp "BrowserStack Available? #{browser_stack_available}"
     return false unless browser_stack_available
     start_local_tunnel
-    super
+    begin
+      super
+    rescue Exception => e
+      pp e
+      raise e
+    end
     true
   end
 

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -127,7 +127,7 @@ class AppAutomateDriver < Appium::Driver
 
   def start_local_tunnel
     status = nil
-    Open3.popen2("/BrowserStackLocal -d start --key #{@access_key} --local-identifier #{@local_id} --force-local") do |stdin, stdout, wait|
+    Open3.popen2("/BrowserStackLocal -d start --key #{@browser_stack_access_key} --local-identifier #{@local_id} --force-local") do |stdin, stdout, wait|
       status = wait.value
     end
     status

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -52,6 +52,7 @@ class AppAutomateDriver < Appium::Driver
   #
   # @return [Boolean] whether the driver was able to be started
   def start_driver
+    pp "BrowserStack Available? #{browser_stack_available}"
     return false unless browser_stack_available
     start_local_tunnel
     super

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -63,8 +63,9 @@ class AppAutomateDriver < Appium::Driver
   #
   # @return [Boolean] whether any devices are available
   def browser_stack_available
-    res = `curl -u "#{@username}:#{@access_key}" "#{BROWSER_STACK_PLAN_STATUS_URI}"`
+    res = `curl -q -u "#{@username}:#{@access_key}" "#{BROWSER_STACK_PLAN_STATUS_URI}"`
     response = JSON.parse(res)
+    pp response
     raise "BrowserStack status check failed due to error: #{response['error']}" if response.include?('error')
     response['parallel_sessions_running'] < response['parallel_sessions_max_allowed']
   end

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -211,7 +211,7 @@ class AppAutomateDriverTest < Test::Unit::TestCase
 
     Appium::Driver.any_instance.stubs(:start_driver).returns(true)
 
-    status_check = %(curl -u "#{USERNAME}:#{ACCESS_KEY}" "https://api-cloud.browserstack.com/app-automate/plan.json")
+    status_check = %(curl -q -u "#{USERNAME}:#{ACCESS_KEY}" "https://api-cloud.browserstack.com/app-automate/plan.json")
     json_response = JSON.dump({
       :parallel_sessions_running => 3,
       :parallel_sessions_max_allowed => 5
@@ -229,7 +229,7 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     AppAutomateDriver.any_instance.stubs(:upload_app).returns(TEST_APP_URL)
     driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION)
 
-    status_check = %(curl -u "#{USERNAME}:#{ACCESS_KEY}" "https://api-cloud.browserstack.com/app-automate/plan.json")
+    status_check = %(curl -q -u "#{USERNAME}:#{ACCESS_KEY}" "https://api-cloud.browserstack.com/app-automate/plan.json")
     json_response = JSON.dump({
       :error => "Error"
     })
@@ -244,7 +244,7 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     AppAutomateDriver.any_instance.stubs(:upload_app).returns(TEST_APP_URL)
     driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION)
 
-    status_check = %(curl -u "#{USERNAME}:#{ACCESS_KEY}" "https://api-cloud.browserstack.com/app-automate/plan.json")
+    status_check = %(curl -q -u "#{USERNAME}:#{ACCESS_KEY}" "https://api-cloud.browserstack.com/app-automate/plan.json")
     json_response = JSON.dump({
       :parallel_sessions_running => 5,
       :parallel_sessions_max_allowed => 5

--- a/test/fixtures/browserstack-app/features/support/env.rb
+++ b/test/fixtures/browserstack-app/features/support/env.rb
@@ -11,9 +11,13 @@ ENV["BUGSNAG_API_KEY"] = $api_key
 
 AfterConfiguration do |config|
   AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
-  $driver.start_driver
+  started = $driver.start_driver
+  if started
+    at_exit do
+      $driver.driver_quit
+    end
+  else
+    puts "Exiting: No BrowserStack devices are available"
+  end
 end
 
-at_exit do
-  $driver.driver_quit
-end


### PR DESCRIPTION
## Goal

Calling `start_driver` now returns a boolean describing whether the driver is able to be started based on the amount of devices currently in use by BrowserStack.

- `start_driver` now returns `true` if a devices slot is available, `false` if it's unavailable
- `browser_stack_available` acquires the current state of BrowserStack, returning `true` if the amount of devices in use are less than the total, `false` if the opposite is true, and raises an Error if it was unable to get a status update.

Before this is merged, minor updates should be prepared for Bugsnag JS and Bugsnag Android, as they should handle the value passed back from `start_driver` and act appropriately.