### PR TITLE
Revert to using global logger

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,6 @@
 Metrics/LineLength:
   Max: 120
+
+# Use our own judgement on the limited use of global variables.
+Style/GlobalVars:
+  Enabled: false

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -15,6 +15,6 @@ When("I open the URL {string}") do |url|
   begin
     open(url, &:read)
   rescue OpenURI::HTTPError
-    MazeLogger.debug $!.inspect
+    $logger.debug $!.inspect
   end
 end

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -4,14 +4,14 @@
 #
 # @step_input key [String] The environment variable
 # @step_input value [String] The intended value of the environment variable
-When("I set environment variable {string} to {string}") do |key, value|
+When('I set environment variable {string} to {string}') do |key, value|
   Runner.environment[key] = value
 end
 
 # Sets an environment variable to the server endpoint.
 #
 # @step_input name [String] The environment variable
-When("I store the endpoint in the environment variable {string}") do |name|
+When('I store the endpoint in the environment variable {string}') do |name|
   steps %Q{
     When I set environment variable "#{name}" to "http://maze-runner:#{MOCK_API_PORT}"
   }
@@ -20,7 +20,7 @@ end
 # Sets an environment variable to the currently set API key.
 #
 # @step_input name [String] The environment variable
-When("I store the api key in the environment variable {string}") do |name|
+When('I store the api key in the environment variable {string}') do |name|
   steps %Q{
     When I set environment variable "#{name}" to "#{$api_key}"
   }
@@ -29,21 +29,21 @@ end
 # Runs a script, blocking until it returns.
 #
 # @step_input script_path [String] Path to the script to be run
-When("I run the script {string} synchronously") do |script_path|
+When('I run the script {string} synchronously') do |script_path|
   Runner.run_script(script_path, blocking: true)
 end
 
 # Runs a script.
 #
 # @step_input script_path [String] Path to the script to be run
-When("I run the script {string}") do |script_path|
+When('I run the script {string}') do |script_path|
   Runner.run_script script_path
 end
 
 # Starts a docker-compose service.
 #
 # @step_input service [String] The name of the service to run
-When("I start the service {string}") do |service|
+When('I start the service {string}') do |service|
   Docker.start_service service
 end
 
@@ -51,14 +51,14 @@ end
 #
 # @step_input service [String] The name of the service to run
 # @step_input command [String] The command to run inside the service
-When("I run the service {string} with the command {string}") do |service, command|
+When('I run the service {string} with the command {string}') do |service, command|
   Docker.start_service(service, command: command)
 end
 
 # Waits for a number of seconds, performing no actions.
 #
 # @step_input seconds [Integer] The number of seconds to sleep for
-When("I wait for {int} second(s)") do |seconds|
-  MazeLogger.warn "Sleep was used! Please avoid using sleep in tests!"
+When('I wait for {int} second(s)') do |seconds|
+  $logger.warn 'Sleep was used! Please avoid using sleep in tests!'
   sleep(seconds)
 end

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -37,10 +37,10 @@ class AppAutomateDriver < Appium::Driver
     # Sets up identifiers for ease of connecting jobs
     name_capabilities = project_name_capabilities(target_device)
 
-    MazeLogger.info 'Appium driver initialised for:'
-    MazeLogger.info "    project : #{name_capabilities[:project]}"
-    MazeLogger.info "    build   : #{name_capabilities[:build]}"
-    MazeLogger.info "    name    : #{name_capabilities[:name]}"
+    $logger.info 'Appium driver initialised for:'
+    $logger.info "    project : #{name_capabilities[:project]}"
+    $logger.info "    build   : #{name_capabilities[:build]}"
+    $logger.info "    name    : #{name_capabilities[:name]}"
 
     @capabilities = {
       'browserstack.console': 'errors',
@@ -82,7 +82,7 @@ class AppAutomateDriver < Appium::Driver
       if retry_if_stale
         wait_for_element(element_id, timeout, false)
       else
-        MazeLogger.warn "StaleElementReferenceError occurred: #{stale_error}"
+        $logger.warn "StaleElementReferenceError occurred: #{stale_error}"
         false
       end
     else

--- a/lib/features/support/diagnostics.rb
+++ b/lib/features/support/diagnostics.rb
@@ -10,12 +10,12 @@ After do |scenario|
   if scenario.failed?
     STDOUT.puts '^^^ +++'
     if Server.stored_requests.empty?
-      MazeLogger.info 'No requests received'
+      $logger.info 'No requests received'
     else
-      MazeLogger.info 'The following requests were received:'
+      $logger.info 'The following requests were received:'
       Server.stored_requests.each.with_index(1) do |request, number|
         json = JSON.pretty_generate request
-        MazeLogger.info "Request #{number}: \n#{json}"
+        $logger.info "Request #{number}: \n#{json}"
       end
     end
   end

--- a/lib/features/support/logger.rb
+++ b/lib/features/support/logger.rb
@@ -3,44 +3,18 @@
 require 'logger'
 
 # A logger, with level configured according to the environment
-class MazeLogger
-
-  class << self
-
-    def debug(*args)
-      logger.debug(*args)
+class MazeLogger < Logger
+  include Singleton
+  def initialize
+    if ENV['VERBOSE'] || ENV['DEBUG']
+      super(STDOUT, level: Logger::DEBUG)
+    elsif ENV['QUIET']
+      super(STDOUT, level: Logger::ERROR)
+    else
+      super(STDOUT, level: Logger::INFO)
     end
-
-    def info(*args)
-      logger.info(*args)
-    end
-
-    def warn(*args)
-      logger.warn(*args)
-    end
-
-    def error(*args)
-      logger.error(*args)
-    end
-
-    def fatal(*args)
-      logger.fatal(*args)
-    end
-
-    private
-
-    def logger
-      return @logger if @logger
-
-      @logger = if ENV['VERBOSE'] || ENV['DEBUG']
-                  Logger.new(STDOUT, level: Logger::DEBUG)
-                elsif ENV['QUIET']
-                  Logger.new(STDOUT, level: Logger::ERROR)
-                else
-                  Logger.new(STDOUT, level: Logger::INFO)
-                end
-      @logger.datetime_format = '%Y-%m-%d %H:%M:%S'
-      @logger
-    end
+    self.datetime_format = '%Y-%m-%d %H:%M:%S'
   end
 end
+
+$logger = MazeLogger.instance

--- a/lib/features/support/runner.rb
+++ b/lib/features/support/runner.rb
@@ -23,7 +23,7 @@ class Runner
     # @return [Array] If blocking, the output and exit_status are returned
     def run_command(cmd, blocking: true, success_codes: [0])
       executor = lambda do
-        MazeLogger.debug(cmd) { 'executing' }
+        $logger.debug(cmd) { 'executing' }
 
         Open3.popen2e(environment, cmd) do |stdin, stdout_and_stderr, wait_thr|
           # Add the pid to the list of pids to kill at the end
@@ -32,15 +32,15 @@ class Runner
           output = []
           stdout_and_stderr.each do |line|
             output << line
-            MazeLogger.debug(cmd) {line}
+            $logger.debug(cmd) {line}
           end
 
           exit_status = wait_thr.value.to_i
-          MazeLogger.debug(cmd) { "exit status: #{exit_status}" }
+          $logger.debug(cmd) { "exit status: #{exit_status}" }
 
           # if the command fails we log the output at warn level too
-          if success_codes != nil && !success_codes.include?(exit_status) && MazeLogger.level != Logger::DEBUG
-            output.each {|line| MazeLogger.warn(cmd) {line}}
+          if success_codes != nil && !success_codes.include?(exit_status) && $logger.level != Logger::DEBUG
+            output.each {|line| $logger.warn(cmd) {line}}
           end
 
           return [output, exit_status]

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -46,7 +46,7 @@ class Server
       @thread = Thread.new do
         server = WEBrick::HTTPServer.new(
           Port: MOCK_API_PORT,
-          Logger: MazeLogger,
+          Logger: $logger,
           AccessLog: [],
         )
         server.mount '/', Servlet
@@ -78,7 +78,7 @@ end
 Before do
   Server.stored_requests.clear
   unless Server.running?
-    MazeLogger.fatal "Mock server is not running on #{MOCK_API_PORT}"
+    $logger.fatal "Mock server is not running on #{MOCK_API_PORT}"
     exit(1)
   end
 end

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -50,16 +50,16 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
   private
 
   def log_request(request)
-    MazeLogger.debug "#{request.request_method} request received!"
-    MazeLogger.debug "URI: #{request.unparsed_uri}"
-    MazeLogger.debug "HEADERS: #{request.raw_header}"
+    $logger.debug "#{request.request_method} request received!"
+    $logger.debug "URI: #{request.unparsed_uri}"
+    $logger.debug "HEADERS: #{request.raw_header}"
     case request['Content-Type']
     when %r{^multipart/form-data; boundary=([^;]+)}
       boundary = WEBrick::HTTPUtils.dequote(Regexp.last_match(1))
       body = WEBrick::HTTPUtils.parse_form_data(request.body(), boundary)
-      MazeLogger.debug "BODY: #{JSON.pretty_generate(body)}"
+      $logger.debug "BODY: #{JSON.pretty_generate(body)}"
     else
-      MazeLogger.debug "BODY: #{JSON.pretty_generate(JSON.parse(request.body))}"
+      $logger.debug "BODY: #{JSON.pretty_generate(JSON.parse(request.body))}"
     end
   end
 end

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -4,14 +4,6 @@ require 'test_helper'
 require_relative '../lib/features/support/app_automate_driver'
 require_relative '../lib/features/support/capabilities/devices'
 
-class MazeLogger
-  class << self
-    def logger=(logger)
-      @logger = logger
-    end
-  end
-end
-
 class AppAutomateDriverTest < Test::Unit::TestCase
 
   USERNAME = 'Username'
@@ -33,11 +25,11 @@ class AppAutomateDriverTest < Test::Unit::TestCase
 
   def start_logger_mock
     logger_mock = mock('logger')
+    $logger = logger_mock
     logger_mock.expects(:info).with('Appium driver initialised for:').once
     logger_mock.expects(:info).with('    project : local').once
     logger_mock.expects(:info).with(regexp_matches(/^\s{4}build\s{3}:\s\S{36}$/))
     logger_mock.expects(:info).with(regexp_matches(/^\s{4}name\s{4}:\s.+$/))
-    MazeLogger.logger = logger_mock
     logger_mock
   end
 
@@ -229,7 +221,7 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     response = driver.wait_for_element('test_button', 15, false)
     assert_false(response, 'The driver must return false if it does not find an element')
   ensure
-    MazeLogger.logger = nil
+    $logger = nil
   end
 
   def test_clear_element_defaults
@@ -332,7 +324,7 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     ENV['BUILDKITE_RETRY_COUNT'] = '5'
     ENV['BUILDKITE_STEP_KEY'] = 'tests-05'
     logger_mock = mock('logger')
-    MazeLogger.logger = logger_mock
+    $logger = logger_mock
     logger_mock.expects(:info).with('Appium driver initialised for:').once
     logger_mock.expects(:info).with('    project : TEST').once
     logger_mock.expects(:info).with('    build   : 156 TEST BRANCH')


### PR DESCRIPTION
## Goal

Reverts part of the previous PR, to go back to using a global variable for the logger.  Whilst testing the next branch based on that, I realised that the logger passed to the WEBrick server needs to be an instance of `Logger` (or a subclass of it) and so it had broken the server logging.

## Design

We could just keep with using the singleton instance `MazeLogger.instance` everywhere, but these seems unnecessarily verbose and that actually using a global variable is reasonable considering the nature of MazeRunner and how/where steps are written.  I've disabled the Rubcop rule on global variables on the basis that we can trust ourselves to use them appropriately.

## Tests

This will be naturally tested further before release by the next change that is already in progress.