### PR TITLE
V2 release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ':docker: Build CI image'
     plugins:
-      - docker-compose#v2.5.1:
+      - docker-compose#v3.3.0:
           build:
             - ci
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
@@ -13,7 +13,7 @@ steps:
 
   - label: ':docker: Push CI'
     plugins:
-      - docker-compose#v2.5.1:
+      - docker-compose#v3.3.0:
           push:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
@@ -22,7 +22,7 @@ steps:
 
   - label: ':docker: Build test images'
     plugins:
-      - docker-compose#v2.5.1:
+      - docker-compose#v3.3.0:
           build:
             - comparison-tests
             - browserstack-app-automate
@@ -34,19 +34,19 @@ steps:
 
   - label: 'Unit tests'
     plugins:
-      docker-compose#v2.5.1:
+      docker-compose#v3.3.0:
         run: ci
     command: 'bundle exec rake'
 
   - label: 'Comparison tests'
     plugins:
-      docker-compose#v2.5.1:
+      docker-compose#v3.3.0:
         run: comparison-tests
     command: 'bundle exec bugsnag-maze-runner'
 
   - label: 'Browserstack-app-automate integration test'
     plugins:
-      docker-compose#v2.5.1:
+      docker-compose#v3.3.0:
         run: browserstack-app-automate
     command: 'bundle exec bugsnag-maze-runner'
     concurrency: 5
@@ -54,25 +54,32 @@ steps:
 
   - label: 'Payload helper tests'
     plugins:
-      docker-compose#v2.5.1:
+      docker-compose#v3.3.0:
         run: payload-helper-tests
     command: 'bundle exec bugsnag-maze-runner'
 
   - wait
 
   - label: 'Update docs'
-    if: build.branch == "v2" || build.branch == "master"
+    if: build.branch == "master"
     plugins:
-      docker-compose#v2.5.1:
+      docker-compose#v3.3.0:
         run: docs
     command: 'bundle exec rake docs:build_and_publish'
 
-  - label: 'Release'
+  - label: 'Push Docker image branch'
     plugins:
-      - docker-compose#v2.5.1:
+      - docker-compose#v3.3.0:
           build: cli
-          cache-from: cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME:-[latest]}-cli
-      - docker-compose#v2.5.1:
+          cache-from: cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
+      - docker-compose#v3.3.0:
           push:
-            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
+
+  - label: 'Push Docker image for tag'
+    if: build.tag =~ /^v2\.[0-9]+\.[0-9]+\$/
+    plugins:
+      - docker-compose#v3.3.0:
+          push:
+            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BUILDKITE_TAG}-cli
+            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,84 +1,15 @@
 ## Goal
 
-<!-- What is the intent of this change?
-e.g. "When initializing the Bugsnag client, it is currently difficult to (...)
-      this change simplifies the process by (...)"
-
-     "Improves the performance of data filtering"
-
-     "Adds additional test coverage to multi-threaded use of Configuration
-      objects"
--->
-
-<!-- For new features, include design documentation:
+<!-- Why is this change necessary? -->
 
 ## Design
 
-Why was this approach to the goal used?
-
--->
+<!-- Why was this approach used? -->
 
 ## Changeset
 
-<!-- What structures or properties or functions were:
-
-### Added
-
-### Removed
-
-### Changed
-
--->
+<!-- What changed? -->
 
 ## Tests
 
-<!-- How was this change tested? What manual and automated tests were
-     run/added? -->
-
-## Discussion
-
-### Alternative Approaches
-
-<!-- What other approaches were considered or discussed? -->
-
-### Outstanding Questions
-
-<!-- Are there any parts of the design or the implementation which seem
-     less than ideal and that could require additional discussion?
-     List here: -->
-
-### Linked issues
-
-<!--
-
-Fixes #
-Related to #
-
--->
-
-## Review
-
-<!-- When submitting for review, consider the points for self-review and the
-     criteria which will be used for secondary review -->
-
-For the submitter, initial self-review:
-
-- [ ] Commented on code changes inline explain the reasoning behind the approach
-- [ ] Reviewed the test cases added for completeness and possible points for discussion
-- [ ] A changelog entry was added for the goal of this pull request
-- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
-- This pull request is ready for:
-  - [ ] Initial review of the intended approach, not yet feature complete
-  - [ ] Structural review of the classes, functions, and properties modified
-  - [ ] Final review
-
-For the pull request reviewer(s), this changeset has been reviewed for:
-
-- [ ] Consistency across platforms for structures or concepts added or modified
-- [ ] Consistency between the changeset and the goal stated above
-- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
-- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
-- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
-- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
-- [ ] Thoroughness of added tests and any missing edge cases
-- [ ] Idiomatic use of the language
+<!-- How was it tested? -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.0.0
+
+Major new version focused on using Buildkite to run tests on real devices using BrowserStack.
+
+# 1.2.0
+
+Addition of HTTP version steps.
+
+# 1.1.0
+
+Various changes have been made since the 1.0.0 release, but no specific versioning strategy
+was not employed.  This minor release encapsulates those changes and no further significant 
+changes to the v1 series is expected (v2 already exists and should be used in preference).
+
 # 1.0.0
 
 Initial release


### PR DESCRIPTION
## Goal

Prepare for the release of v2.0.0.

## Design

Pipeline pushes the Docker image tagged with the branch name on every build so that it can be tested in notifier pipelines pre-merge.

Once merged and a release is created in Github (which tags the repo), the Docker image is tagged with both the release version number and "latest", in order that clients can choose to either roll with the latest release or selectively upgrade.  (They can also ride the bleeding edge by using "master").

## Changeset

Changelog and pipeline updated ready for v2.0.0 release.
PR template updated to match Android as, whilst good intentioned, it was too onerous to complete.

## Testing

I made and deleted a couple of fake releases of github to verify that the pipeline will be triggered.
