### PR TITLE
Fix Android mapping API assertion as Build UUID not strictly required

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -74,7 +74,6 @@ Then(/^the request (\d+) is valid for the Android Mapping API$/) do |request_ind
   assert_not_nil(parts["apiKey"], "'apiKey' should not be nil")
   assert_not_nil(parts["appId"], "'appId' should not be nil")
   assert_not_nil(parts["versionCode"], "'versionCode' should not be nil")
-  assert_not_nil(parts["buildUUID"], "'buildUUID' should not be nil")
   assert_not_nil(parts["versionName"], "'versionName' should not be nil")
 end
 


### PR DESCRIPTION
## Goal

The build UUID field is asserted to be non-nil, but the API allows for it to be nullable. Previously the plugin always sent a request where the field was not null, but as part of the performance improvements this is no longer the case.

API docs: https://docs.bugsnag.com/api/android-mapping-upload/#for-proguard
