### PR TITLE
V1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.0
+
+Various changes have been made since the 1.0.0 release, but no specific versioning strategy
+was not employed.  This minor release encapsulates those changes and no further significant 
+changes to the v1 series is expected (v2 already exists and should be used in preference).
+
 # 1.0.0
 
 Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (1.0.0)
+    bugsnag-maze-runner (1.1.0)
       cucumber (~> 3.1.0)
       cucumber-expressions (= 5.0.15)
       minitest (~> 5.0)

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -1,50 +1,46 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'version'
 
 Gem::Specification.new do |spec|
-  spec.name    = 'bugsnag-maze-runner'
+  spec.name = 'bugsnag-maze-runner'
   spec.version = BugsnagMazeRunner::VERSION
-  spec.authors = ['Delisa Mason']
-  spec.email   = ['iskanamagus@gmail.com']
+  spec.authors = ['Steve Kirkand']
+  spec.email = ['steve@bugsnag.com']
   spec.required_ruby_version = '>= 2.0.0'
   spec.description =
-    %q{
-    Automation steps and mock server to validate request payloads
-    response.
-    }
+    'Automation steps and mock server to validate request payloads response.'
   spec.summary = 'Bugsnag API request validation harness'
   spec.license = 'MIT'
-  spec.require_paths = ["lib"]
-  spec.files = [
-    'bin/bugsnag-maze-runner',
-    'bin/maze-runner',
-    'bin/commands/init.rb',
-    'bin/bugsnag-print-load-paths',
-    'lib/features/scripts/await-android-emulator.sh',
-    'lib/features/scripts/clear-android-app-data.sh',
-    'lib/features/scripts/install-android-app.sh',
-    'lib/features/scripts/launch-android-app.sh',
-    'lib/features/scripts/launch-android-emulator.sh',
-    'lib/features/steps/android_steps.rb',
-    'lib/features/steps/automation_steps.rb',
-    'lib/features/steps/error_reporting_steps.rb',
-    'lib/features/steps/request_assertion_steps.rb',
-    'lib/features/support/compare.rb',
-    'lib/features/support/env.rb',
-    'lib/features/support/docker.rb',
-    'lib/version.rb',
+  spec.require_paths = ['lib']
+  spec.files = %w[
+    bin/bugsnag-maze-runner
+    bin/maze-runner
+    bin/commands/init.rb
+    bin/bugsnag-print-load-paths
+    lib/features/scripts/await-android-emulator.sh
+    lib/features/scripts/clear-android-app-data.sh
+    lib/features/scripts/install-android-app.sh
+    lib/features/scripts/launch-android-app.sh
+    lib/features/scripts/launch-android-emulator.sh
+    lib/features/steps/android_steps.rb
+    lib/features/steps/automation_steps.rb
+    lib/features/steps/error_reporting_steps.rb
+    lib/features/steps/request_assertion_steps.rb
+    lib/features/support/compare.rb
+    lib/features/support/env.rb
+    lib/features/support/docker.rb
+    lib/version.rb
   ]
   spec.executables = spec.files.grep(%r{^bin/[\w\-]+$}) { |f| File.basename(f) }
 
-  spec.add_dependency "cucumber", "~> 3.1.0"
-  spec.add_dependency "test-unit", "~> 3.2.0"
-  spec.add_dependency "rack", "~> 2.0.0"
-  spec.add_dependency "minitest", "~> 5.0"
-  spec.add_dependency "os", "~> 1.0.0"
+  spec.add_dependency 'cucumber', '~> 3.1.0'
+  spec.add_dependency 'minitest', '~> 5.0'
+  spec.add_dependency 'os', '~> 1.0.0'
+  spec.add_dependency 'rack', '~> 2.0.0'
+  spec.add_dependency 'test-unit', '~> 3.2.0'
 
   # Pinned due to issues with 5.0.16-5.0.17
-  spec.add_dependency "cucumber-expressions", "5.0.15"
-  spec.add_dependency "rake", "~> 12.3.3"
+  spec.add_dependency 'cucumber-expressions', '5.0.15'
+  spec.add_dependency 'rake', '~> 12.3.3'
 end

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'version'
 
 Gem::Specification.new do |spec|
+  spec.metadata['allowed_push_host'] = 'https://bugsnag.jfrog.io/artifactory/api/gems/platforms-rubygems'
   spec.name = 'bugsnag-maze-runner'
   spec.version = BugsnagMazeRunner::VERSION
   spec.authors = ['Steve Kirkand']

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = "1.0.0"
+  VERSION = '1.1.0'.freeze
 end


### PR DESCRIPTION
## Goal

To create a distinct version of the v1 MazeRunner, encapsulating the a number of changes that went into master since the original "1.0.0" was conceived.  Some Rubocop style violations have also ben resolved (being wary of doing too much when v1 is going to be retired).

## Design

Publishing a gem to Artifactory (or any other gem repository) allows us to employ pessimistic upgrading in dependent gems, avoiding the need to raise PRs on notifier repos simply to change the version of MazeRunner that it uses.

## Tests

Most changes are visually identifiable as benign, but the updated gem was built and its content manual inspected (by untarring) to verify that the required files were still copied into the correct locations.

