### PR TITLE
Update v1 to Rake 12.3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,11 @@ Pods
 .bundle
 .gradle
 .idea
+.rakeTasks
 *.gem
+coverage/
 maze_output/
 Gemfile.lock
 package-lock.json
 test/fixtures/init-test
+**/src/main/gen/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5-alpine as ci
+FROM ruby:2.7-alpine as ci
 
 RUN apk update && apk add docker
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,14 @@ PATH
       minitest (~> 5.0)
       os (~> 1.0.0)
       rack (~> 2.0.0)
-      rake (~> 12.3.0)
+      rake (~> 12.3.3)
       test-unit (~> 3.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.11.4)
-    builder (3.2.3)
+    backports (3.17.0)
+    builder (3.2.4)
     cucumber (3.1.0)
       builder (>= 2.1.2)
       cucumber-core (~> 3.1.0)
@@ -33,22 +33,21 @@ GEM
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
     gherkin (5.1.0)
-    minitest (5.11.3)
-    multi_json (1.13.1)
+    minitest (5.14.0)
+    multi_json (1.14.1)
     multi_test (0.1.2)
-    os (1.0.0)
-    power_assert (1.1.3)
-    rack (2.0.5)
-    rake (12.3.1)
-    test-unit (3.2.8)
+    os (1.0.1)
+    power_assert (1.1.6)
+    rack (2.0.9)
+    rake (12.3.3)
+    test-unit (3.2.9)
       power_assert
 
 PLATFORMS
   ruby
-  x64-mingw32
 
 DEPENDENCIES
   bugsnag-maze-runner!
 
 BUNDLED WITH
-   1.17.1
+   2.1.2

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -46,5 +46,5 @@ Gem::Specification.new do |spec|
 
   # Pinned due to issues with 5.0.16-5.0.17
   spec.add_dependency "cucumber-expressions", "5.0.15"
-  spec.add_dependency "rake", "~> 12.3.0"
+  spec.add_dependency "rake", "~> 12.3.3"
 end


### PR DESCRIPTION
## Goal

Resolve security warning from Github due to outdated version of Rake.

## Design

Minimal set of changes possible made, as we are looking to promote the v2 branch asap.

## Changeset

### Changed

rake update to 12.3.3 minimum
Gemfile.lock regenerated
Dockerfile updated to provide Bundler 2
Generated files added to .gitignore

## Tests

Testing using existing unit tests and CI pipeline.
