### PR TITLE
V2 unhandled helper steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,6 +32,12 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
 
+  - label: 'Payload helper tests'
+    plugins:
+      docker-compose#v2.5.1:
+        run: payload-helper-tests
+    command: 'bundle exec bugsnag-maze-runner'
+
   - wait
 
   - label: 'Release'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,9 @@ services:
       context: test/fixtures/comparison
       args:
         BUILDKITE_BRANCH:
+
+  payload-helper-tests:
+    build:
+      context: test/fixtures/payload-helpers
+      args:
+        BUILDKITE_BRANCH:

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -43,8 +43,8 @@ end
 #
 # @param event [Int] The event to verify
 # @param severity [String] Optional. An expected severity different to the default "warning"
-Then(/^event (\d+) is unhandled(?: with the severity "(.+)")$/) do |event, severity|
-  step "the payload field \"events.#{event}.unhandled\" is true"
+Then(/^event (\d+) is handled(?: with the severity "(.+)")$/) do |event, severity|
+  step "the payload field \"events.#{event}.unhandled\" is false"
 end
 
 # Checks the payloadVersion is set correctly in the payload body in the Javascript or regular place

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -31,7 +31,18 @@ end
 #
 # @param event [Int] The event to verify
 Then("event {int} is unhandled") do |event|
-  step "the payload field \"events.#{event}.unhandled\" is true"
+  if read_key_path(Server.current_request[:body], "events.#{event}.session").nil?
+    steps %Q{
+      Then the payload field "events.#{event}.unhandled" is true
+      And the payload field "events.#{event}.severity" equals "error"
+    }
+  else
+    steps %Q{
+      Then the payload field "events.#{event}.unhandled" is true
+      And the payload field "events.#{event}.severity" equals "error"
+      And the payload field "events.#{event}.session.events.unhandled" is greater than 0
+    }
+  end
 end
 
 # Verifies that an event is correct for an unhandled error
@@ -43,7 +54,18 @@ end
 # @param event [Int] The event to verify
 # @param severity [String] An expected severity different to the default "error"
 Then("event {int} is unhandled with the severity {string}") do |event, severity|
-  step "the payload field \"events.#{event}.unhandled\" is true"
+  if read_key_path(Server.current_request[:body], "events.#{event}.session").nil?
+    steps %Q{
+      Then the payload field "events.#{event}.unhandled" is true
+      And the payload field "events.#{event}.severity" equals "#{severity}"
+    }
+  else
+    steps %Q{
+      Then the payload field "events.#{event}.unhandled" is true
+      And the payload field "events.#{event}.severity" equals "#{severity}"
+      And the payload field "events.#{event}.session.events.unhandled" is greater than 0
+    }
+  end
 end
 
 # Verifies that an event is correct for an handled error
@@ -54,7 +76,18 @@ end
 #
 # @param event [Int] The event to verify
 Then("event {int} is handled") do |event|
-  step "the payload field \"events.#{event}.unhandled\" is false"
+  if read_key_path(Server.current_request[:body], "events.#{event}.session").nil?
+    steps %Q{
+      Then the payload field "events.#{event}.unhandled" is false
+      And the payload field "events.#{event}.severity" equals "warning"
+    }
+  else
+    steps %Q{
+      Then the payload field "events.#{event}.unhandled" is false
+      And the payload field "events.#{event}.severity" equals "warning"
+      And the payload field "events.#{event}.session.events.handled" is greater than 0
+    }
+  end
 end
 
 # Verifies that an event is correct for an handled error
@@ -66,7 +99,18 @@ end
 # @param event [Int] The event to verify
 # @param severity [String] An expected severity different to the default "error"
 Then("event {int} is handled with the severity {string}") do |event, severity|
-  step "the payload field \"events.#{event}.unhandled\" is false"
+  if read_key_path(Server.current_request[:body], "events.#{event}.session").nil?
+    steps %Q{
+      Then the payload field "events.#{event}.unhandled" is false
+      And the payload field "events.#{event}.severity" equals "#{severity}"
+    }
+  else
+    steps %Q{
+      Then the payload field "events.#{event}.unhandled" is false
+      And the payload field "events.#{event}.severity" equals "#{severity}"
+      And the payload field "events.#{event}.session.events.handled" is greater than 0
+    }
+  end
 end
 
 # Checks the payloadVersion is set correctly in the payload body in the Javascript or regular place

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -31,7 +31,7 @@ end
 #
 # @param event [Int] The event to verify
 # @param severity [String] Optional. An expected severity different to the default "error"
-Then(/^event (\d.) is unhandled(?: with the severity "(.+)")$/) do |event, severity|
+Then(/^event (\d+) is unhandled(?: with the severity "(.+)")$/) do |event, severity|
   step "the payload field \"events.#{event}.unhandled\" is true"
 end
 
@@ -43,7 +43,7 @@ end
 #
 # @param event [Int] The event to verify
 # @param severity [String] Optional. An expected severity different to the default "warning"
-Then(/^event (\d.) is unhandled(?: with the severity "(.+)")$/) do |event, severity|
+Then(/^event (\d+) is unhandled(?: with the severity "(.+)")$/) do |event, severity|
   step "the payload field \"events.#{event}.unhandled\" is true"
 end
 

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -77,11 +77,13 @@ end
 # @param event [Int] The event to verify
 Then("event {int} is handled") do |event|
   if read_key_path(Server.current_request[:body], "events.#{event}.session").nil?
+    pp "Handled no session"
     steps %Q{
       Then the payload field "events.#{event}.unhandled" is false
       And the payload field "events.#{event}.severity" equals "warning"
     }
   else
+    pp "Handled with session"
     steps %Q{
       Then the payload field "events.#{event}.unhandled" is false
       And the payload field "events.#{event}.severity" equals "warning"

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -23,6 +23,30 @@ Then("the request is valid for the error reporting API version {string} for the 
   }
 end
 
+# Verifies that an event is correct for an unhandled error
+# This checks various elements of the payload matching an unhandled error including:
+#    The unhandled flag
+#    Any attached session information
+#    Severity
+#
+# @param event [Int] The event to verify
+# @param severity [String] Optional. An expected severity different to the default "error"
+Then(/^event (\d.) is unhandled(?: with the severity "(.+)")$/) do |event, severity|
+  step "the payload field \"events.#{event}.unhandled\" is true"
+end
+
+# Verifies that an event is correct for an handled error
+# This checks various elements of the payload matching an handled error including:
+#    The unhandled flag
+#    Any attached session information
+#    Severity
+#
+# @param event [Int] The event to verify
+# @param severity [String] Optional. An expected severity different to the default "warning"
+Then(/^event (\d.) is unhandled(?: with the severity "(.+)")$/) do |event, severity|
+  step "the payload field \"events.#{event}.unhandled\" is true"
+end
+
 # Checks the payloadVersion is set correctly in the payload body in the Javascript or regular place
 #
 # @param payload_version [String] The payload version expected

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -30,20 +30,42 @@ end
 #    Severity
 #
 # @param event [Int] The event to verify
-# @param severity [String] Optional. An expected severity different to the default "error"
-Then(/^event (\d+) is unhandled(?: with the severity "(.+)")$/) do |event, severity|
+Then("event {int} is unhandled") do |event|
   step "the payload field \"events.#{event}.unhandled\" is true"
 end
 
-# Verifies that an event is correct for an handled error
-# This checks various elements of the payload matching an handled error including:
+# Verifies that an event is correct for an unhandled error
+# This checks various elements of the payload matching an unhandled error including:
 #    The unhandled flag
 #    Any attached session information
 #    Severity
 #
 # @param event [Int] The event to verify
-# @param severity [String] Optional. An expected severity different to the default "warning"
-Then(/^event (\d+) is handled(?: with the severity "(.+)")$/) do |event, severity|
+# @param severity [String] An expected severity different to the default "error"
+Then("event {int} is unhandled with the severity {string}") do |event, severity|
+  step "the payload field \"events.#{event}.unhandled\" is true"
+end
+
+# Verifies that an event is correct for an handled error
+# This checks various elements of the payload matching an unhandled error including:
+#    The unhandled flag
+#    Any attached session information
+#    Severity
+#
+# @param event [Int] The event to verify
+Then("event {int} is handled") do |event|
+  step "the payload field \"events.#{event}.unhandled\" is false"
+end
+
+# Verifies that an event is correct for an handled error
+# This checks various elements of the payload matching an unhandled error including:
+#    The unhandled flag
+#    Any attached session information
+#    Severity
+#
+# @param event [Int] The event to verify
+# @param severity [String] An expected severity different to the default "error"
+Then("event {int} is handled with the severity {string}") do |event, severity|
   step "the payload field \"events.#{event}.unhandled\" is false"
 end
 

--- a/test/fixtures/payload-helpers/Dockerfile
+++ b/test/fixtures/payload-helpers/Dockerfile
@@ -1,0 +1,7 @@
+ARG BUILDKITE_BRANCH
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BUILDKITE_BRANCH}-ci
+
+RUN apk add bash curl
+
+COPY . /app
+WORKDIR /app

--- a/test/fixtures/payload-helpers/Gemfile
+++ b/test/fixtures/payload-helpers/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'bugsnag-maze-runner', path: '../../..'

--- a/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
@@ -1,0 +1,47 @@
+Feature: Testing helper methods respond correctly
+
+    Scenario: The request body matches an expected error payload
+        When I send a "payload"-type request
+        Then I wait to receive a request
+        And the request is valid for the error reporting API version "4.0" for the "Maze-runner" notifier
+
+    Scenario: The request body matches an expected session payload
+        When I send a "session"-type request
+        Then I wait to receive a request
+        And the request is valid for the session reporting API version "1.0" for the "Maze-runner" notifier
+
+    Scenario: The request body is correct for an unhandled payload
+        When I send a "unhandled"-type request
+        Then I wait to receive a request
+        And event 0 is unhandled
+
+    Scenario: The request body is correct for an unhandled payload with session data
+        When I send an "unhandled session"-type request
+        Then I wait to receive a request
+        And event 0 is unhandled
+
+    Scenario: The request body is correct for an unhandled payload with a custom severity
+        When I send an "unhandled severity"-type request
+        Then I wait to receive a request
+        And event 0 is unhandled with the severity "info"
+
+    Scenario: The request body is correct for a handled payload
+        When I send a "handled"-type request
+        Then I wait to receive a request
+        And event 0 is handled
+
+    Scenario: The request body is correct for a handled payload with session data
+        When I send a "handled session"-type request
+        Then I wait to receive a request
+        And event 0 is handled
+
+    Scenario: The request body is correct for a handled payload with a custom severity
+        When I send a "handled severity"-type request
+        Then I wait to receive a request
+        And event 0 is unhandled with the severity "error"
+
+    Scenario: The request body is correct for a payload with mixed events
+        When I send a "handled then unhandled"-type request
+        Then I wait to receive a request
+        And event 0 is handled
+        And event 1 is unhandled

--- a/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
@@ -38,7 +38,7 @@ Feature: Testing helper methods respond correctly
     Scenario: The request body is correct for a handled payload with a custom severity
         When I send a "handled severity"-type request
         Then I wait to receive a request
-        And event 0 is unhandled with the severity "error"
+        And event 0 is handled with the severity "error"
 
     Scenario: The request body is correct for a payload with mixed events
         When I send a "handled then unhandled"-type request

--- a/test/fixtures/payload-helpers/features/scripts/send_request.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_request.sh
@@ -112,7 +112,7 @@ templates = {
     }
   },
   'handled session' => {
-    'headers' => {}
+    'headers' => {},
     'body' => {
       'events' => [
         {

--- a/test/fixtures/payload-helpers/features/scripts/send_request.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_request.sh
@@ -51,7 +51,7 @@ templates = {
     }
   },
   'unhandled' => {
-    'headers' => {}
+    'headers' => {},
     'body' => {
       'events' => [
         {
@@ -65,7 +65,7 @@ templates = {
     }
   },
   'unhandled session' => {
-    'headers' => {}
+    'headers' => {},
     'body' => {
       'events' => [
         {
@@ -84,7 +84,7 @@ templates = {
     }
   },
   'unhandled severity' => {
-    'headers' => {}
+    'headers' => {},
     'body' => {
       'events' => [
         {
@@ -98,7 +98,7 @@ templates = {
     }
   },
   'handled' => {
-    'headers' => {}
+    'headers' => {},
     'body' => {
       'events' => [
         {
@@ -131,7 +131,7 @@ templates = {
     }
   },
   'handled severity' => {
-    'headers' => {}
+    'headers' => {},
     'body' => {
       'events' => [
         {
@@ -145,7 +145,7 @@ templates = {
     }
   },
   'handled then unhandled' => {
-    'headers' => {}
+    'headers' => {},
     'body' => {
       'events' => [
         {

--- a/test/fixtures/payload-helpers/features/scripts/send_request.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_request.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env ruby
+
+require 'net/http'
+require 'json'
+
+http = Net::HTTP.new('localhost', ENV['MOCK_API_PORT'])
+request = Net::HTTP::Post.new('/')
+request['Content-Type'] = 'application/json'
+
+templates = {
+  'payload' => {
+    'headers' => {
+      'Bugsnag-Api-Key' => ENV['BUGSNAG_API_KEY'],
+      'Bugsnag-Payload-Version' => '4.0',
+      'Bugsnag-Sent-At' => Time.now().utc().strftime('%Y-%m-%dT%H:%M:%S')
+    },
+    'body' => {
+      'apiKey' => ENV['BUGSNAG_API_KEY'],
+      'payloadVersion' => '4.0',
+      'notifier' => {
+        'name' => 'Maze-runner',
+        'url' => 'not null',
+        'version' => '4.4.4'
+      },
+      'events' => [
+        {
+          'severity' => 'bad',
+          'severityReason' => {
+            'type' => 'very bad'
+          },
+          'unhandled' => true,
+          'exceptions' => []
+        }
+      ]
+    }
+  },
+  'session' => {
+    'headers' => {
+      'Bugsnag-Api-Key' => ENV['BUGSNAG_API_KEY'],
+      'Bugsnag-Payload-Version' => '1.0',
+      'Bugsnag-Sent-At' => Time.now().utc().strftime('%Y-%m-%dT%H:%M:%S')
+    },
+    'body' => {
+      'notifier' => {
+        'name' => 'Maze-runner',
+        'url' => 'not null',
+        'version' => '4.4.4'
+      },
+      'app' => 'not null',
+      'device' => 'not null'
+    }
+  },
+  'unhandled' => {
+    'headers' => {}
+    'body' => {
+      'events' => [
+        {
+          'severity' => 'error',
+          'severityReason' => {
+            'type' => 'unhandled'
+          },
+          'unhandled' => true
+        }
+      ]
+    }
+  },
+  'unhandled session' => {
+    'headers' => {}
+    'body' => {
+      'events' => [
+        {
+          'severity' => 'error',
+          'severityReason' => {
+            'type' => 'unhandled'
+          },
+          'session' => {
+            'events' => {
+              'unhandled' => 1
+            }
+          },
+          'unhandled' => true
+        }
+      ]
+    }
+  },
+  'unhandled severity' => {
+    'headers' => {}
+    'body' => {
+      'events' => [
+        {
+          'severity' => 'info',
+          'severityReason' => {
+            'type' => 'userSpecifiedSeverity'
+          },
+          'unhandled' => true
+        }
+      ]
+    }
+  },
+  'handled' => {
+    'headers' => {}
+    'body' => {
+      'events' => [
+        {
+          'severity' => 'warning',
+          'severityReason' => {
+            'type' => 'handled'
+          },
+          'unhandled' => false
+        }
+      ]
+    }
+  },
+  'handled session' => {
+    'headers' => {}
+    'body' => {
+      'events' => [
+        {
+          'severity' => 'warning',
+          'severityReason' => {
+            'type' => 'handled'
+          },
+          'session' => {
+            'events' => {
+              'handled' => 1
+            }
+          },
+          'unhandled' => false
+        }
+      ]
+    }
+  },
+  'handled severity' => {
+    'headers' => {}
+    'body' => {
+      'events' => [
+        {
+          'severity' => 'error',
+          'severityReason' => {
+            'type' => 'userSpecifiedSeverity'
+          },
+          'unhandled' => false
+        }
+      ]
+    }
+  },
+  'handled then unhandled' => {
+    'headers' => {}
+    'body' => {
+      'events' => [
+        {
+          'severity' => 'warning',
+          'severityReason' => {
+            'type' => 'handled'
+          },
+          'session' => {
+            'events' => {
+              'handled' => 1,
+              'unhandled' => 0
+            }
+          },
+          'unhandled' => false
+        },
+        {
+          'severity' => 'error',
+          'severityReason' => {
+            'type' => 'unhandled'
+          },
+          'session' => {
+            'events' => {
+              'handled' => 1,
+              'unhandled' => 1
+            }
+          },
+          'unhandled' => true
+        }
+      ]
+    }
+  }
+}
+
+exit(1) if ENV['request_type'].nil?
+
+request_template = templates[ENV['request_type']]
+
+request_template['headers'].each do |header, value|
+  request[header] = value
+end
+
+request.body = JSON.dump(request_template['body'])
+
+http.request(request)

--- a/test/fixtures/payload-helpers/features/steps/scripting_steps.rb
+++ b/test/fixtures/payload-helpers/features/steps/scripting_steps.rb
@@ -1,0 +1,7 @@
+When(/^I send an? "(.+)"-type request$/) do |request_type|
+  steps %Q{
+    When I set environment variable "request_type" to "#{request_type}"
+    And I set environment variable "MOCK_API_PORT" to "9339"
+    And I run the script "features/scripts/send_request.sh" synchronously
+  }
+end

--- a/test/fixtures/payload-helpers/features/support/env.rb
+++ b/test/fixtures/payload-helpers/features/support/env.rb
@@ -1,0 +1,1 @@
+ENV["BUGSNAG_API_KEY"] = $api_key


### PR DESCRIPTION
## Goal

Adds simple checks that an error has the correct unhandled/handled flags, default or custom severity, and checks that unhandled/handled counts in sessions are correct.
Further details, such as checking severity reasons should be done on a per-test basis, as that can vary wildly in different notifiers and frameworks.