### PR TITLE
Add retries and fast-failure to maze-runner

### DIFF
--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -33,4 +33,4 @@ COPY . ./
 RUN bundle install
 
 FROM ci as cli
-ENTRYPOINT ["bundle", "exec", "maze-runner"]
+ENTRYPOINT ["bundle", "exec", "maze-runner", "--fail-fast", "--retry", "2"]


### PR DESCRIPTION
## Goal

Adds 2 automatic retries when a step fails.  These retries work immediately without running to the end of the tests.
In addition, ensures the tests will exit on the first test failure.  These conditions work in conjunction, so the retries will occur immediately after a failing scenario, with the tests exiting if the failure occurs 3 times.

## Testing

I've verified that this works manually, but the nature of the `fail-fast` tests mean that a solid test will potentially be difficult.  As this is an in-built feature of cucumber, I don't believe it is necessary to add exhaustive tests.

I can however add an integration test for the retries using a stateful fixture that will only pass after a number of retries.