### PR TITLE
V2 breadcrumb step updates

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -124,12 +124,13 @@ end
 
 ### Step definition links
 
-- [Request assertion steps](/maze-runner/requirements/step_transformers.html#step_definition64-stepdefinition)
-- [Error content steps](/maze-runner/requirements/step_transformers.html#step_definition25-stepdefinition)
-- [Session content steps](/maze-runner/requirements/step_transformers.html#step_definition55-stepdefinition)
+- [Request assertion steps](/maze-runner/requirements/step_transformers.html#step_definition66-stepdefinition)
+- [Error content steps](/maze-runner/requirements/step_transformers.html#step_definition29-stepdefinition)
+- [Breadcrumb steps](/maze-runner/requirements/step_transformers.html#step_definition21-stepdefinition)
+- [Session content steps](/maze-runner/requirements/step_transformers.html#step_definition57-stepdefinition)
 - [Environment steps](/maze-runner/requirements/step_transformers.html#step_definition1-stepdefinition)
 - [Script and docker steps](/maze-runner/requirements/step_transformers.html#step_definition7-stepdefinition)
-- [BrowserStack steps](//maze-runner/requirements/step_transformers.html#step_definition21-stepdefinition)
+- [BrowserStack steps](/maze-runner/requirements/step_transformers.html#step_definition25-stepdefinition)
 
 ### Step examples
 

--- a/lib/features/steps/breadcrumb_steps.rb
+++ b/lib/features/steps/breadcrumb_steps.rb
@@ -1,0 +1,31 @@
+# @!group Breadcrumb steps
+
+# Tests whether the first event entry contains a specific breadcrumb with a type and name.
+#
+# @step_input type [String] The expected breadcrumb's type
+# @step_input name [String] The expected breadcrumb's name
+Then("the event has a {string} breadcrumb named {string}") do |type, name|
+  value = Server.current_request[:body]["events"].first["breadcrumbs"]
+  found = false
+  value.each do |crumb|
+    if crumb["type"] == type and crumb["name"] == name then
+      found = true
+    end
+  end
+  fail("No breadcrumb matched: #{value}") unless found
+end
+
+# Tests whether the first event entry contains a specific breadcrumb with a type and message.
+#
+# @step_input type [String] The expected breadcrumb's type
+# @step_input message [String] The expected breadcrumb's message
+Then("the event has a {string} breadcrumb with message {string}") do |type, message|
+  value = Server.current_request[:body]["events"].first["breadcrumbs"]
+  found = false
+  value.each do |crumb|
+    if crumb["type"] == type and crumb["metaData"] and crumb["metaData"]["message"] == message then
+      found = true
+    end
+  end
+  fail("No breadcrumb matched: #{value}") unless found
+end

--- a/lib/features/steps/breadcrumb_steps.rb
+++ b/lib/features/steps/breadcrumb_steps.rb
@@ -29,3 +29,28 @@ Then("the event has a {string} breadcrumb with message {string}") do |type, mess
   end
   fail("No breadcrumb matched: #{value}") unless found
 end
+
+# Tests whether the first event entry does not contain a breadcrumb with a specific type.
+# Used for confirming filtering of breadcrumbs
+#
+# @step_input type [String] The type of breadcrumb is not expected to be present
+Then("the event does not have a {string} breadcrumb") do |type|
+  value = Server.current_request[:body]["events"].first["breadcrumbs"]
+  found = false
+  value.each do |crumb|
+    if crumb["type"] == type
+      found = true
+    end
+  end
+  fail("Breadcrumb with type: #{type} matched") if found
+end
+
+# Tests whether any breadcrumb matches a given JSON fixture.  This follows all the usual rules for JSON fixture matching.
+#
+# @step_input json_fixture [String] A path to the JSON fixture to compare against
+Then("the event contains a breadcrumb matching the JSON fixture in {string}") do |json_fixture|
+  breadcrumbs = read_key_path(Server.current_request[:body], "events.0.breadcrumbs")
+  expected = JSON.parse(open(json_fixture, &:read))
+  match = breadcrumbs.any? { |breadcrumb| value_compare(expected, breadcrumb).equal? }
+  assert(match, "No breadcrumbs in the event matched the given breadcrumb")
+end

--- a/lib/features/steps/breadcrumb_steps.rb
+++ b/lib/features/steps/breadcrumb_steps.rb
@@ -33,7 +33,7 @@ end
 # Tests whether the first event entry does not contain a breadcrumb with a specific type.
 # Used for confirming filtering of breadcrumbs
 #
-# @step_input type [String] The type of breadcrumb is not expected to be present
+# @step_input type [String] The type of breadcrumb expected to not be present
 Then("the event does not have a {string} breadcrumb") do |type|
   value = Server.current_request[:body]["events"].first["breadcrumbs"]
   found = false

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -164,36 +164,6 @@ Then("the event {string} matches the JSON fixture in {string}") do |field, fixtu
   step "the payload field \"events.0.#{field}\" matches the JSON fixture in \"#{fixture_path}\""
 end
 
-# Tests whether the first event entry contains a specific breadcrumb with a type and name.
-#
-# @step_input type [String] The expected breadcrumb's type
-# @step_input name [String] The expected breadcrumb's name
-Then("the event has a {string} breadcrumb named {string}") do |type, name|
-  value = Server.current_request[:body]["events"].first["breadcrumbs"]
-  found = false
-  value.each do |crumb|
-    if crumb["type"] == type and crumb["name"] == name then
-      found = true
-    end
-  end
-  fail("No breadcrumb matched: #{value}") unless found
-end
-
-# Tests whether the first event entry contains a specific breadcrumb with a type and message.
-#
-# @step_input type [String] The expected breadcrumb's type
-# @step_input message [String] The expected breadcrumb's message
-Then("the event has a {string} breadcrumb with message {string}") do |type, message|
-  value = Server.current_request[:body]["events"].first["breadcrumbs"]
-  found = false
-  value.each do |crumb|
-    if crumb["type"] == type and crumb["metaData"] and crumb["metaData"]["message"] == message then
-      found = true
-    end
-  end
-  fail("No breadcrumb matched: #{value}") unless found
-end
-
 # Tests whether a value in the first exception of the first event entry starts with a string.
 #
 # @step_input field [String] The relative location of the value to test

--- a/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
@@ -13,7 +13,7 @@ Feature: Breadcrumb helper steps
     Scenario: The payload does not contain a type of breadcrumb
         When I send a "breadcrumbs"-type request
         Then I wait to receive a request
-        And the event does not have a "request" type breadcrumb
+        And the event does not have a "request" breadcrumb
 
     Scenario: The payload has a breadcrumb which matches a JSON fixture
         When I send a "breadcrumbs"-type request

--- a/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
@@ -1,0 +1,21 @@
+Feature: Breadcrumb helper steps
+
+    Scenario: The payload contains a breadcrumb with a type and name
+        When I send a "breadcrumbs"-type request
+        Then I wait to receive a request
+        And the event has a "process" breadcrumb named "foo"
+
+    Scenario: The payload contains a breadcrumb with a type and message
+        When I send a "breadcrumbs"-type request
+        Then I wait to receive a request
+        And the event has a "process" breadcrumb with message "Foobar"
+
+    Scenario: The payload does not contain a type of breadcrumb
+        When I send a "breadcrumbs"-type request
+        Then I wait to receive a request
+        And the event does not have a "request" type breadcrumb
+
+    Scenario: The payload has a breadcrumb which matches a JSON fixture
+        When I send a "breadcrumbs"-type request
+        Then I wait to receive a request
+        And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/breadcrumb_match.json"

--- a/test/fixtures/payload-helpers/features/fixtures/breadcrumb_match.json
+++ b/test/fixtures/payload-helpers/features/fixtures/breadcrumb_match.json
@@ -1,0 +1,10 @@
+{
+    "type": "process",
+    "name": "bar",
+    "timestamp": "^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:[\\d\\.]+Z?$",
+    "metaData": {
+      "a": 1,
+      "b": 2,
+      "c": "NUMBER"
+    }
+  }

--- a/test/fixtures/payload-helpers/features/scripts/send_request.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_request.sh
@@ -176,7 +176,36 @@ templates = {
         }
       ]
     }
-  }
+  },
+  'breadcrumbs' => {
+    'headers' => {},
+    'body' => {
+      'events' => [
+        {
+          'breadcrumbs' => [
+            {
+              'type' => 'process',
+              'name' => 'foo',
+              'timestamp' => '2019-11-26T10:15:46Z',
+              'metaData' => {
+                'message' => "Foobar"
+              }
+            },
+            {
+              'type' => 'process',
+              'name' => 'bar',
+              'timestamp' => '2019-11-26T10:1823Z',
+              'metaData' => {
+                'a' => 1,
+                'b' => 2,
+                'c' => 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
 }
 
 exit(1) if ENV['request_type'].nil?

--- a/test/fixtures/payload-helpers/features/scripts/send_request.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_request.sh
@@ -194,7 +194,7 @@ templates = {
             {
               'type' => 'process',
               'name' => 'bar',
-              'timestamp' => '2019-11-26T10:1823Z',
+              'timestamp' => '2019-11-26T10:18:23Z',
               'metaData' => {
                 'a' => 1,
                 'b' => 2,


### PR DESCRIPTION
## Goal
This change moves the existing breadcrumb steps from error_reporting_steps.rb to their own file, breadcrumb_steps.rb.  In addition, it adds two new steps to enable easier testing of breadcrumbs:

- A step that tests that a breadcrumb with a particular type is not present within a payload, useful for testing both breadcrumb filtering and automatic breadcrumb configuration in notifiers such as JS
- A step that takes a JSON fixture and searches for a matching breadcrumb within a payload. This is useful for verifying the types of information and fields present in a breadcrumb without having to know the index of said breadcrumb.

In addition, this PR updates the step links to fit with the new docs generated by this PR, and adds some testing around the breadcrumb steps.