### PR TITLE
Typed platform checks

### DIFF
--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -53,17 +53,18 @@ When("I send the keys {string} to the element {string}") do |keys, element_id|
 end
 
 # Tests that the given payload value is correct for the target BrowserStack platform.
+# This step will assume the expected and payload values are strings.
 # If the step is invoked when a remote BrowserStack device is not in use this step will fail.
 #
 # The DataTable used for this step should have `ios` and `android` in the same row as their expected value:
 #   | android | Java.lang.RuntimeException |
 #   | ios     | NSException                |
 #
-# If the expected value is set to "skip", the check should be skipped.
+# If the expected value is set to "@skip", the check should be skipped.
 #
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then("the event {string} matches the correct platform value:") do |field_path, platform_values|
+Then("the event {string} matches the string platform value:") do |field_path, platform_values|
   if !defined?($driver) || $driver.nil?
     fail("This step should only be used if the AppAutomateDriver is present")
   end
@@ -71,7 +72,67 @@ Then("the event {string} matches the correct platform value:") do |field_path, p
   expected_value = Hash[platform_values.raw][os]
   fail("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
   unless expected_value.eql?("@skip")
-    assert_equal(expected_value, read_key_path(Server.current_request[:body], "events.0.#{field_path}"))
+    payload_value = read_key_path(Server.current_request[:body], "events.0.#{field_path}")
+    result = value_compare(expected_value, payload_value)
+    assert_true(result.equal?, "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
+  end
+end
+
+# Tests that the given payload value is correct for the target BrowserStack platform.
+# This step will assume the expected and payload values are numeric.
+# If the step is invoked when a remote BrowserStack device is not in use this step will fail.
+#
+# The DataTable used for this step should have `ios` and `android` in the same row as their expected value:
+#   | android | 1  |
+#   | ios     | 5.5 |
+#
+# If the expected value is set to "@skip", the check should be skipped.
+#
+# @step_input field_path [String] The field to test
+# @step_input platform_values [DataTable] A table of acceptable values for each platform
+Then("the event {string} matches the numeric platform value:") do |field_path, platform_values|
+  if !defined?($driver) || $driver.nil?
+    fail("This step should only be used if the AppAutomateDriver is present")
+  end
+  os = $driver.capabilities['os']
+  expected_value = Hash[platform_values.raw][os]
+  fail("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
+  unless expected_value.eql?("@skip")
+    payload_value = read_key_path(Server.current_request[:body], "events.0.#{field_path}")
+    assert_equal(expected_value.to_f, payload_value)
+  end
+end
+
+# Tests that the given payload value is correct for the target BrowserStack platform.
+# This step will assume the expected and payload values are booleans.
+# If the step is invoked when a remote BrowserStack device is not in use this step will fail.
+#
+# The DataTable used for this step should have `ios` and `android` in the same row as their expected value:
+#   | android | 1 |
+#   | ios     | 5 |
+#
+# If the expected value is set to "@skip", the check should be skipped.
+#
+# @step_input field_path [String] The field to test
+# @step_input platform_values [DataTable] A table of acceptable values for each platform
+Then("the event {string} matches the boolean platform value:") do |field_path, platform_values|
+  if !defined?($driver) || $driver.nil?
+    fail("This step should only be used if the AppAutomateDriver is present")
+  end
+  os = $driver.capabilities['os']
+  expected_value = Hash[platform_values.raw][os]
+  fail("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
+  unless expected_value.eql?("@skip")
+    if expected_value.downcase == 'true'
+      expected_bool = true
+    elsif expected_value.downcase == 'false'
+      expected_bool = false
+    else
+      expected_bool = expected_value
+    end
+    payload_value = read_key_path(Server.current_request[:body], "events.0.#{field_path}")
+    result = value_compare(expected_bool, payload_value)
+    assert_true(result.equal?, "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
   end
 end
 

--- a/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -5,8 +5,7 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
 import android.widget.Button
-import com.bugsnag.android.Bugsnag
-import com.bugsnag.android.Configuration
+import com.bugsnag.android.*
 import java.lang.Exception
 
 class MainActivity : AppCompatActivity() {

--- a/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -15,7 +15,16 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         val button = findViewById<Button>(R.id.trigger_error)
-        button.setOnClickListener { Bugsnag.notify(Exception("HandledException!")) }
+        button.setOnClickListener { 
+            Bugsnag.notify(Exception("HandledException!"), { event ->
+                event.addMetadata("test", "boolean_false", false)
+                event.addMetadata("test", "boolean_true", true)
+                event.addMetadata("test", "float", 1.55)
+                event.addMetadata("test", "integer", 2)
+
+                true
+            })
+        }
     }
 
     override fun onResume() {

--- a/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -15,14 +15,13 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         val button = findViewById<Button>(R.id.trigger_error)
         button.setOnClickListener { 
-            Bugsnag.notify(Exception("HandledException!"), { report ->
-                val metaData = MetaData()
-                metaData.addToTab("test", "boolean_false", false)
-                metaData.addToTab("test", "boolean_true", true)
-                metaData.addToTab("test", "float", 1.55)
-                metaData.addToTab("test", "integer", 2)
-                report.error.metaData = metaData
-            }
+            Bugsnag.notify(Exception("HandledException!"), {
+                val error = it.error!!
+                error.metaData.addToTab("test", "boolean_false", false)
+                error.metaData.addToTab("test", "boolean_true", true)
+                error.metaData.addToTab("test", "float", 1.55)
+                error.metaData.addToTab("test", "integer", 2)
+            })
         }
     }
 

--- a/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -16,14 +16,14 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         val button = findViewById<Button>(R.id.trigger_error)
         button.setOnClickListener { 
-            Bugsnag.notify(Exception("HandledException!"), { event ->
-                event.addMetadata("test", "boolean_false", false)
-                event.addMetadata("test", "boolean_true", true)
-                event.addMetadata("test", "float", 1.55)
-                event.addMetadata("test", "integer", 2)
-
-                true
-            })
+            Bugsnag.notify(Exception("HandledException!"), { report ->
+                val metaData = MetaData()
+                metaData.addToTab("test", "boolean_false", false)
+                metaData.addToTab("test", "boolean_true", true)
+                metaData.addToTab("test", "float", 1.55)
+                metaData.addToTab("test", "integer", 2)
+                report.error.metaData = metaData
+            }
         }
     }
 

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -15,11 +15,25 @@ Scenario: Verify "equals the correct platform value" step
   When I click the element "trigger_error"
   Then I wait to receive a request
   And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-  And the event "exceptions.0.errorClass" matches the correct platform value:
+  # Verify string comparison
+  And the event "exceptions.0.errorClass" matches the string platform value:
     | android | java.lang.Exception |
-  And the event "exceptions.0.message" matches the correct platform value:
-    | android | HandledException!   |
-  And the event "exceptions.0.message" matches the correct platform value:
+  # Verify boolean comparisons
+  And the event "metaData.test.boolean_true" matches the boolean platform value:
+    | android | true |
+  And the event "metaData.test.boolean_false" matches the boolean platform value:
+    | android | false |
+  # Verify numeric comparisons
+  And the event "metaData.test.float" matches the numeric platform value:
+    | android | 1.55 |
+  And the event "metaData.test.integer" matches the numeric platform value:
+    | android | 2 |
+  # Verify the skips
+  And the event "metaData.test.integer" matches the string platform value:
+    | android | @skip |
+  And the event "metaData.test.integer" matches the boolean platform value:
+    | android | @skip |
+  And the event "exceptions.0.errorClass" matches the numeric platform value:
     | android | @skip |
   # Verifies the environment variable change works
   And the payload field "apiKey" equals the environment variable "BUGSNAG_API_KEY"


### PR DESCRIPTION
## Goal

Updates the previously added platform checks to specify whether the target value should be a String, Boolean, or Numeric.

This is required for:
1. If skipping certain checks such as `app.codeBundleId` on iOS the step needs to be able to test for any of the basic data types otherwise the Android checks will be invalidated.
2. The original step only used String checking, this allows us to check boolean and numeric values such as appVersionCodes or unhandled/handled error counts.

Alternatives:
The main alternative would be a more structured table and a single step.
This step/table would look something like:
```
Then the event "some variable thing" matches the correct platform value:
  | platform | type    | value                  |
  | android  | bool    | true                    |
  | ios          | @skip |                           |
```

Unfortunately this introduces complexities such as having to parse the type, and be more difficult to parse visually.

## Future work

It would be good to refactor this into a separate class (which can then have other platform specific comparisons added to it), which would allow us to streamline messaging and shared logic.

## Tests

Updated the metadata in the `Browserstack app` test fixture to run each variant of the different scenarios, including `@skip`s.

## When merging

Requires Squash and Merge