### PR TITLE
Trigger notifier pipelines against master updates

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -81,15 +81,24 @@ steps:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
 
+  - wait
+
+  - label: 'Trigger Cocoa build against new master'
+    branches: 'master trigger-pipelines'
+    trigger: 'cocoa-bugsnag-notifier'
+    build:
+      branch: 'maze-runner-master'
+    async: true
+
   - label: 'Update docs'
-    if: build.tag =~ /^v2\.[0-9]+\.[0-9]+\$/
+    if: build.tag =~ /^v[2-9]\.[0-9]+\.[0-9]+\$/
     plugins:
       docker-compose#v3.3.0:
         run: docs
     command: 'bundle exec rake docs:build_and_publish'
 
   - label: 'Push Docker image for tag'
-    if: build.tag =~ /^v2\.[0-9]+\.[0-9]+\$/
+    if: build.tag =~ /^v[2-9]\.[0-9]+\.[0-9]+\$/
     plugins:
       - docker-compose#v3.3.0:
           push:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -84,21 +84,21 @@ steps:
   - wait
 
   - label: 'Trigger Android build against new master'
-    branches: 'master trigger-pipelines'
+    branches: 'master'
     trigger: 'android-bugsnag-notifier'
     build:
       branch: 'maze-runner-master'
     async: true
 
   - label: 'Trigger Cocoa build against new master'
-    branches: 'master trigger-pipelines'
+    branches: 'master'
     trigger: 'cocoa-bugsnag-notifier'
     build:
       branch: 'maze-runner-master'
     async: true
 
   - label: 'Trigger JS build against new master'
-    branches: 'master trigger-pipelines'
+    branches: 'master'
     trigger: 'at-bugsnag-js'
     build:
       branch: 'maze-runner-master'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -83,9 +83,23 @@ steps:
 
   - wait
 
+  - label: 'Trigger Android build against new master'
+    branches: 'master trigger-pipelines'
+    trigger: 'android-bugsnag-notifier'
+    build:
+      branch: 'maze-runner-master'
+    async: true
+
   - label: 'Trigger Cocoa build against new master'
     branches: 'master trigger-pipelines'
     trigger: 'cocoa-bugsnag-notifier'
+    build:
+      branch: 'maze-runner-master'
+    async: true
+
+  - label: 'Trigger JS build against new master'
+    branches: 'master trigger-pipelines'
+    trigger: 'at-bugsnag-js'
     build:
       branch: 'maze-runner-master'
     async: true


### PR DESCRIPTION
## Goal

Automatically trigger builds on our Android, Cocoa and JavaScript repos against the new `master` Maze Runner whenever it changes.  This will provide us with additional confidence in changes prior to making a new release, allowing us to move faster.  If a breaking change does occur, this approach will also allow us to more easily see which change was responsible.

## Design

I have set up a standard `maze-runner-master` branches on our Android, Cocoa and JavaScript notifiers that run tests using the latest `master-cli` Maze Runner Docker image.  When a change is merged to Maze Runner `master` (and only `master`), the pipeline will publish the new Docker image tagged with `master-cli` before triggering builds for each repository.

Possible drawbacks of this approach are:
- The need for special `maze-runner-master` branches to exist on other repos.  We should make the Bugsnag engineering team aware of this in the short term.  Longer term, if we find this useful, it may be possible to build parameterization into the other pipeline and avoid the need for these branches.
- The need to occasionally rebase the `maze-runner-master` branches on the other repos to keep them up-to-date.  They don't need to be kept up-to-the-minute, though, and a monthly reminder to rebase should suffice.

## Changeset

Additional trigger steps once the new image has been pushed.  I've also taken the opportunity to broaden the scope of publishing docs and pushing release images for Maze Runner versions 3 onwards (up to 9, anyway).

## Tests

This PR consists of three commits, for which the generates builds can be inspected. The first two commits include this branch as one to perform the triggers for, demonstrating that the other pipelines will be run.  The third commit removes `trigger-pipelines` from the list, giving confidence that it will now only occur once merged to `master`.