### PR TITLE
Update timestamp regex to allow +0000 syntax

### DIFF
--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -4,4 +4,4 @@ require 'securerandom'
 $api_key = SecureRandom.hex(16).tr('+/=', 'xyz')
 
 # A regex providing the pattern expected from timestamps
-TIMESTAMP_REGEX = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
+TIMESTAMP_REGEX = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+(\+\d+)?Z?$/


### PR DESCRIPTION
## Goal

This allows us to support timestamps that don't use the `Z` notation for timezones, and use difference from UTC time, such as:
`2020-07-20T13:40:56+0000`
