### PR TITLE
Fix failed request write: Check content-type is JSON before writing

### DIFF
--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -57,7 +57,11 @@ def write_failed_requests_to_disk(scenario)
         end
         file.puts
         file.puts "BODY:"
-        file.puts JSON.pretty_generate(request[:body])
+        if request[:request].header["content-type"].first == 'application/json'
+          file.puts JSON.pretty_generate(request[:body])
+        else
+          file.puts "The request body was a non-JSON format"
+        end
       end
     end
   end

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -60,7 +60,7 @@ def write_failed_requests_to_disk(scenario)
         if request[:request].header["content-type"].first == 'application/json'
           file.puts JSON.pretty_generate(request[:body])
         else
-          file.puts "The request body was a non-JSON format"
+          file.puts request[:body]
         end
       end
     end


### PR DESCRIPTION
## Goal

Prevents errors when writing failed requests to disk if the content-type is not JSON.

Tested locally, it continues to write JSON payloads to disk and doesn't fail when writing a non-JSON payload.

This is a simple fix, as a feature we could add a switch and parse different content-types differently (i.e. output formdata, ignore binary objects).

Replaces https://github.com/bugsnag/maze-runner/pull/64