### PR TITLE
General fixes & v2.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.3.1 - 2020/08/25
+
+## Fixes
+
+- Fix module load order by requiring Servlet and Logger from Server class
+  [#118](https://github.com/bugsnag/maze-runner/pull/118)
+
 # 2.3.0 - 2020/08/24
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix module load order by requiring Servlet and Logger from Server class
   [#118](https://github.com/bugsnag/maze-runner/pull/118)
+- Fix error when parsing request with no body
+  [#118](https://github.com/bugsnag/maze-runner/pull/118)
 
 # 2.3.0 - 2020/08/24
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (2.3.0)
+    bugsnag-maze-runner (2.3.1)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -2,6 +2,7 @@
 
 require 'webrick'
 require 'json'
+require_relative './servlet'
 
 # This port number is semi-arbitrary. It doesn't matter for the sake of
 # the application what it is, but there are some constraints due to some

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -3,6 +3,7 @@
 require 'webrick'
 require 'json'
 require_relative './servlet'
+require_relative './logger'
 
 # This port number is semi-arbitrary. It doesn't matter for the sake of
 # the application what it is, but there are some constraints due to some

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -53,6 +53,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
     $logger.debug "#{request.request_method} request received!"
     $logger.debug "URI: #{request.unparsed_uri}"
     $logger.debug "HEADERS: #{request.raw_header}"
+    return if request.body.nil?
     case request['Content-Type']
     when nil
       return

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -54,6 +54,8 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
     $logger.debug "URI: #{request.unparsed_uri}"
     $logger.debug "HEADERS: #{request.raw_header}"
     case request['Content-Type']
+    when nil
+      return
     when %r{^multipart/form-data; boundary=([^;]+)}
       boundary = WEBrick::HTTPUtils.dequote(Regexp.last_match(1))
       body = WEBrick::HTTPUtils.parse_form_data(request.body(), boundary)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.3.1'.freeze
 end


### PR DESCRIPTION
## Goal
Getting some errors caused by the mock Server class starting before the Servlet has been required by cucumber.  This explicitly makes sure the Servlet (and the logger) is required by the Server file.

In addition fixes an error was introduced in the Servlet where if the payload Body is `nil` when attempting to log the request the app would crash.

Also contains version updates and changelog entries for v2.3.1 release.

## Tests

It runs and doesn't complain.
