### PR TITLE
Enable additional capabilities in Appium

### DIFF
--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -20,7 +20,8 @@ class AppAutomateDriver < Appium::Driver
   # @param target_device [String] a key from the Devices array selecting which device capabilities to target
   # @param app_location [String] the location of the test-app to upload
   # @param locator [Symbol] the primary locator strategy Appium should use to find elements
-  def initialize(username, access_key, local_id, target_device, app_location, locator=:id)
+  # @param additional_capabilities [Hash] a hash of additional capabilities to be used in this test run
+  def initialize(username, access_key, local_id, target_device, app_location, locator=:id, additional_capabilities={})
     @device_type = target_device
     @element_locator = locator
     @access_key = access_key
@@ -34,6 +35,7 @@ class AppAutomateDriver < Appium::Driver
       'autoAcceptAlerts': 'true',
       'app' => app_url
     }
+    capabilities.merge! additional_capabilities
     capabilities.merge! devices[target_device]
     super({
       'caps' => capabilities,

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -42,6 +42,26 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     end
   end
 
+  def test_add_capabilities
+    AppAutomateDriver.any_instance.stubs(:upload_app).returns(TEST_APP_URL)
+    added_capabilities = {
+      "automationName" => "Appium"
+    }
+    driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION, :id, added_capabilities)
+
+    assert_equal('errors', driver.caps[:'browserstack.console'])
+    assert_equal(LOCAL_ID, driver.caps[:'browserstack.localIdentifier'])
+    assert_equal('true', driver.caps[:'browserstack.local'])
+    assert_equal('true', driver.caps[:'browserstack.networkLogs'])
+    assert_equal(TEST_APP_URL, driver.caps[:app])
+
+    Devices::DEVICE_HASH[TARGET_DEVICE].each do |key, value|
+      assert_equal(value, driver.caps[key.to_sym])
+    end
+
+    assert_equal('Appium', driver.caps[:automationName])
+  end
+
   def test_upload_app_success
     json_response = JSON.dump({
       :app_url => TEST_APP_URL


### PR DESCRIPTION
## Goal

Enables capabilities to be added to on a case-by-case basis, such as when needing to activate network or other kinds of logs on specific test runs.