### PR TITLE
[PLAT-3907] Add reset_app method with 0.1 second timeout by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [#109](https://github.com/bugsnag/maze-runner/pull/109)
 - Update platform comparison steps to target different parameter types
   [#110](https://github.com/bugsnag/maze-runner/pull/110)
+- Add reset_with_timeout method to improve flake resilience
+  [#114](https://github.com/bugsnag/maze-runner/pull/114)
 
 # 2.2.1 - 2020/07/10
 

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -125,7 +125,7 @@ class AppAutomateDriver < Appium::Driver
   # Reset the currently running application after a given timeout
   #
   # @param timeout [Number] the amount of time in seconds to wait before resetting
-  def reset_app(timeout=0.1)
+  def reset_with_timeout(timeout=0.1)
     sleep(timeout)
     reset
   end

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -122,6 +122,14 @@ class AppAutomateDriver < Appium::Driver
     element.send_keys(text)
   end
 
+  # Reset the currently running application after a given timeout
+  #
+  # @param timeout [Number] the amount of time in seconds to wait before resetting
+  def reset_app(timeout=0.1)
+    sleep(timeout)
+    reset
+  end
+
   # Determines and returns sensible project, build, and name capabilities
   #
   # @param target_device [String] the device in the device list being targeted

--- a/test/fixtures/browserstack-app/features/support/env.rb
+++ b/test/fixtures/browserstack-app/features/support/env.rb
@@ -14,6 +14,10 @@ AfterConfiguration do |config|
   $driver.start_driver
 end
 
+After do
+  $driver.reset_app
+end
+
 at_exit do
   $driver.driver_quit
 end

--- a/test/fixtures/browserstack-app/features/support/env.rb
+++ b/test/fixtures/browserstack-app/features/support/env.rb
@@ -15,7 +15,7 @@ AfterConfiguration do |config|
 end
 
 After do
-  $driver.reset_app
+  $driver.reset_with_timeout
 end
 
 at_exit do


### PR DESCRIPTION
## Goal
Reduces the chance that we get duplicate requests from the test fixture closing too quickly.  While this doesn't deterministically deal with the issue, it should provide some more resilience by allowing extra time for HTTP requests to resolve.

In order to use this method, `$driver.reset` calls in the `After` blocks that use AppAutomateDriver should be changed to `$driver.reset_app`

## Design
The 0.1 second default timeout is intended to allow HTTP requests in progress to resolve before the app is reset, while also being small enough that it shouldn't have a large impact on the overall runtime of tests.  This value is variable, so can be adjusted on a per notifier basis.

## Tests
The intended use has been added to the browserstack test fixture.