### PR TITLE
Fix broken build api step syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Enhancements
 
+- Fix broken Build API step syntax
+  [#125](https://github.com/bugsnag/maze-runner/pull/125)
 - Range of additional Android 6, 8.0 and 8.1 device options provided, 
   together with Android 11 and iOS 14.
   [#127](https://github.com/bugsnag/maze-runner/pull/127)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.5.0 - TBD
+# 2.5.0 - 2020/09/10
 
 ## Enhancements
 
@@ -22,7 +22,7 @@
   [#122](https://github.com/bugsnag/maze-runner/pull/122)
 - Use BRANCH_NAME throughout instead of BUILDKITE_BRANCH
   [#123](https://github.com/bugsnag/maze-runner/pull/123)
-
+    
 # 2.3.2 - 2020/08/26
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (2.4.0)
+    bugsnag-maze-runner (2.5.0)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/lib/features/steps/build_api_steps.rb
+++ b/lib/features/steps/build_api_steps.rb
@@ -5,7 +5,7 @@
 Then("the request is valid for the Build API") do
   steps %Q{
     And the payload field "apiKey" equals "#{$api_key}"
-    the payload field "appVersion" is not null
+    And the payload field "appVersion" is not null
   }
 end
 
@@ -14,10 +14,10 @@ end
 Then("the request is valid for the Android Mapping API") do
   steps %Q{
     And the payload field "apiKey" equals "#{$api_key}"
-    the payload field "proguard" is not null
-    the payload field "appId" is not null
-    the payload field "versionCode" is not null
-    the payload field "buildUUID" is not null
-    the payload field "versionName" is not null
+    And the payload field "proguard" is not null
+    And the payload field "appId" is not null
+    And the payload field "versionCode" is not null
+    And the payload field "buildUUID" is not null
+    And the payload field "versionName" is not null
   }
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '2.4.0'.freeze
+  VERSION = '2.5.0'.freeze
 end


### PR DESCRIPTION
## Goal

The missing "And" from the beginning of these steps caused the following issue:
```
Then the request is valid for the Build API                                      # maze-runner-094befd98347/lib/features/steps/build_api_steps.rb:5
      Parser errors:
      (5:5): expected: #EOF, #TableRow, #DocStringSeparator, #StepLine, #TagLine, #ScenarioLine, #ScenarioOutlineLine, #Comment, #Empty, got 'the payload field "appVersion" is not null' (Gherkin::CompositeParserException)
      features/abi_apk_splits.feature:7:in `Then the request is valid for the Build API'
```

This should fix it by making it parsable.

## Tests

Will be tested with another project.  WIP will be removed then.
