### PR TITLE
Do not explicitly set appium versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.3.2 - 2020/08/26
+
+## Fixes
+
+- Remove explicit setting of Appium versions on individual `DEVICE_TYPE`s, introduced in 2.3.0.
+  [#119](https://github.com/bugsnag/maze-runner/pull/119)
+
 # 2.3.1 - 2020/08/25
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (2.3.1)
+    bugsnag-maze-runner (2.3.2)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -27,8 +27,8 @@ GEM
       appium_lib_core (~> 3.3)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (3.10.1)
-      faye-websocket (~> 0.10.0)
+    appium_lib_core (3.11.0)
+      faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.17.2)
     builder (3.2.4)
@@ -53,7 +53,7 @@ GEM
     curb (0.9.10)
     diff-lcs (1.3)
     eventmachine (1.2.7)
-    faye-websocket (0.10.9)
+    faye-websocket (0.11.0)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     gherkin (5.1.0)

--- a/lib/features/support/capabilities/devices.rb
+++ b/lib/features/support/capabilities/devices.rb
@@ -8,8 +8,7 @@ class Devices
     'device' => 'Google Pixel 4',
     'platformName' => 'Android',
     'os' => 'android',
-    'os_version' => '10.0',
-    'browserstack.appium_version' => '1.15.0'
+    'os_version' => '10.0'
   }.freeze
   ANDROID_9_0 = {
     'autoGrantPermissions' => 'true',
@@ -64,29 +63,25 @@ class Devices
       'device' => 'iPhone 8',
       'platformName' => 'iOS',
       'os' => 'ios',
-      'os_version' => '13',
-      'browserstack.appium_version' => '1.16.0'
+      'os_version' => '13'
   }.freeze
   IOS_12 = {
     'device' => 'iPhone 8',
     'platformName' => 'iOS',
     'os' => 'ios',
-    'os_version' => '12',
-    'browserstack.appium_version' => '1.16.0'
+    'os_version' => '12'
   }.freeze
   IOS_11 = {
     'device' => 'iPhone 8',
     'platformName' => 'iOS',
     'os' => 'ios',
-    'os_version' => '11',
-    'browserstack.appium_version' => '1.16.0'
+    'os_version' => '11'
   }.freeze
   IOS_10 = {
     'device' => 'iPhone 7',
     'platformName' => 'iOS',
     'os' => 'ios',
-    'os_version' => '10',
-    'browserstack.appium_version' => '1.15.0'
+    'os_version' => '10'
   }.freeze
   DEVICE_HASH = {
     'ANDROID_10_0' => ANDROID_10_0,

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '2.3.1'.freeze
+  VERSION = '2.3.2'.freeze
 end


### PR DESCRIPTION
## Goal

Remove the explicit setting of appium_version on devices, as there is a suspicion that it acts against BrowserStack's management of Appium version use during their engineering investigations.

## Tests

Tested in advance of release by running our JS and Android pipelines against it.