### PR TITLE
Add project-name flag and update docker-compose image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker/compose:1.23.2 as compose
+FROM docker/compose:1.24.0 as compose
 FROM ruby:2.5-alpine as ci
 
 ENV GLIBC_VERSION 2.28-r0

--- a/lib/features/support/docker.rb
+++ b/lib/features/support/docker.rb
@@ -29,9 +29,18 @@ class Docker
       run_docker_compose_command("down -t 0", success_codes: [0,256]) if compose_stack_exists?
     end
 
+    def compose_project_name
+      @compose_project_name ||= nil
+    end
+
+    def compose_project_name=(project_name)
+      @compose_project_name = project_name
+    end
+
     private
     def run_docker_compose_command(command, compose_file:COMPOSE_FILENAME, success_codes:nil)
-      command = "docker-compose -f #{compose_file} #{command}"
+      project_name = compose_project_name.nil? ? "" : "-p #{compose_project_name}"
+      command = "docker-compose #{project_name} -f #{compose_file} #{command}"
       Runner.run_command(command, success_codes: success_codes)
     end
 


### PR DESCRIPTION
## Goal

Enables setting a compose project name for use in docker compose.  This allows multiple containers to be run from a single docker-compose file without interfering with one-another.

Example usage:

```ruby
Before do
  Docker.compose_project_name = "#{rand.to_s}:#{Time.new.strftime("%s")}"
end
```

Required for the Ruby e2e tests move.

In addition, updates to a new version of docker-compose in the maze-runner image so that the `-a` flag can be used in `docker-compose ps` for debugging purposes.