### PR TITLE
Add HTTP version step

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -29,6 +29,9 @@ end
 Then(/^I should receive no requests$/) do
   step "I should receive 0 request"
 end
+Then(/^the HTTP version is "(.+)"(?: for request (\d+))?$/) do |http_version, request_index|
+  assert_equal(http_version, find_request(request_index)[:request].http_version.to_s)
+end
 Then(/^the "(.+)" header is not null(?: for request (\d+))?$/) do |header_name, request_index|
   assert_not_nil(find_request(request_index)[:request][header_name],
                 "The '#{header_name}' header should not be null")

--- a/test/fixtures/request-test/Gemfile
+++ b/test/fixtures/request-test/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'bugsnag-maze-runner', path: '../../..'

--- a/test/fixtures/request-test/features/steps/scripting_steps.rb
+++ b/test/fixtures/request-test/features/steps/scripting_steps.rb
@@ -5,3 +5,12 @@ When(/^I send an HTTP 1.1 request$/) do
     --data '{"foo":"FOO","bar":"BAR"}' \
     http://localhost:#{MOCK_API_PORT}`
 end
+
+When(/^I send an HTTP 1.0 request$/) do
+  `curl --header "Content-Type: application/json" \
+    --http1.0 \
+    --request POST \
+    --data '{"foo":"FOO","bar":"BAR"}' \
+    http://localhost:#{MOCK_API_PORT}`
+end
+

--- a/test/fixtures/request-test/features/steps/scripting_steps.rb
+++ b/test/fixtures/request-test/features/steps/scripting_steps.rb
@@ -1,0 +1,7 @@
+When(/^I send an HTTP 1.1 request$/) do
+  `curl --header "Content-Type: application/json" \
+    --http1.1 \
+    --request POST \
+    --data '{"foo":"FOO","bar":"BAR"}' \
+    http://localhost:#{MOCK_API_PORT}`
+end

--- a/test/fixtures/request-test/features/verify_request_steps.feature
+++ b/test/fixtures/request-test/features/verify_request_steps.feature
@@ -7,6 +7,7 @@ Feature: Tests steps that target request details
 
     Scenario: The HTTP version can be asserted against on different requests
         Given I send an HTTP 1.1 request
-        And I send an HTTP 1.1 request
+        And I send an HTTP 1.0 request
         Then I should receive 2 requests
-        And the HTTP version is "1.1" for request 1
+        And the HTTP version is "1.1" for request 0
+        And the HTTP version is "1.0" for request 1

--- a/test/fixtures/request-test/features/verify_request_steps.feature
+++ b/test/fixtures/request-test/features/verify_request_steps.feature
@@ -1,0 +1,12 @@
+Feature: Tests steps that target request details
+
+    Scenario: The HTTP version can be asserted against
+        Given I send an HTTP 1.1 request
+        Then I should receive a request
+        And the HTTP version is "1.1"
+
+    Scenario: The HTTP version can be asserted against on different requests
+        Given I send an HTTP 1.1 request
+        And I send an HTTP 1.1 request
+        Then I should receive 2 requests
+        And the HTTP version is "1.1" for request 1

--- a/test/integration/automation_test.rb
+++ b/test/integration/automation_test.rb
@@ -26,6 +26,10 @@ class SampleTest < Test::Unit::TestCase
   def test_comparing_requests_to_json_files
     run_scenario("test/fixtures/comparison")
   end
+  
+  def test_request_functions
+    run_scenario("test/fixtures/request-test")
+  end
 
   def test_init_command
     fixture_dir = "test/fixtures/init-test"


### PR DESCRIPTION
## Goal
Adds a step for interrogating the HTTP_VERSION of a given request

## Testing
Verified manually.
Added test fixture testing this step specifically.
To run:
`git checkout v1-add-http-versions`
`cd test/fixtures/request-test`
`bundle install`
`bundle exec maze-runner`