### PR TITLE
Use BRANCH_NAME throughout instead of BUILDKITE_BRANCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   [#121](https://github.com/bugsnag/maze-runner/pull/121)
 - Notifier builds automatically triggered against new versions of `master`
   [#122](https://github.com/bugsnag/maze-runner/pull/122)
+- Use BRANCH_NAME throughout instead of BUILDKITE_BRANCH
+  [#123](https://github.com/bugsnag/maze-runner/pull/123)
 
 # 2.3.2 - 2020/08/26
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,9 @@ services:
     build:
       context: test/fixtures/browserstack-app
       args:
-        BUILDKITE_BRANCH:
+        BRANCH_NAME:
     environment:
-      BUILDKITE_BRANCH:
+      BRANCH_NAME:
       BUILDKITE_PIPELINE_NAME:
       BUILDKITE_RETRY_COUNT:
       BUILDKITE:
@@ -40,7 +40,7 @@ services:
     build:
       context: test/fixtures/comparison
       args:
-        BUILDKITE_BRANCH:
+        BRANCH_NAME:
 
   payload-helper-tests:
     build:

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -166,7 +166,7 @@ class AppAutomateDriver < Appium::Driver
 
       bk_build_array = []
       bk_build_array << ENV['BUILDKITE_BUILD_NUMBER'] if ENV['BUILDKITE_BUILD_NUMBER']
-      bk_build_array << ENV['BUILDKITE_BRANCH'] if ENV['BUILDKITE_BRANCH']
+      bk_build_array << ENV['BRANCH_NAME'] if ENV['BRANCH_NAME']
       bk_build = bk_build_array.join(' ')
 
       bk_name_array = [name]

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -15,9 +15,9 @@ class AppAutomateDriverTest < Test::Unit::TestCase
   LOCAL_TUNNEL_COMMAND = "/BrowserStackLocal -d start --key #{ACCESS_KEY} --local-identifier #{LOCAL_ID} --force-local"
 
   def setup
+    ENV.delete('BRANCH_NAME')
     ENV.delete('BUILDKITE')
     ENV.delete('BUILDKITE_PIPELINE_NAME')
-    ENV.delete('BUILDKITE_BRANCH')
     ENV.delete('BUILDKITE_BUILD_NUMBER')
     ENV.delete('BUILDKITE_RETRY_COUNT')
     ENV.delete('BUILDKITE_STEP_KEY')
@@ -336,9 +336,9 @@ class AppAutomateDriverTest < Test::Unit::TestCase
   end
 
   def test_environment_ids
+    ENV['BRANCH_NAME'] = 'TEST BRANCH'
     ENV['BUILDKITE'] = 'true'
     ENV['BUILDKITE_PIPELINE_NAME'] = 'TEST'
-    ENV['BUILDKITE_BRANCH'] = 'TEST BRANCH'
     ENV['BUILDKITE_BUILD_NUMBER'] = '156'
     ENV['BUILDKITE_RETRY_COUNT'] = '5'
     ENV['BUILDKITE_STEP_KEY'] = 'tests-05'

--- a/test/fixtures/browserstack-app/dockerfile
+++ b/test/fixtures/browserstack-app/dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDKITE_BRANCH
+ARG BRANCH_NAME
 FROM openjdk:8-jdk-stretch AS browserstack-app-automate-builder
 
 RUN apt-get update
@@ -20,7 +20,7 @@ COPY . .
 
 RUN ./gradlew app:assembleRelease
 
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BUILDKITE_BRANCH}-ci AS browserstack-app-automate
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci AS browserstack-app-automate
 
 RUN apk add bash curl
 

--- a/test/fixtures/comparison/Dockerfile
+++ b/test/fixtures/comparison/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILDKITE_BRANCH
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BUILDKITE_BRANCH}-ci
+ARG BRANCH_NAME
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
 RUN apk add bash curl
 


### PR DESCRIPTION
## Goal

Use the `BRANCH_NAME` variable to avoid `/`s in branch names breaking CI.

## Tests

Tested by CI, having included a `/` in this branch's name.
