### PR TITLE
Improve diagnostics

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,7 +49,7 @@ steps:
       docker-compose#v3.3.0:
         run: browserstack-app-automate
     command: 'bundle exec bugsnag-maze-runner'
-    concurrency: 5
+    concurrency: 10
     concurrency_group: 'browserstack-app'
 
   - label: 'Payload helper tests'
@@ -60,14 +60,7 @@ steps:
 
   - wait
 
-  - label: 'Update docs'
-    if: build.branch == "master"
-    plugins:
-      docker-compose#v3.3.0:
-        run: docs
-    command: 'bundle exec rake docs:build_and_publish'
-
-  - label: 'Push Docker image branch'
+  - label: 'Push Docker image for branch'
     plugins:
       - docker-compose#v3.3.0:
           build: cli
@@ -76,6 +69,13 @@ steps:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
 
+  - label: 'Update docs'
+    if: build.tag =~ /^v2\.[0-9]+\.[0-9]+\$/
+    plugins:
+      docker-compose#v3.3.0:
+        run: docs
+    command: 'bundle exec rake docs:build_and_publish'
+
   - label: 'Push Docker image for tag'
     if: build.tag =~ /^v2\.[0-9]+\.[0-9]+\$/
     plugins:
@@ -83,3 +83,4 @@ steps:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BUILDKITE_TAG}-cli
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli
+

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -47,14 +47,14 @@ end
 # @!group Request assertion steps
 
 # Shortcut to waiting to receive a single request
-Then("I wait to receive a request") do
-  step "I wait to receive 1 request"
+Then('I wait to receive a request') do
+  step 'I wait to receive 1 request'
 end
 
 # Continually checks to see if the required amount of requests have been received. Times out after 30 seconds.
 #
 # @step_input request_count [Integer] The amount of requests expected
-Then("I wait to receive {int} request(s)") do |request_count|
+Then('I wait to receive {int} request(s)') do |request_count|
   max_attempts = 300
   attempts = 0
   received = false
@@ -64,26 +64,23 @@ Then("I wait to receive {int} request(s)") do |request_count|
     sleep 0.1
   end
   raise "Requests not received in 30s (received #{Server.stored_requests.size})" unless received
-  unless Server.stored_requests.size == request_count
-    $logger.warn Server.stored_requests.inspect
-  end
   assert_equal(request_count, Server.stored_requests.size, "#{Server.stored_requests.size} requests received")
 end
 
 # Assert that the test Server hasn't received any requests.
-Then("I should receive no requests") do
+Then('I should receive no requests') do
   assert_equal(0, Server.stored_requests.size, "#{Server.stored_requests.size} requests received")
 end
 
 # Shifts the received request, dropping the oldest request each time.
-Then("I discard the oldest request") do
+Then('I discard the oldest request') do
   Server.stored_requests.shift
 end
 
 # Tests that a header is not null
 #
 # @step_input header_name [String] The header to test
-Then("the {string} header is not null") do |header_name|
+Then('the {string} header is not null') do |header_name|
   assert_not_nil(Server.current_request[:request][header_name],
                 "The '#{header_name}' header should not be null")
 end
@@ -92,7 +89,7 @@ end
 #
 # @step_input header_name [String] The header to test
 # @step_input header_value [String] The string it should match
-Then("the {string} header equals {string}") do |header_name, header_value|
+Then('the {string} header equals {string}') do |header_name, header_value|
   assert_equal(header_value, Server.current_request[:request][header_name])
 end
 
@@ -100,7 +97,7 @@ end
 #
 # @step_input header_name [String] The header to test
 # @step_input header_values [DataTable] A parsed data table
-Then("the {string} header equals one of:") do |header_name, header_values|
+Then('the {string} header equals one of:') do |header_name, header_values|
   assert_includes(header_values.raw.flatten, Server.current_request[:request][header_name])
 end
 
@@ -108,7 +105,7 @@ end
 #   Uses the regex /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
 #
 # @step_input header_name [String] The header to test
-Then("the {string} header is a timestamp") do |header_name|
+Then('the {string} header is a timestamp') do |header_name|
   header = Server.current_request[:request][header_name]
   assert_match(TIMESTAMP_REGEX, header)
 end
@@ -117,14 +114,14 @@ end
 #
 # @step_input parameter_name [String] The parameter to test
 # @step_input parameter_value [String] The expected value
-Then("the {string} query parameter equals {string}") do |parameter_name, parameter_value|
+Then('the {string} query parameter equals {string}') do |parameter_name, parameter_value|
   assert_equal(parameter_value, parse_querystring(Server.current_request)[parameter_name][0])
 end
 
 # Tests that a query parameter is present and not null.
 #
 # @step_input parameter_name [String] The parameter to test
-Then("the {string} query parameter is not null") do |parameter_name|
+Then('the {string} query parameter is not null') do |parameter_name|
   assert_not_nil(parse_querystring(Server.current_request)[parameter_name][0], "The '#{parameter_name}' query parameter should not be null")
 end
 
@@ -132,7 +129,7 @@ end
 #   Uses the regex /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
 #
 # @step_input parameter_name [String] The parameter to test
-Then("the {string} query parameter is a timestamp") do |parameter_name|
+Then('the {string} query parameter is a timestamp') do |parameter_name|
   param = parse_querystring(Server.current_request)[parameter_name][0]
   assert_match(TIMESTAMP_REGEX, param)
 end
@@ -140,7 +137,7 @@ end
 # Tests the number of fields a multipart request contains.
 #
 # @step_input part_count [Integer] The number of expected fields
-Then("the multipart request has {int} fields") do |part_count|
+Then('the multipart request has {int} fields') do |part_count|
   parts = Server.current_request[:body]
   assert_equal(part_count, parts.size)
 end
@@ -148,7 +145,7 @@ end
 # Tests that a multipart request field exists and is not null.
 #
 # @step_input part_key [String] The key to the multipart element
-Then("the field {string} for multipart request is not null") do |part_key|
+Then('the field {string} for multipart request is not null') do |part_key|
   parts = Server.current_request[:body]
   assert_not_nil(parts[part_key], "The field '#{part_key}' should not be null")
 end
@@ -157,7 +154,7 @@ end
 #
 # @step_input part_key [String] The key to the multipart element
 # @step_input expected_value [String] The string to match against
-Then("the field {string} for multipart request equals {string}") do |part_key, expected_value|
+Then('the field {string} for multipart request equals {string}') do |part_key, expected_value|
   parts = Server.current_request[:body]
   assert_equal(parts[part_key], expected_value)
 end
@@ -165,7 +162,7 @@ end
 # Tests that a multipart request field is null.
 #
 # @step_input part_key [String] The key to the multipart element
-Then("the field {string} for multipart request is null") do |part_key|
+Then('the field {string} for multipart request is null') do |part_key|
   parts = Server.current_request[:body]
   assert_nil(parts[part_key], "The field '#{part_key}' should be null")
 end
@@ -173,7 +170,7 @@ end
 # Tests the payload body does not match a JSON fixture.
 #
 # @step_input fixture_path [String] Path to a JSON fixture
-Then("the payload body does not match the JSON fixture in {string}") do |fixture_path|
+Then('the payload body does not match the JSON fixture in {string}') do |fixture_path|
   payload_value = Server.current_request[:body]
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = value_compare(expected_value, payload_value)
@@ -183,7 +180,7 @@ end
 # Test the payload body matches a JSON fixture.
 #
 # @step_input fixture_path [String] Path to a JSON fixture
-Then("the payload body matches the JSON fixture in {string}") do |fixture_path|
+Then('the payload body matches the JSON fixture in {string}') do |fixture_path|
   payload_value = Server.current_request[:body]
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = value_compare(expected_value, payload_value)
@@ -194,7 +191,7 @@ end
 #
 # @step_input field_path [String] Path to the tested element
 # @step_input fixture_path [String] Path to a JSON fixture
-Then("the payload field {string} matches the JSON fixture in {string}") do |field_path, fixture_path|
+Then('the payload field {string} matches the JSON fixture in {string}') do |field_path, fixture_path|
   payload_value = read_key_path(Server.current_request[:body], field_path)
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = value_compare(expected_value, payload_value)
@@ -204,21 +201,21 @@ end
 # Tests that a payload element is true.
 #
 # @step_input field_path [String] Path to the tested element
-Then("the payload field {string} is true") do |field_path|
+Then('the payload field {string} is true') do |field_path|
   assert_equal(true, read_key_path(Server.current_request[:body], field_path))
 end
 
 # Tests that a payload element is false.
 #
 # @step_input field_path [String] Path to the tested element
-Then("the payload field {string} is false") do |field_path|
+Then('the payload field {string} is false') do |field_path|
   assert_equal(false, read_key_path(Server.current_request[:body], field_path))
 end
 
 # Tests that a payload element is null.
 #
 # @step_input field_path [String] Path to the tested element
-Then("the payload field {string} is null") do |field_path|
+Then('the payload field {string} is null') do |field_path|
   value = read_key_path(Server.current_request[:body], field_path)
   assert_nil(value, "The field '#{field_path}' should be null but is #{value}")
 end
@@ -226,7 +223,7 @@ end
 # Tests that a payload element is not null.
 #
 # @step_input field_path [String] Path to the tested element
-Then("the payload field {string} is not null") do |field_path|
+Then('the payload field {string} is not null') do |field_path|
   assert_not_nil(read_key_path(Server.current_request[:body], field_path),
                 "The field '#{field_path}' should not be null")
 end
@@ -235,7 +232,7 @@ end
 #
 # @step_input field_path [String] Path to the tested element
 # @step_input int_value [Integer] The value to test against
-Then("the payload field {string} equals {int}") do |field_path, int_value|
+Then('the payload field {string} equals {int}') do |field_path, int_value|
   assert_equal(int_value, read_key_path(Server.current_request[:body], field_path))
 end
 
@@ -243,7 +240,7 @@ end
 #
 # @step_input field_path [String] The payload element to test
 # @step_input env_var [String] The environment variable to test against
-Then("the payload field {string} equals the environment variable {string}") do |field_path, env_var|
+Then('the payload field {string} equals the environment variable {string}') do |field_path, env_var|
   environment_value = ENV[env_var]
   assert_false(environment_value.nil?, "The environment variable #{env_var} must not be nil")
   value = read_key_path(Server.current_request[:body], field_path)
@@ -255,7 +252,7 @@ end
 #
 # @step_input field_path [String] The payload element to test
 # @step_input int_value [Integer] The value to compare against
-Then("the payload field {string} is greater than {int}") do |field_path, int_value|
+Then('the payload field {string} is greater than {int}') do |field_path, int_value|
   value = read_key_path(Server.current_request[:body], field_path)
   assert_kind_of Integer, value
   assert(value > int_value, "The payload field '#{field_path}' is not greater than '#{int_value}'")
@@ -265,7 +262,7 @@ end
 #
 # @step_input field_path [String] The payload element to test
 # @step_input int_value [Integer] The value to compare against
-Then("the payload field {string} is less than {int}") do |field_path, int_value|
+Then('the payload field {string} is less than {int}') do |field_path, int_value|
   value = read_key_path(Server.current_request[:body], field_path)
   assert_kind_of Integer, value
   assert(value < int_value, "The payload field '#{field_path}' is not less than '#{int_value}'")
@@ -275,7 +272,7 @@ end
 #
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
-Then("the payload field {string} equals {string}") do |field_path, string_value|
+Then('the payload field {string} equals {string}') do |field_path, string_value|
   assert_equal(string_value, read_key_path(Server.current_request[:body], field_path))
 end
 
@@ -283,7 +280,7 @@ end
 #
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
-Then("the payload field {string} starts with {string}") do |field_path, string_value|
+Then('the payload field {string} starts with {string}') do |field_path, string_value|
   value = read_key_path(Server.current_request[:body], field_path)
   assert_kind_of String, value
   assert(value.start_with?(string_value), "Field '#{field_path}' value ('#{value}') does not start with '#{string_value}'")
@@ -293,7 +290,7 @@ end
 #
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
-Then("the payload field {string} ends with {string}") do |field_path, string_value|
+Then('the payload field {string} ends with {string}') do |field_path, string_value|
   value = read_key_path(Server.current_request[:body], field_path)
   assert_kind_of String, value
   assert(value.end_with? string_value, "Field '#{field_path}' does not end with '#{string_value}'")
@@ -303,7 +300,7 @@ end
 #
 # @step_input field [String] The payload element to test
 # @step_input count [Integer] The value expected
-Then("the payload field {string} is an array with {int} elements") do |field, count|
+Then('the payload field {string} is an array with {int} elements') do |field, count|
   value = read_key_path(Server.current_request[:body], field)
   assert_kind_of Array, value
   assert_equal(count, value.length)
@@ -312,7 +309,7 @@ end
 # Tests a payload field is an array with at least one element.
 #
 # @step_input field [String] The payload element to test
-Then("the payload field {string} is a non-empty array") do |field|
+Then('the payload field {string} is a non-empty array') do |field|
   value = read_key_path(Server.current_request[:body], field)
   assert_kind_of Array, value
   assert(value.length > 0, "the field '#{field}' must be a non-empty array")
@@ -322,7 +319,7 @@ end
 #
 # @step_input field [String] The payload element to test
 # @step_input regex [String] The regex to test against
-Then("the payload field {string} matches the regex {string}") do |field, regex_string|
+Then('the payload field {string} matches the regex {string}') do |field, regex_string|
   regex = Regexp.new(regex_string)
   value = read_key_path(Server.current_request[:body], field)
   assert_match(regex, value)
@@ -331,7 +328,7 @@ end
 # Tests a payload field is a numeric timestamp.
 #
 # @step_input field [String] The payload element to test
-Then("the payload field {string} is a parsable timestamp in seconds") do |field|
+Then('the payload field {string} is a parsable timestamp in seconds') do |field|
   value = read_key_path(Server.current_request[:body], field)
   begin
     int = value.to_i
@@ -345,7 +342,7 @@ end
 #
 # @step_input key_path [String] The path to the tested array
 # @step_input element_key_path [String] The key for the expected element inside the array
-Then("each element in payload field {string} has {string}") do |key_path, element_key_path|
+Then('each element in payload field {string} has {string}') do |key_path, element_key_path|
   value = read_key_path(Server.current_request[:body], key_path)
   assert_kind_of Array, value
   value.each do |element|

--- a/lib/features/support/diagnostics.rb
+++ b/lib/features/support/diagnostics.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'json'
+
+After do |scenario|
+  if scenario.failed?
+    if Server.stored_requests.empty?
+      $logger.info 'No requests received'
+    else
+      $logger.info 'The following requests were received:'
+      Server.stored_requests.each_with_index do |request, number|
+        json = JSON.pretty_generate request
+        $logger.info "Request #{number}: \n#{json}"
+      end
+    end
+  end
+end
+
+

--- a/lib/features/support/logger.rb
+++ b/lib/features/support/logger.rb
@@ -1,9 +1,20 @@
+# frozen_string_literal: true
+
 require 'logger'
 
-if ENV['VERBOSE'] || ENV['DEBUG']
-  $logger = Logger.new(STDOUT, level: Logger::DEBUG)
-elsif ENV['QUIET']
-  $logger = Logger.new(STDOUT, level: Logger::ERROR)
-else
-  $logger = Logger.new(STDOUT, level: Logger::INFO)
+# A logger, with level configured according to the environment
+class MazeLogger < Logger
+  def initialize
+    if ENV['VERBOSE'] || ENV['DEBUG']
+      super(STDOUT, level: Logger::DEBUG)
+    elsif ENV['QUIET']
+      super(STDOUT, level: Logger::ERROR)
+    else
+      super(STDOUT, level: Logger::INFO)
+    end
+    self.datetime_format = '%Y-%m-%d %H:%M:%S'
+  end
 end
+
+# TODO Added for backward compatibility, but remove in time
+$logger = MazeLogger.new

--- a/lib/features/support/logger.rb
+++ b/lib/features/support/logger.rb
@@ -4,6 +4,7 @@ require 'logger'
 
 # A logger, with level configured according to the environment
 class MazeLogger < Logger
+  include Singleton
   def initialize
     if ENV['VERBOSE'] || ENV['DEBUG']
       super(STDOUT, level: Logger::DEBUG)
@@ -16,5 +17,7 @@ class MazeLogger < Logger
   end
 end
 
-# TODO Added for backward compatibility, but remove in time
-$logger = MazeLogger.new
+# TODO: Added for backward compatibility, but use of the global should be
+#   replaced with accessing the singleton instance (assigning to local
+#   variables for brevity as appropriate).
+$logger = MazeLogger.instance


### PR DESCRIPTION
## Goal

The main objective of this PR is to provide better diagnostics whenever a scenario fails, but logging out all requests that were received.  This is an improvement on what we currently have, where we often have no useful output to analyse. 

Some peripheral changes have also been made to resolve Rubucop warnings - expect this to happen across forthcoming PRs as we visit different areas.

## Design

This is intended to be a quick win, but it can make the log noisy.  The plan will be to move the logging into files that get attached as downloadable artifacts in Buildkite steps.

## Changeset

New support file to manage diagnostic output. Warnings resolved in a couple of other files in the same area.

## Tests

I've run the Cocoa tests against this branch locally and on CI to check behaviour and will encourage the use of `master` for ongoing work before we make a new release.  In general, though, we may want to look at enhancing the maze-runner pipeline to include more tests for specific notifiers so that we get sufficient confidence from just a successful CI run.
