### PR TITLE
Update platform comparison step to allow step skipping via keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBA
+
+## Enhancements
+
+- Update platform comparison step to allow skipping via keywords
+
 # 2.2.1 - 2020/07/10
 
 ## Fixes

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -70,7 +70,7 @@ Then("the event {string} matches the correct platform value:") do |field_path, p
   os = $driver.capabilities['os']
   expected_value = Hash[platform_values.raw][os]
   fail("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
-  unless expected_value.eql?("skip")
+  unless expected_value.eql?("@skip")
     assert_equal(expected_value, read_key_path(Server.current_request[:body], "events.0.#{field_path}"))
   end
 end

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -59,6 +59,8 @@ end
 #   | android | Java.lang.RuntimeException |
 #   | ios     | NSException                |
 #
+# If the expected value is set to "skip", the check should be skipped.
+#
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
 Then("the event {string} matches the correct platform value:") do |field_path, platform_values|
@@ -68,7 +70,9 @@ Then("the event {string} matches the correct platform value:") do |field_path, p
   os = $driver.capabilities['os']
   expected_value = Hash[platform_values.raw][os]
   fail("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
-  assert_equal(expected_value, read_key_path(Server.current_request[:body], "events.0.#{field_path}"))
+  unless expected_value.eql?("skip")
+    assert_equal(expected_value, read_key_path(Server.current_request[:body], "events.0.#{field_path}"))
+  end
 end
 
 # Sends keys to a given element, clearing it first

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -20,6 +20,6 @@ Scenario: Verify "equals the correct platform value" step
   And the event "exceptions.0.message" matches the correct platform value:
     | android | HandledException!   |
   And the event "exceptions.0.message" matches the correct platform value:
-    | android | skip |
+    | android | @skip |
   # Verifies the environment variable change works
   And the payload field "apiKey" equals the environment variable "BUGSNAG_API_KEY"

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -19,5 +19,7 @@ Scenario: Verify "equals the correct platform value" step
     | android | java.lang.Exception |
   And the event "exceptions.0.message" matches the correct platform value:
     | android | HandledException!   |
+  And the event "exceptions.0.message" matches the correct platform value:
+    | android | skip |
   # Verifies the environment variable change works
   And the payload field "apiKey" equals the environment variable "BUGSNAG_API_KEY"


### PR DESCRIPTION
## Goal

Adds the ability to skip a step on a platform (useful for parameters such as `appVersionCode` which are Android specific).
This is accomplished by using the `@skip` keyword/tag inside of the value table, e.g.:
```
  And the event "app.appVersionCode" matches the correct platform value:
    | android | 1.0       |
    | ios         | @skip |
```

Tested by adding the step to the BrowserStackApp test fixture.
