### PR TITLE
Collapse logs for passing scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Enhancements.
 - Run Cucumber with strict mode, unless any strict/no-strict option has been set.
 - Log all received requests when a Scenario fails
+- Auto-collapse log output for passing scenarios when run using Buildkite
 
 # 2.0.0
 

--- a/lib/features/support/diagnostics.rb
+++ b/lib/features/support/diagnostics.rb
@@ -3,7 +3,7 @@
 require 'json'
 
 Before do |scenario|
-  STDOUT.puts "--- #{scenario.name}"
+  STDOUT.puts "--- Scenario: #{scenario.name}"
 end
 
 After do |scenario|

--- a/lib/features/support/diagnostics.rb
+++ b/lib/features/support/diagnostics.rb
@@ -2,8 +2,13 @@
 
 require 'json'
 
+Before do |scenario|
+  STDOUT.puts "--- #{scenario.name}"
+end
+
 After do |scenario|
   if scenario.failed?
+    STDOUT.puts '^^^ +++'
     if Server.stored_requests.empty?
       $logger.info 'No requests received'
     else


### PR DESCRIPTION
## Goal

Make the Maze Runner output easier to digest in Buildkite by using collapsed log sections for scenarios that pass.  For any scenarios that fail, the log is automatically expanded.

## Design

This approach use the Collapsing Log feature of Buildkite and works by simply outputting stylised text before each scenario (and after in the case of a fail).  `STDOUT.puts` is needed as Cucumber captures any output to normal `puts`, formatting it as test output and hence breaking the collapsing logs.

## Tests

Run against a currently flaking Buildkite, observing that collapsing occurred as desired.
