### PR TITLE
Ensure `nil?` is called before `empty?` on potentially `nil` variables

### DIFF
--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -122,8 +122,8 @@ class AppAutomateDriver < Appium::Driver
       bk_name_array << ENV['BUILDKITE_RETRY_COUNT'] if ENV['BUILDKITE_RETRY_COUNT']
       bk_name = bk_name_array.join(' ')
 
-      project = bk_project unless bk_project.empty? or bk_project.nil?
-      build = bk_build unless bk_build.empty? or bk_build.nil?
+      project = bk_project unless bk_project.nil? or bk_project.empty?
+      build = bk_build unless bk_build.nil? or bk_build.empty?
       name = bk_name
     end
     {


### PR DESCRIPTION
## Goal

When testing some functionality that relies on the `BUILDKITE` environment variable it was discovered that the `empty?` and `nil?` guards on this code not only don't work correctly but cause an error to be thrown if the either of the variables in question are `nil`.

This change swaps the order of the `nil?` and `empty?` guards so that if the variable is `nil` the `empty?` call will not occur on the `nil` object, and the error won't be thrown.
It will allow us to define and test behaviour that depends on the presence of the `BUILDKITE` variable, although it should have minimal visible effect on the actual CI runs.