### PR TITLE
Add a step that matches different values for different BrowserStack OS's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [#104](https://github.com/bugsnag/maze-runner/pull/104)
 - Provide new step to allow a timeout to be set when waiting for an element to be available.
   [#105](https://github.com/bugsnag/maze-runner/pull/105)
+- Provide new step to allow different expected values on different platforms
+  [#103](https://github.com/bugsnag/maze-runner/pull/103)
 
 # 2.1.2 - 2020/06/23
 

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -33,3 +33,22 @@ end
 When("I send the keys {string} to the element {string}") do |keys, element_id|
   $driver.send_keys_to_element(element_id, keys)
 end
+
+# Tests that the given payload value is correct for the target BrowserStack platform.
+# If the step is invoked when a remote BrowserStack device is not in use this step will fail.
+#
+# The DataTable used for this step should have `ios` and `android` in the same row as their expected value:
+#   | android | Java.lang.RuntimeException |
+#   | ios     | NSException                |
+#
+# @step_input field_path [String] The field to test
+# @step_input platform_values [DataTable] A table of acceptable values for each platform
+Then("the event {string} matches the correct platform value:") do |field_path, platform_values|
+  if !defined?($driver) || $driver.nil?
+    fail("This step should only be used if the AppAutomateDriver is present")
+  end
+  os = $driver.capabilities['os']
+  expected_value = Hash[platform_values.raw][os]
+  fail("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
+  assert_equal(expected_value, read_key_path(Server.current_request[:body], field_path))
+end

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -50,5 +50,5 @@ Then("the event {string} matches the correct platform value:") do |field_path, p
   os = $driver.capabilities['os']
   expected_value = Hash[platform_values.raw][os]
   fail("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
-  assert_equal(expected_value, read_key_path(Server.current_request[:body], field_path))
+  assert_equal(expected_value, read_key_path(Server.current_request[:body], "events.0.#{field_path}"))
 end

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -10,6 +10,10 @@ class AppAutomateDriver < Appium::Driver
   #   @return [String] The device, from the list of device capabilities, used for this test
   attr_reader :device_type
 
+  # @!attribute [r] capabilities
+  #   @return [Hash] The capabilities used to launch the BrowserStack instance
+  attr_reader :capabilities
+
   # The App upload uri for BrowserStack App Automate
   BROWSER_STACK_APP_UPLOAD_URI = "https://api-cloud.browserstack.com/app-automate/upload"
 
@@ -37,7 +41,7 @@ class AppAutomateDriver < Appium::Driver
     $logger.info "    build   : #{name_capabilities[:build]}"
     $logger.info "    name    : #{name_capabilities[:name]}"
 
-    capabilities = {
+    @capabilities = {
       'browserstack.console': 'errors',
       'browserstack.localIdentifier': local_id,
       'browserstack.local': 'true',
@@ -45,11 +49,11 @@ class AppAutomateDriver < Appium::Driver
       'autoAcceptAlerts': 'true',
       'app': app_url
     }
-    capabilities.merge! additional_capabilities
-    capabilities.merge! devices[target_device]
-    capabilities.merge! name_capabilities
+    @capabilities.merge! additional_capabilities
+    @capabilities.merge! devices[target_device]
+    @capabilities.merge! name_capabilities
     super({
-      'caps' => capabilities,
+      'caps' => @capabilities,
       'appium_lib' => {
         :server_url => "http://#{username}:#{access_key}@hub-cloud.browserstack.com/wd/hub"
       }

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -9,3 +9,15 @@ Scenario: Test Handled Android Exception
   And the exception "message" equals "HandledException!"
   # Verifies the environment variable change works
   And the payload field "apiKey" equals the environment variable "BUGSNAG_API_KEY"
+
+Scenario: Verify "equals the correct platform value" step
+  Given the element "trigger_error" is present
+  When I click the element "trigger_error"
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+  And the event "exceptions.0.errorClass" matches the correct platform value:
+    | android | java.lang.Exception |
+  And the event "exceptions.0.message" matches the correct platform value:
+    | android | HandledException!   |
+  # Verifies the environment variable change works
+  And the payload field "apiKey" equals the environment variable "BUGSNAG_API_KEY"


### PR DESCRIPTION
## Goal

This adds a verification step that checks for different values based on the value of the `AppAutomatorDriver`s `os` capability.

This has four outcomes:
1. `$driver` isn't present as this isn't a BrowserStack app automation test, the step will automatically fail
2. The `os` value isn't present in the table, the step will automatically fail
3. & 4. Pass and fail depending on if the expected value matches the payload value

## Usage

```
Then the event "exceptions.0.errorClass" matches the correct platform value:
  | android | Java.lang.RuntimeException |
  | ios         | NSException                           |
```

## Tests

Added steps to the BrowserStack app feature for a positive outcome, tested negative outcomes manually 
