### PR TITLE
Allow timeout to be set when waiting for an element to be present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Add ability to clear text from an element.
+- Increase default timeout for an element to be available to 30s.
 
 # 2.1.2 - 2020/06/23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-# 2.2.0 - 2020/07/09
+# 2.2.0 - 2020/07/10
 
 ## Enhancements
 
 - Add ability to clear text from an element.
-- Increase default timeout for an element to be available to 30s.
+  [#104](https://github.com/bugsnag/maze-runner/pull/104)
+- Provide new step to allow a timeout to be set when waiting for an element to be available.
+  [#105](https://github.com/bugsnag/maze-runner/pull/105)
 
 # 2.1.2 - 2020/06/23
 

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -9,6 +9,16 @@ Given("the element {string} is present") do |element_id|
   assert(present, "The element #{element_id} could not be found")
 end
 
+# Checks a UI element is present within a specified number of seconds
+# Requires a running Appium driver
+#
+# @step_input element_id [String] The locator id
+# @step_input timeout [Int] The number of seconds to wait before timing out
+Given("the element {string} is present within {int} seconds") do |element_id, timeout|
+  present = $driver.wait_for_element(element_id, timeout: timeout)
+  assert(present, "The element #{element_id} could not be found")
+end
+
 # Clicks a given element
 # Requires a running Appium driver
 #

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -67,7 +67,7 @@ class AppAutomateDriver < Appium::Driver
   # @param element_id [String] the element to search for using the @element_locator strategy
   # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
   # @param retry_if_stale [Boolean] enables the method to retry acquiring the element if a StaleObjectException occurs
-  def wait_for_element(element_id, timeout=30, retry_if_stale=true)
+  def wait_for_element(element_id, timeout=15, retry_if_stale=true)
     begin
       wait = Selenium::WebDriver::Wait.new(:timeout => timeout)
       wait.until { find_element(@element_locator, element_id).displayed? }

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -67,7 +67,7 @@ class AppAutomateDriver < Appium::Driver
   # @param element_id [String] the element to search for using the @element_locator strategy
   # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
   # @param retry_if_stale [Boolean] enables the method to retry acquiring the element if a StaleObjectException occurs
-  def wait_for_element(element_id, timeout=15, retry_if_stale=true)
+  def wait_for_element(element_id, timeout=30, retry_if_stale=true)
     begin
       wait = Selenium::WebDriver::Wait.new(:timeout => timeout)
       wait.until { find_element(@element_locator, element_id).displayed? }


### PR DESCRIPTION
## Goal

Increase default timeout for an element to be aware to 30s, for the cases where an app may be slower to load.
