### PR TITLE
Use rubygems.org as the push host

### DIFF
--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -3,7 +3,6 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'version'
 
 Gem::Specification.new do |spec|
-  spec.metadata['allowed_push_host'] = 'https://bugsnag.jfrog.io/artifactory/api/gems/platforms-rubygems'
   spec.name = 'bugsnag-maze-runner'
   spec.version = BugsnagMazeRunner::VERSION
   spec.authors = ['Steve Kirkand']


### PR DESCRIPTION
Removed limitation on Gem push host.

Maze Runner Gems must be pushed to rubygems.org in order that there is public read access for notifier repos to pull from.