### PR TITLE
Info log level by default

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -222,7 +222,7 @@ is being run.
 ### Logging
 
 Maze-runner contains a Ruby logger connected to `STDOUT` that will attempt to log several events that occur during the testing life-cycle.
-By default the logger is set to report `WARN` level events or higher, but will log `DEBUG` level events if the `VERBOSE` or `DEBUG` flags are set.
+By default the logger is set to report `INFO` level events or higher, but will log `DEBUG` level events if the `VERBOSE` or `DEBUG` flags are set.  If the `QUIET` flag is set it will instead log at the `ERROR` level and above, and this option will supercede the `VERBOSE` or `DEBUG` options.
 
 | Log Level | Event | Information |
 |-----------|-------|-------------|

--- a/DOCS.md
+++ b/DOCS.md
@@ -222,7 +222,7 @@ is being run.
 ### Logging
 
 Maze-runner contains a Ruby logger connected to `STDOUT` that will attempt to log several events that occur during the testing life-cycle.
-By default the logger is set to report `INFO` level events or higher, but will log `DEBUG` level events if the `VERBOSE` or `DEBUG` flags are set.  If the `QUIET` flag is set it will instead log at the `ERROR` level and above, and this option will supercede the `VERBOSE` or `DEBUG` options.
+By default the logger is set to report `INFO` level events or higher, but will log `DEBUG` level events if the `VERBOSE` or `DEBUG` flags are set.  If the `QUIET` flag is set it will instead log at the `ERROR` level and above.
 
 | Log Level | Event | Information |
 |-----------|-------|-------------|

--- a/lib/features/support/logger.rb
+++ b/lib/features/support/logger.rb
@@ -2,6 +2,8 @@ require 'logger'
 
 if ENV['VERBOSE'] || ENV['DEBUG']
   $logger = Logger.new(STDOUT, level: Logger::DEBUG)
+elsif ENV['QUIET']
+  $logger = Logger.new(STDOUT, level: Logger::ERROR)
 else
-  $logger = Logger.new(STDOUT, level: Logger::WARN)
+  $logger = Logger.new(STDOUT, level: Logger::INFO)
 end


### PR DESCRIPTION
## Goal

- Lower default log level from `WARN` to `INFO` allowing `INFO` to be used for general information output
- Add the `QUIET` flag which will set the log level to `ERROR`, removing most of our output information
