### PR TITLE
Buildkite agent updates: Prep for 4.3.5

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,7 @@ steps:
     if: build.branch == "v2" || build.branch == "master"
     plugins:
       docker-compose#v2.5.1:
-        run: ci
+        run: docs
     command: 'bundle exec rake docs:build_and_publish'
 
   - label: 'Release'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,15 +2,24 @@ steps:
   - label: ':docker: Build'
     plugins:
       - docker-compose#v2.5.1:
-          build: ci
+          build:
+            - ci
+            - comparison-tests
+            - browserstack-app-automate
+            - payload-helper-tests
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
-          cache-from: ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME:-[latest]}-ci
-      - docker-compose#v2.5.1:
-          push:
+          cache-from:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
   - wait
+
+  - label: ':docker: Push CI'
+    plugins:
+      - docker-compose#v2.5.1:
+          push:
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
   - label: 'Unit tests'
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,15 @@ steps:
 
   - wait
 
+  - label: ':docker: Push CI'
+    plugins:
+      - docker-compose#v2.5.1:
+          push:
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+
+  - wait
+
   - label: ':docker: Build test images'
     plugins:
       - docker-compose#v2.5.1:
@@ -20,13 +29,6 @@ steps:
             - payload-helper-tests
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
           build-parallel: true
-
-  - label: ':docker: Push CI'
-    plugins:
-      - docker-compose#v2.5.1:
-          push:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,9 @@
 steps:
-  - label: ':docker: Build'
+  - label: ':docker: Build CI image'
     plugins:
       - docker-compose#v2.5.1:
           build:
             - ci
-            - comparison-tests
-            - browserstack-app-automate
-            - payload-helper-tests
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
           cache-from:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
@@ -14,12 +11,27 @@ steps:
 
   - wait
 
+  - label: ':docker: Build test images'
+    plugins:
+      - docker-compose#v2.5.1:
+          build:
+            - comparison-tests
+            - browserstack-app-automate
+            - payload-helper-tests
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+          build-parallel: true
+          cache-from:
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+
   - label: ':docker: Push CI'
     plugins:
       - docker-compose#v2.5.1:
           push:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+
+  - wait
 
   - label: 'Unit tests'
     plugins:
@@ -53,7 +65,7 @@ steps:
     if: build.branch == "v2" || build.branch == "master"
     plugins:
       docker-compose#v2.5.1:
-        run: docs
+        run: ci
     command: 'bundle exec rake docs:build_and_publish'
 
   - label: 'Release'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,9 +20,6 @@ steps:
             - payload-helper-tests
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
           build-parallel: true
-          cache-from:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
   - label: ':docker: Push CI'
     plugins:


### PR DESCRIPTION
## Background

When updating to v4.3.5 elastic stack CI buildkite agent we found that due to a change made to how commands inside of extensions are run we were essentially unable to use two docker-compose plugins within a single build step, as only the first one would actually run.

In response to this we've updated to the last version that doesn't include this change (4.3.4), and have ticketed updating the existing pipelines that would have issues caused by this change.

## Goal

This PR re-arranges the maze-runner CI pipeline in order to work with the updated buildkite version.  It also provides a PoC and place for discussion of what changes would be required on other notifier pipelines.

## Changes

Overall I don't believe these changes represent massive steps away from how the notifier pipelines are currently set up, but I'll explain them to ensure that certain changes that would be advantageous can be picked up at this stage. 

### :docker: Build step
- This has been refactored from a step that built and cached the maze-runner image into two:
  1. Builds the image, caching from the normal locations
  2. Pushes the image to the remote image repository
- It also demonstrates the usage of the in-built image caching between steps. Due to the modified docker-compose file used by the docker-compose plugin, the images are automatically pushed to the ECR repo after building and are pulled down in subsequent steps referring to the same image.  This way they do not need to explicitly refer to, pull from, or in any way depend on the ECR repo.

### :docker: Push CI
- This step would not normally have to be as soon after the build step of a particular image, however as the latter test images build the last pushed `CI` image this is necessary to build all of the test images.

### :docker: Build test images
- This step also demonstrates the cross-caching capability built into the docker-compose plugin.  All three test images are built in this step, but then not pushed or explicitly cached in any way.
In the latter steps the images will not need to be rebuilt when attempting to run as they would previously, instead pulling down the previously built images from this step.  This allows for separation of build steps and helps to illustrate when a step is failing due to a build error vs when a step is failing due to an error when running.

## Application to other pipelines
These changes and the ideas behind them could be applied to other notifier pipelines in the following ways:
- The build and push/retag steps must be separated, giving us more flexibility in where we choose to push the image up.  Likely it'll retain the same order, i.e. building then immediately pushing for caching efficiency, but it could be useful in other scenarios.
- Build/Push steps can and should be grouped together where possible in order to make the steps as readable as possible. This also enables a fail-fast approach, where if an image would fail to build before it is run, the other builds should also immediately fail, as opposed to continuing to run and consume resources in a doomed pipeline.