### PR TITLE
Allow flaky tests by default when —retry is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.1 - 2020/06/22
+
+## Fixes
+
+- Account for --retry being provided when adding --strict option (to allow flaky tests).
+
 # 2.1.0 - 2020/06/04
 
 ## Enhancements

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -36,9 +36,16 @@ class MazeRunner
   def add_maze_runner_options
     @args << 'features' if @args.empty?
 
-    # Strict mode unless any no/strict option is given
+    # Add strict mode unless any no/strict option is given,
+    # but also allow flaky tests if --retry was provided.
     regex = /--(no-)?strict(-(undefined|pending|flaky))?/
-    @args << '--strict' if @args.all? { |arg| regex.match(arg).nil? }
+    if @args.all? { |arg| regex.match(arg).nil? }
+      if @args.any? '--retry'
+        @args << '--strict-undefined' << '--strict-pending'
+      else
+        @args << '--strict'
+      end
+    end
 
     # Load internal steps and helper functions
     load_dir = File.expand_path(File.dirname(File.dirname(__FILE__))).freeze


### PR DESCRIPTION
## Goal

Allow tests to be flaky by default when `--retry` is provided.

## Design

By default, MR will add the `--strict` option when calling Cucumber.  Except when:
- If any strict or no-strict option is provided to MR, no action is taken
- If `--retry` is given to MR then `--strict-undefined` and `--strict-pending` are added.

## Tests

Tested locally by outputting the options passed to Cucumber and trying each combination of options.
