### PR TITLE
V2 updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,12 +11,12 @@ PATH
       os (~> 1.0.0)
       rake (~> 12.3.3)
       selenium-webdriver (~> 3.11)
-      test-unit (~> 3.2.0)
+      test-unit (~> 3.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.2.1)
+    activesupport (6.0.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -26,7 +26,7 @@ GEM
       appium_lib_core (~> 3.3)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (3.5.0)
+    appium_lib_core (3.6.1)
       faye-websocket (~> 0.10.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.17.0)
@@ -75,16 +75,16 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     os (1.0.1)
-    power_assert (1.1.6)
+    power_assert (1.1.7)
     props (1.2.0)
       iniparser (>= 0.1.0)
     rake (12.3.3)
     redcarpet (3.5.0)
-    rubyzip (2.2.0)
+    rubyzip (2.3.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    test-unit (3.2.9)
+    test-unit (3.3.5)
       power_assert
     textutils (1.4.0)
       activesupport
@@ -92,7 +92,7 @@ GEM
       props (>= 1.1.2)
       rubyzip (>= 1.0.0)
     thread_safe (0.3.6)
-    tomlrb (1.2.9)
+    tomlrb (1.3.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     websocket-driver (0.7.1)

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "cucumber", "~> 3.1.0"
   spec.add_dependency "gherkin", "~> 5.1.0"
-  spec.add_dependency "test-unit", "~> 3.2.0"
+  spec.add_dependency "test-unit", "~> 3.3.0"
   spec.add_dependency "minitest", "~> 5.0"
   spec.add_dependency "os", "~> 1.0.0"
 

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -33,4 +33,4 @@ COPY . ./
 RUN bundle install
 
 FROM ci as cli
-ENTRYPOINT ["bundle", "exec", "maze-runner", "--fail-fast", "--retry", "2"]
+ENTRYPOINT ["bundle", "exec", "maze-runner"]


### PR DESCRIPTION
Two updates in this PR.
1) Update test-unit to prevent a warning being logged when running mazerunner
2) Remove the custom entrypoint that retries failures. If we want to do this it should be in the ci pipeline in the repo under test, as it is way more discoverable there. The merits of having it or not are a separate discussion that I believe has already happened, but having it baked in to the maze runner images means its hard to know that is why it is not running the full suite and its hard to disable it locally to opt out (you basically have to know you have to override the entrypoint).