### PR TITLE
[PLAT-4734] Push Docker images as v1 rather than latest, which conflicts with v2.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,10 +4,10 @@ steps:
       - docker-compose#v2.5.1:
           build: ci
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
-          cache-from: ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME:-[latest]}-ci
+          cache-from: ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME:-[v1]}-ci
       - docker-compose#v2.5.1:
           push:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:v1-ci
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
   - wait
@@ -24,8 +24,8 @@ steps:
     plugins:
       - docker-compose#v2.5.1:
           build: cli
-          cache-from: cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME:-[latest]}-cli
+          cache-from: cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME:-[v1]}-cli
       - docker-compose#v2.5.1:
           push:
-            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli
+            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:v1-cli
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli


### PR DESCRIPTION
## Goal

Avoid changes to v1 overwriting the Docker images published for v2 releases, which use `latest-cli`.

## Tests

Peer review, a passing CI and subsequent remedial actions for other pipelines should be sufficient to verify this.