### PR TITLE
Resolve diversion of v1 work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0
+
+Addition of HTTP version steps.
+
 # 1.1.0
 
 Various changes have been made since the 1.0.0 release, but no specific versioning strategy

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'version'
 
 Gem::Specification.new do |spec|
+  spec.metadata['allowed_push_host'] = 'https://bugsnag.jfrog.io/artifactory/api/gems/platforms-rubygems'
   spec.name = 'bugsnag-maze-runner'
   spec.version = BugsnagMazeRunner::VERSION
   spec.authors = ['Steve Kirkand']


### PR DESCRIPTION
This resolves an unfortunate but small diversion of v1 changes over the master and v1 branch.

Once this is merged, master will be retagged at 1.2.0 and the v1 branch deleted.