### PR TITLE
Separate endpoints for error and session requests

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,10 +18,17 @@ config.setEndpoints("http://localhost:9339/notify", "http://localhost:9339/sessi
 ### Cucumber steps changed
  
 Several Cucumber steps have changed their wording:
-```diff
-- I wait to receive a request
-+ asdasd
-```
+
+Old step | New step
+----| -------- | 
+I wait to receive a request | I wait to receive an error
+I wait to receive {int} request(s) | I wait to receive {int} error(s)
+I discard the oldest request | I discard the oldest error
+I should receive no requests | I should receive no errors
+the {string} header is not null | the error {string} header is not null
+the {string} query parameter equals {string} | the error {string} query parameter equals {string}
+the {string} query parameter is not null | the error {string} query parameter is not null
+the {string} query parameter is a timestamp | the error {string} query parameter is a timestamp
 
 ### Cucumber steps removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,13 +15,15 @@ v3:
 config.setEndpoints("http://localhost:9339/notify", "http://localhost:9339/sessions")
 ```
 
-### Cucumber steps reworded
+### Cucumber steps changed
  
 Several Cucumber steps have changed their wording:
+```diff
+- I wait to receive a request
++ asdasd
+```
 
-TODO
-
-### Cucumber steos removed
+### Cucumber steps removed
 
 The following Cucumber steps are no longer required at the scenario level, as they are included
 in the newly worded steps above.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,29 @@
+## v2 to v3
+
+In v2, a single "request" endpoint received HTTP requests for both errors (notify) and sessions.  In v3 these have 
+been separated, meaning:
+
+### Client Configuration
+
+Bugsnag clients must now be configured with different endpoints:
+v2
+```
+config.setEndpoints("http://localhost:9339", "http://localhost:9339")
+```
+v3:
+```
+config.setEndpoints("http://localhost:9339/notify", "http://localhost:9339/sessions")
+```
+
+### Cucumber steps reworded
+ 
+Several Cucumber steps have changed their wording:
+
+TODO
+
+### Cucumber steos removed
+
+The following Cucumber steps are no longer required at the scenario level, as they are included
+in the newly worded steps above.
+
+TODO

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -4,15 +4,15 @@ require 'cucumber'
 require 'json'
 
 AfterConfiguration do |config|
-  Server.instance.start
+  Server.start
 end
 
 # Before each scenario
 Before do |scenario|
   STDOUT.puts "--- Scenario: #{scenario.name}"
   Runner.environment.clear
-  Server.instance.errors.clear
-  Server.instance.sessions.clear
+  Server.errors.clear
+  Server.sessions.clear
   Store.values.clear
 end
 
@@ -35,11 +35,11 @@ After do |scenario|
   # TODO Revamp and log sessions
   if scenario.failed?
     STDOUT.puts '^^^ +++'
-    if Server.instance.errors.empty?
+    if Server.errors.empty?
       $logger.info 'No errors received'
     else
-      $logger.info "#{Server.instance.errors.size} errors were received:"
-      Server.instance.errors.all.each.with_index(1) do |request, number|
+      $logger.info "#{Server.errors.size} errors were received:"
+      Server.errors.all.each.with_index(1) do |request, number|
         $logger.info "Request #{number}:"
         LogUtil.log_hash(Logger::Severity::INFO, request)
       end
@@ -50,7 +50,7 @@ end
 # After all tests
 at_exit do
   # Stop the mock server
-  Server.instance.stop
+  Server.stop
 
   # In order to not impact future test runs, we down
   # all services (which removes networks etc) so that

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -150,7 +150,7 @@ end
 def testStringPlatformValues(field_path, platform_values)
   expected_value = getExpectedValueForPlatform(platform_values)
   unless shouldSkipPlatformCheck(expected_value)
-    payload_value = read_key_path(Server.current_request[:body], field_path)
+    payload_value = read_key_path(Server.instance.errors.current[:body], field_path)
     assert_equal(expected_value, payload_value)
   end
 end
@@ -165,7 +165,7 @@ def testBooleanPlatformValues(field_path, platform_values)
     else
       expected_bool = expected_value
     end
-    payload_value = read_key_path(Server.current_request[:body], field_path)
+    payload_value = read_key_path(Server.instance.errors.current[:body], field_path)
     assert_equal(expected_bool, payload_value)
   end
 end
@@ -173,7 +173,7 @@ end
 def testNumericPlatformValues(field_path, platform_values)
   expected_value = getExpectedValueForPlatform(platform_values)
   unless shouldSkipPlatformCheck(expected_value)
-    payload_value = read_key_path(Server.current_request[:body], field_path)
+    payload_value = read_key_path(Server.instance.errors.current[:body], field_path)
     assert_equal(expected_value.to_f, payload_value)
   end
 end

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -150,7 +150,7 @@ end
 def testStringPlatformValues(field_path, platform_values)
   expected_value = getExpectedValueForPlatform(platform_values)
   unless shouldSkipPlatformCheck(expected_value)
-    payload_value = read_key_path(Server.instance.errors.current[:body], field_path)
+    payload_value = read_key_path(Server.errors.current[:body], field_path)
     assert_equal(expected_value, payload_value)
   end
 end
@@ -165,7 +165,7 @@ def testBooleanPlatformValues(field_path, platform_values)
     else
       expected_bool = expected_value
     end
-    payload_value = read_key_path(Server.instance.errors.current[:body], field_path)
+    payload_value = read_key_path(Server.errors.current[:body], field_path)
     assert_equal(expected_bool, payload_value)
   end
 end
@@ -173,7 +173,7 @@ end
 def testNumericPlatformValues(field_path, platform_values)
   expected_value = getExpectedValueForPlatform(platform_values)
   unless shouldSkipPlatformCheck(expected_value)
-    payload_value = read_key_path(Server.instance.errors.current[:body], field_path)
+    payload_value = read_key_path(Server.errors.current[:body], field_path)
     assert_equal(expected_value.to_f, payload_value)
   end
 end

--- a/lib/features/steps/breadcrumb_steps.rb
+++ b/lib/features/steps/breadcrumb_steps.rb
@@ -5,7 +5,7 @@
 # @step_input type [String] The expected breadcrumb's type
 # @step_input name [String] The expected breadcrumb's name
 Then("the event has a {string} breadcrumb named {string}") do |type, name|
-  value = Server.instance.errors.current[:body]["events"].first["breadcrumbs"]
+  value = Server.errors.current[:body]["events"].first["breadcrumbs"]
   found = false
   value.each do |crumb|
     if crumb["type"] == type and crumb["name"] == name then
@@ -20,7 +20,7 @@ end
 # @step_input type [String] The expected breadcrumb's type
 # @step_input message [String] The expected breadcrumb's message
 Then("the event has a {string} breadcrumb with message {string}") do |type, message|
-  value = Server.instance.errors.current[:body]["events"].first["breadcrumbs"]
+  value = Server.errors.current[:body]["events"].first["breadcrumbs"]
   found = false
   value.each do |crumb|
     if crumb["type"] == type and crumb["metaData"] and crumb["metaData"]["message"] == message then
@@ -35,7 +35,7 @@ end
 #
 # @step_input type [String] The type of breadcrumb expected to not be present
 Then("the event does not have a {string} breadcrumb") do |type|
-  value = Server.instance.errors.current[:body]["events"].first["breadcrumbs"]
+  value = Server.errors.current[:body]["events"].first["breadcrumbs"]
   found = false
   value.each do |crumb|
     if crumb["type"] == type
@@ -49,7 +49,7 @@ end
 #
 # @step_input json_fixture [String] A path to the JSON fixture to compare against
 Then("the event contains a breadcrumb matching the JSON fixture in {string}") do |json_fixture|
-  breadcrumbs = read_key_path(Server.instance.errors.current[:body], "events.0.breadcrumbs")
+  breadcrumbs = read_key_path(Server.errors.current[:body], "events.0.breadcrumbs")
   expected = JSON.parse(open(json_fixture, &:read))
   match = breadcrumbs.any? { |breadcrumb| value_compare(expected, breadcrumb).equal? }
   assert(match, "No breadcrumbs in the event matched the given breadcrumb")

--- a/lib/features/steps/breadcrumb_steps.rb
+++ b/lib/features/steps/breadcrumb_steps.rb
@@ -5,7 +5,7 @@
 # @step_input type [String] The expected breadcrumb's type
 # @step_input name [String] The expected breadcrumb's name
 Then("the event has a {string} breadcrumb named {string}") do |type, name|
-  value = Server.current_request[:body]["events"].first["breadcrumbs"]
+  value = Server.instance.errors.current[:body]["events"].first["breadcrumbs"]
   found = false
   value.each do |crumb|
     if crumb["type"] == type and crumb["name"] == name then
@@ -20,7 +20,7 @@ end
 # @step_input type [String] The expected breadcrumb's type
 # @step_input message [String] The expected breadcrumb's message
 Then("the event has a {string} breadcrumb with message {string}") do |type, message|
-  value = Server.current_request[:body]["events"].first["breadcrumbs"]
+  value = Server.instance.errors.current[:body]["events"].first["breadcrumbs"]
   found = false
   value.each do |crumb|
     if crumb["type"] == type and crumb["metaData"] and crumb["metaData"]["message"] == message then
@@ -35,7 +35,7 @@ end
 #
 # @step_input type [String] The type of breadcrumb expected to not be present
 Then("the event does not have a {string} breadcrumb") do |type|
-  value = Server.current_request[:body]["events"].first["breadcrumbs"]
+  value = Server.instance.errors.current[:body]["events"].first["breadcrumbs"]
   found = false
   value.each do |crumb|
     if crumb["type"] == type
@@ -49,7 +49,7 @@ end
 #
 # @step_input json_fixture [String] A path to the JSON fixture to compare against
 Then("the event contains a breadcrumb matching the JSON fixture in {string}") do |json_fixture|
-  breadcrumbs = read_key_path(Server.current_request[:body], "events.0.breadcrumbs")
+  breadcrumbs = read_key_path(Server.instance.errors.current[:body], "events.0.breadcrumbs")
   expected = JSON.parse(open(json_fixture, &:read))
   match = breadcrumbs.any? { |breadcrumb| value_compare(expected, breadcrumb).equal? }
   assert(match, "No breadcrumbs in the event matched the given breadcrumb")

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -78,9 +78,9 @@ end
 #
 # @step_input payload_version [String] The payload version expected
 Then('the payload contains the payloadVersion {string}') do |payload_version|
-  body_version = read_key_path(Server.instance.errors.current[:body], 'payloadVersion')
+  body_version = read_key_path(Server.errors.current[:body], 'payloadVersion')
   body_set = payload_version == body_version
-  event_version = read_key_path(Server.instance.errors.current[:body], 'events.0.payloadVersion')
+  event_version = read_key_path(Server.errors.current[:body], 'events.0.payloadVersion')
   event_set = payload_version == event_version
   assert_true(body_set || event_set, "The payloadVersion was not the expected value of #{payload_version}. #{body_version} found in body, #{event_version} found in event")
 end
@@ -275,7 +275,7 @@ end
 # @param payload_key [String] The thread identifier key
 # @param payload_value [Any] The thread identifier value
 def validate_error_reporting_thread(payload_key, payload_value)
-  threads = Server.instance.errors.current[:body]['events'].first['threads']
+  threads = Server.errors.current[:body]['events'].first['threads']
   assert_kind_of Array, threads
   count = 0
 
@@ -305,7 +305,7 @@ def test_unhandled_state(event, unhandled, severity=nil)
     Then the payload field "events.#{event}.unhandled" is #{expected_unhandled_state}
     And the payload field "events.#{event}.severity" equals "#{expected_severity}"
   )
-  unless read_key_path(Server.instance.errors.current[:body], "events.#{event}.session").nil?
+  unless read_key_path(Server.errors.current[:body], "events.#{event}.session").nil?
     session_field = unhandled ? 'unhandled' : 'handled'
     steps %(
       And the payload field "events.#{event}.session.events.#{session_field}" is greater than 0

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -5,8 +5,8 @@
 #
 # @step_input payload_version [String] The payload version expected
 # @step_input notifier_name [String] The expected name of the notifier
-Then("the request is valid for the error reporting API version {string} for the {string} notifier") do |payload_version, notifier_name|
-  steps %Q{
+Then('the request is valid for the error reporting API version {string} for the {string} notifier') do |payload_version, notifier_name|
+  steps %(
     Then the "Bugsnag-Api-Key" header equals "#{$api_key}"
     And the payload field "apiKey" equals "#{$api_key}"
     And the "Bugsnag-Payload-Version" header equals "#{payload_version}"
@@ -23,7 +23,7 @@ Then("the request is valid for the error reporting API version {string} for the 
     And each element in payload field "events" has "severityReason.type"
     And each element in payload field "events" has "unhandled"
     And each element in payload field "events" has "exceptions"
-  }
+  )
 end
 
 # Verifies that an event is correct for an unhandled error
@@ -33,7 +33,7 @@ end
 #    Severity
 #
 # @param event [Integer] The event to verify
-Then("event {int} is unhandled") do |event|
+Then('event {int} is unhandled') do |event|
   test_unhandled_state(event, true)
 end
 
@@ -45,7 +45,7 @@ end
 #
 # @param event [Integer] The event to verify
 # @param severity [String] An expected severity different to the default "error"
-Then("event {int} is unhandled with the severity {string}") do |event, severity|
+Then('event {int} is unhandled with the severity {string}') do |event, severity|
   test_unhandled_state(event, true, severity)
 end
 
@@ -56,7 +56,7 @@ end
 #    Severity
 #
 # @param event [Integer] The event to verify
-Then("event {int} is handled") do |event|
+Then('event {int} is handled') do |event|
   test_unhandled_state(event, false)
 end
 
@@ -68,7 +68,7 @@ end
 #
 # @param event [Integer] The event to verify
 # @param severity [String] An expected severity different to the default "error"
-Then("event {int} is handled with the severity {string}") do |event, severity|
+Then('event {int} is handled with the severity {string}') do |event, severity|
   test_unhandled_state(event, false, severity)
 end
 
@@ -77,10 +77,10 @@ end
 #   For all other notifiers this should be a top-level key.
 #
 # @step_input payload_version [String] The payload version expected
-Then("the payload contains the payloadVersion {string}") do |payload_version|
-  body_version = read_key_path(Server.current_request[:body], "payloadVersion")
+Then('the payload contains the payloadVersion {string}') do |payload_version|
+  body_version = read_key_path(Server.instance.errors.current[:body], 'payloadVersion')
   body_set = payload_version == body_version
-  event_version = read_key_path(Server.current_request[:body], "events.0.payloadVersion")
+  event_version = read_key_path(Server.instance.errors.current[:body], 'events.0.payloadVersion')
   event_set = payload_version == event_version
   assert_true(body_set || event_set, "The payloadVersion was not the expected value of #{payload_version}. #{body_version} found in body, #{event_version} found in event")
 end
@@ -97,7 +97,7 @@ end
 #
 # @step_input field [String] The relative location of the value to test
 # @step_input string_value [String] The string to match against
-Then("the event {string} equals {string}") do |field, string_value|
+Then('the event {string} equals {string}') do |field, string_value|
   step "the payload field \"events.0.#{field}\" equals \"#{string_value}\""
 end
 
@@ -105,7 +105,7 @@ end
 #
 # @step_input field [String] The relative location of the value to test
 # @step_input value [Integer] The integer to test against
-Then("the event {string} equals {int}") do |field, value|
+Then('the event {string} equals {int}') do |field, value|
   step "the payload field \"events.0.#{field}\" equals #{value}"
 end
 
@@ -113,7 +113,7 @@ end
 #
 # @step_input field [String] The relative location of the value to test
 # @step_input string_value [String] The string to match against
-Then("the event {string} starts with {string}") do |field, string_value|
+Then('the event {string} starts with {string}') do |field, string_value|
   step "the payload field \"events.0.#{field}\" starts with \"#{string_value}\""
 end
 
@@ -121,7 +121,7 @@ end
 #
 # @step_input field [String] The relative location of the value to test
 # @step_input string_value [String] The string to match against
-Then("the event {string} ends with {string}") do |field, string_value|
+Then('the event {string} ends with {string}') do |field, string_value|
   step "the payload field \"events.0.#{field}\" ends with \"#{string_value}\""
 end
 
@@ -129,7 +129,7 @@ end
 #
 # @step_input field [String] The relative location of the value to test
 # @step_input pattern [String] The regex to match against
-Then("the event {string} matches {string}") do |field, pattern|
+Then('the event {string} matches {string}') do |field, pattern|
   step "the payload field \"events.0.#{field}\" matches the regex \"#{pattern}\""
 end
 
@@ -137,14 +137,14 @@ end
 #   Uses the regex /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
 #
 # @step_input field [String] The relative location of the value to test
-Then("the event {string} is a timestamp") do |field|
+Then('the event {string} is a timestamp') do |field|
   step "the payload field \"events.0.#{field}\" matches the regex \"#{TIMESTAMP_REGEX}\""
 end
 
 # Tests whether a value in the first event entry is a numeric and parsable timestamp.
 #
 # @step_input field [String] The relative location of the value to test
-Then("the event {string} is a parsable timestamp in seconds") do |field|
+Then('the event {string} is a parsable timestamp in seconds') do |field|
   step "the payload field \"events.0.#{field}\" is a parsable timestamp in seconds"
 end
 
@@ -152,7 +152,7 @@ end
 #
 # @step_input field [String] The payload element to check
 # @step_input env_var [String] The environment variable to test against
-Then("the event {string} equals the environment variable {string}") do |field, env_var|
+Then('the event {string} equals the environment variable {string}') do |field, env_var|
   step "the payload field \"events.0.#{field}\" equals the environment variable \"#{env_var}\""
 end
 
@@ -160,7 +160,7 @@ end
 #
 # @step_input field [String] The relative location of the value to test
 # @step_input fixture_path [String] The fixture to match against
-Then("the event {string} matches the JSON fixture in {string}") do |field, fixture_path|
+Then('the event {string} matches the JSON fixture in {string}') do |field, fixture_path|
   step "the payload field \"events.0.#{field}\" matches the JSON fixture in \"#{fixture_path}\""
 end
 
@@ -168,7 +168,7 @@ end
 #
 # @step_input field [String] The relative location of the value to test
 # @step_input string_value [String] The string to match against
-Then("the exception {string} starts with {string}") do |field, string_value|
+Then('the exception {string} starts with {string}') do |field, string_value|
   step "the payload field \"events.0.exceptions.0.#{field}\" starts with \"#{string_value}\""
 end
 
@@ -176,7 +176,7 @@ end
 #
 # @step_input field [String] The relative location of the value to test
 # @step_input string_value [String] The string to match against
-Then("the exception {string} ends with {string}") do |field, string_value|
+Then('the exception {string} ends with {string}') do |field, string_value|
   step "the payload field \"events.0.exceptions.0.#{field}\" ends with \"#{string_value}\""
 end
 
@@ -184,7 +184,7 @@ end
 #
 # @step_input field [String] The relative location of the value to test
 # @step_input string_value [String] The string to match against
-Then("the exception {string} equals {string}") do |field, string_value|
+Then('the exception {string} equals {string}') do |field, string_value|
   step "the payload field \"events.0.exceptions.0.#{field}\" equals \"#{string_value}\""
 end
 
@@ -192,7 +192,7 @@ end
 #
 # @step_input field [String] The relative location of the value to test
 # @step_input pattern [String] The regex to match against
-Then("the exception {string} matches {string}") do |field, pattern|
+Then('the exception {string} matches {string}') do |field, pattern|
   step "the payload field \"events.0.exceptions.0.#{field}\" matches the regex \"#{pattern}\""
 end
 
@@ -201,7 +201,7 @@ end
 # @step_input key [String] The element of the stack frame to test
 # @step_input num [Integer] The stack frame where the element is present
 # @step_input value [Integer] The value to test against
-Then("the {string} of stack frame {int} equals {int}") do |key, num, value|
+Then('the {string} of stack frame {int} equals {int}') do |key, num, value|
   field = "events.0.exceptions.0.stacktrace.#{num}.#{key}"
   step "the payload field \"#{field}\" equals #{value}"
 end
@@ -211,7 +211,7 @@ end
 # @step_input key [String] The element of the stack frame to test
 # @step_input num [Integer] The stack frame where the element is present
 # @step_input pattern [String] The regex to match against
-Then("the {string} of stack frame {int} matches {string}") do |key, num, pattern|
+Then('the {string} of stack frame {int} matches {string}') do |key, num, pattern|
   field = "events.0.exceptions.0.stacktrace.#{num}.#{key}"
   step "the payload field \"#{field}\" matches the regex \"#{pattern}\""
 end
@@ -221,7 +221,7 @@ end
 # @step_input key [String] The element of the stack frame to test
 # @step_input num [Integer] The stack frame where the element is present
 # @step_input value [String] The value to test against
-Then("the {string} of stack frame {int} equals {string}") do |key, num, value|
+Then('the {string} of stack frame {int} equals {string}') do |key, num, value|
   field = "events.0.exceptions.0.stacktrace.#{num}.#{key}"
   step "the payload field \"#{field}\" equals \"#{value}\""
 end
@@ -231,7 +231,7 @@ end
 # @step_input key [String] The element of the stack frame to test
 # @step_input num [Integer] The stack frame where the element is present
 # @step_input value [String] The value to test against
-Then("the {string} of stack frame {int} starts with {string}") do |key, num, value|
+Then('the {string} of stack frame {int} starts with {string}') do |key, num, value|
   field = "events.0.exceptions.0.stacktrace.#{num}.#{key}"
   step "the payload field \"#{field}\" starts with \"#{value}\""
 end
@@ -241,7 +241,7 @@ end
 # @step_input key [String] The element of the stack frame to test
 # @step_input num [Integer] The stack frame where the element is present
 # @step_input value [String] The value to test against
-Then("the {string} of stack frame {int} ends with {string}") do |key, num, value|
+Then('the {string} of stack frame {int} ends with {string}') do |key, num, value|
   field = "events.0.exceptions.0.stacktrace.#{num}.#{key}"
   step "the payload field \"#{field}\" ends with \"#{value}\""
 end
@@ -259,15 +259,15 @@ end
 # Tests whether a thread from the first event, identified by name, is the error reporting thread.
 #
 # @step_input thread_name [String] The name of the thread to test
-Then("the thread with name {string} contains the error reporting flag") do |thread_name|
-  validate_error_reporting_thread("name", thread_name)
+Then('the thread with name {string} contains the error reporting flag') do |thread_name|
+  validate_error_reporting_thread('name', thread_name)
 end
 
 # Tests whether a thread from the first event, identified by an id, is the error reporting thread.
 #
 # @step_input thread_id [String] The id of the thread to test
-Then("the thread with id {string} contains the error reporting flag") do |thread_id|
-  validate_error_reporting_thread("id", thread_id)
+Then('the thread with id {string} contains the error reporting flag') do |thread_id|
+  validate_error_reporting_thread('id', thread_id)
 end
 
 # Tests that a thread from the first event, identified by a particular key-value pair, is the error reporting thread.
@@ -275,12 +275,12 @@ end
 # @param payload_key [String] The thread identifier key
 # @param payload_value [Any] The thread identifier value
 def validate_error_reporting_thread(payload_key, payload_value)
-  threads = Server.current_request[:body]["events"].first["threads"]
+  threads = Server.instance.errors.current[:body]['events'].first['threads']
   assert_kind_of Array, threads
   count = 0
 
   threads.each do |thread|
-    if thread[payload_key].to_s == payload_value && thread["errorReportingThread"] == true
+    if thread[payload_key].to_s == payload_value && thread['errorReportingThread'] == true
       count += 1
     end
   end
@@ -293,22 +293,22 @@ end
 # @param unhandled [Boolean] Whether the event is unhandled or handled
 # @param severity [String] Optional. An overwritten severity to look for
 def test_unhandled_state(event, unhandled, severity=nil)
-  expected_unhandled_state = unhandled ? "true" : "false"
+  expected_unhandled_state = unhandled ? 'true' : 'false'
   expected_severity = if severity
-      severity
-    elsif unhandled
-      "error"
-    else
-      "warning"
-  end
-  steps %Q{
+                        severity
+                      elsif unhandled
+                        'error'
+                      else
+                        'warning'
+                      end
+  steps %(
     Then the payload field "events.#{event}.unhandled" is #{expected_unhandled_state}
     And the payload field "events.#{event}.severity" equals "#{expected_severity}"
-  }
-  unless read_key_path(Server.current_request[:body], "events.#{event}.session").nil?
-    session_field = unhandled ? "unhandled" : "handled"
-    steps %Q{
+  )
+  unless read_key_path(Server.instance.errors.current[:body], "events.#{event}.session").nil?
+    session_field = unhandled ? 'unhandled' : 'handled'
+    steps %(
       And the payload field "events.#{event}.session.events.#{session_field}" is greater than 0
-    }
+    )
   end
 end

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -22,22 +22,22 @@ Then('I wait to receive {int} error(s)') do |request_count|
   received = false
   until (attempts >= max_attempts) || received
     attempts += 1
-    received = (Server.instance.errors.size >= request_count)
+    received = (Server.errors.size >= request_count)
     sleep 0.1
   end
-  raise "Errors not received in 30s (received #{Server.instance.errors.size})" unless received
+  raise "Errors not received in 30s (received #{Server.errors.size})" unless received
 
-  assert_equal(request_count, Server.instance.errors.size, "#{Server.instance.errors.size} requests received")
+  assert_equal(request_count, Server.errors.size, "#{Server.errors.size} requests received")
 end
 
 # Assert that the test Server hasn't received any errors.
 Then('I should receive no errors') do
-  assert_equal(0, Server.instance.errors.size, "#{Server.instance.errors.size} errors received")
+  assert_equal(0, Server.errors.size, "#{Server.errors.size} errors received")
 end
 
 # Moves to the next error
 Then('I discard the oldest error') do
-  Server.instance.errors.next
+  Server.errors.next
 end
 
 #
@@ -48,7 +48,7 @@ end
 #
 # @step_input header_name [String] The header to test
 Then('the error {string} header is not null') do |header_name|
-  assert_not_nil(Server.instance.errors.current[:request][header_name],
+  assert_not_nil(Server.errors.current[:request][header_name],
                  "The '#{header_name}' header should not be null")
 end
 
@@ -57,7 +57,7 @@ end
 # @step_input header_name [String] The header to test
 # @step_input header_value [String] The string it should match
 Then('the {string} header equals {string}') do |header_name, header_value|
-  assert_equal(header_value, Server.instance.errors.current[:request][header_name])
+  assert_equal(header_value, Server.errors.current[:request][header_name])
 end
 
 # Tests that a header matches one of a list of strings
@@ -65,7 +65,7 @@ end
 # @step_input header_name [String] The header to test
 # @step_input header_values [DataTable] A parsed data table
 Then('the {string} header equals one of:') do |header_name, header_values|
-  assert_includes(header_values.raw.flatten, Server.instance.errors.current[:request][header_name])
+  assert_includes(header_values.raw.flatten, Server.errors.current[:request][header_name])
 end
 
 # Tests that a header is a timestamp.
@@ -73,7 +73,7 @@ end
 #
 # @step_input header_name [String] The header to test
 Then('the {string} header is a timestamp') do |header_name|
-  header = Server.instance.errors.current[:request][header_name]
+  header = Server.errors.current[:request][header_name]
   assert_match(TIMESTAMP_REGEX, header)
 end
 
@@ -86,14 +86,14 @@ end
 # @step_input parameter_name [String] The parameter to test
 # @step_input parameter_value [String] The expected value
 Then('the error {string} query parameter equals {string}') do |parameter_name, parameter_value|
-  assert_equal(parameter_value, parse_querystring(Server.instance.errors.current)[parameter_name][0])
+  assert_equal(parameter_value, parse_querystring(Server.errors.current)[parameter_name][0])
 end
 
 # Tests that a query parameter is present and not null.
 #
 # @step_input parameter_name [String] The parameter to test
 Then('the error {string} query parameter is not null') do |parameter_name|
-  assert_not_nil(parse_querystring(Server.instance.errors.current)[parameter_name][0],
+  assert_not_nil(parse_querystring(Server.errors.current)[parameter_name][0],
                  "The '#{parameter_name}' query parameter should not be null")
 end
 
@@ -102,7 +102,7 @@ end
 #
 # @step_input parameter_name [String] The parameter to test
 Then('the error {string} query parameter is a timestamp') do |parameter_name|
-  param = parse_querystring(Server.instance.errors.current)[parameter_name][0]
+  param = parse_querystring(Server.errors.current)[parameter_name][0]
   assert_match(TIMESTAMP_REGEX, param)
 end
 
@@ -114,7 +114,7 @@ end
 #
 # @step_input part_count [Integer] The number of expected fields
 Then('the multipart request has {int} fields') do |part_count|
-  parts = Server.instance.current[:body]
+  parts = Server.current[:body]
   assert_equal(part_count, parts.size)
 end
 
@@ -122,7 +122,7 @@ end
 #
 # @step_input part_key [String] The key to the multipart element
 Then('the field {string} for multipart request is not null') do |part_key|
-  parts = Server.instance.current[:body]
+  parts = Server.current[:body]
   assert_not_nil(parts[part_key], "The field '#{part_key}' should not be null")
 end
 
@@ -131,7 +131,7 @@ end
 # @step_input part_key [String] The key to the multipart element
 # @step_input expected_value [String] The string to match against
 Then('the field {string} for multipart request equals {string}') do |part_key, expected_value|
-  parts = Server.instance.errors.current[:body]
+  parts = Server.errors.current[:body]
   assert_equal(parts[part_key], expected_value)
 end
 
@@ -139,7 +139,7 @@ end
 #
 # @step_input part_key [String] The key to the multipart element
 Then('the field {string} for multipart request is null') do |part_key|
-  parts = Server.instance.errors.current[:body]
+  parts = Server.errors.current[:body]
   assert_nil(parts[part_key], "The field '#{part_key}' should be null")
 end
 
@@ -151,7 +151,7 @@ end
 #
 # @step_input fixture_path [String] Path to a JSON fixture
 Then('the payload body does not match the JSON fixture in {string}') do |fixture_path|
-  payload_value = Server.instance.errors.current[:body]
+  payload_value = Server.errors.current[:body]
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = value_compare(expected_value, payload_value)
   assert_false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
@@ -161,7 +161,7 @@ end
 #
 # @step_input fixture_path [String] Path to a JSON fixture
 Then('the payload body matches the JSON fixture in {string}') do |fixture_path|
-  payload_value = Server.instance.errors.current[:body]
+  payload_value = Server.errors.current[:body]
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = value_compare(expected_value, payload_value)
   assert_true(result.equal?, "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
@@ -172,7 +172,7 @@ end
 # @step_input field_path [String] Path to the tested element
 # @step_input fixture_path [String] Path to a JSON fixture
 Then('the payload field {string} matches the JSON fixture in {string}') do |field_path, fixture_path|
-  payload_value = read_key_path(Server.instance.errors.current[:body], field_path)
+  payload_value = read_key_path(Server.errors.current[:body], field_path)
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = value_compare(expected_value, payload_value)
   assert_true(result.equal?, "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
@@ -182,21 +182,21 @@ end
 #
 # @step_input field_path [String] Path to the tested element
 Then('the payload field {string} is true') do |field_path|
-  assert_equal(true, read_key_path(Server.instance.errors.current[:body], field_path))
+  assert_equal(true, read_key_path(Server.errors.current[:body], field_path))
 end
 
 # Tests that a payload element is false.
 #
 # @step_input field_path [String] Path to the tested element
 Then('the payload field {string} is false') do |field_path|
-  assert_equal(false, read_key_path(Server.instance.errors.current[:body], field_path))
+  assert_equal(false, read_key_path(Server.errors.current[:body], field_path))
 end
 
 # Tests that a payload element is null.
 #
 # @step_input field_path [String] Path to the tested element
 Then('the payload field {string} is null') do |field_path|
-  value = read_key_path(Server.instance.errors.current[:body], field_path)
+  value = read_key_path(Server.errors.current[:body], field_path)
   assert_nil(value, "The field '#{field_path}' should be null but is #{value}")
 end
 
@@ -204,7 +204,7 @@ end
 #
 # @step_input field_path [String] Path to the tested element
 Then('the payload field {string} is not null') do |field_path|
-  assert_not_nil(read_key_path(Server.instance.errors.current[:body], field_path),
+  assert_not_nil(read_key_path(Server.errors.current[:body], field_path),
                 "The field '#{field_path}' should not be null")
 end
 
@@ -213,7 +213,7 @@ end
 # @step_input field_path [String] Path to the tested element
 # @step_input int_value [Integer] The value to test against
 Then('the payload field {string} equals {int}') do |field_path, int_value|
-  assert_equal(int_value, read_key_path(Server.instance.errors.current[:body], field_path))
+  assert_equal(int_value, read_key_path(Server.errors.current[:body], field_path))
 end
 
 # Tests the payload field value against an environment variable.
@@ -223,7 +223,7 @@ end
 Then('the payload field {string} equals the environment variable {string}') do |field_path, env_var|
   environment_value = ENV[env_var]
   assert_false(environment_value.nil?, "The environment variable #{env_var} must not be nil")
-  value = read_key_path(Server.instance.errors.current[:body], field_path)
+  value = read_key_path(Server.errors.current[:body], field_path)
 
   assert_equal(environment_value, value)
 end
@@ -233,7 +233,7 @@ end
 # @step_input field_path [String] The payload element to test
 # @step_input int_value [Integer] The value to compare against
 Then('the payload field {string} is greater than {int}') do |field_path, int_value|
-  value = read_key_path(Server.instance.errors.current[:body], field_path)
+  value = read_key_path(Server.errors.current[:body], field_path)
   assert_kind_of Integer, value
   assert(value > int_value, "The payload field '#{field_path}' is not greater than '#{int_value}'")
 end
@@ -243,7 +243,7 @@ end
 # @step_input field_path [String] The payload element to test
 # @step_input int_value [Integer] The value to compare against
 Then('the payload field {string} is less than {int}') do |field_path, int_value|
-  value = read_key_path(Server.instance.errors.current[:body], field_path)
+  value = read_key_path(Server.errors.current[:body], field_path)
   assert_kind_of Integer, value
   assert(value < int_value, "The payload field '#{field_path}' is not less than '#{int_value}'")
 end
@@ -253,7 +253,7 @@ end
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
 Then('the payload field {string} equals {string}') do |field_path, string_value|
-  assert_equal(string_value, read_key_path(Server.instance.errors.current[:body], field_path))
+  assert_equal(string_value, read_key_path(Server.errors.current[:body], field_path))
 end
 
 # Tests a payload field starts with a string.
@@ -261,7 +261,7 @@ end
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
 Then('the payload field {string} starts with {string}') do |field_path, string_value|
-  value = read_key_path(Server.instance.errors.current[:body], field_path)
+  value = read_key_path(Server.errors.current[:body], field_path)
   assert_kind_of String, value
   assert(value.start_with?(string_value), "Field '#{field_path}' value ('#{value}') does not start with '#{string_value}'")
 end
@@ -271,7 +271,7 @@ end
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
 Then('the payload field {string} ends with {string}') do |field_path, string_value|
-  value = read_key_path(Server.instance.errors.current[:body], field_path)
+  value = read_key_path(Server.errors.current[:body], field_path)
   assert_kind_of String, value
   assert(value.end_with? string_value, "Field '#{field_path}' does not end with '#{string_value}'")
 end
@@ -281,7 +281,7 @@ end
 # @step_input field [String] The payload element to test
 # @step_input count [Integer] The value expected
 Then('the payload field {string} is an array with {int} elements') do |field, count|
-  value = read_key_path(Server.instance.errors.current[:body], field)
+  value = read_key_path(Server.errors.current[:body], field)
   assert_kind_of Array, value
   assert_equal(count, value.length)
 end
@@ -290,7 +290,7 @@ end
 #
 # @step_input field [String] The payload element to test
 Then('the payload field {string} is a non-empty array') do |field|
-  value = read_key_path(Server.instance.errors.current[:body], field)
+  value = read_key_path(Server.errors.current[:body], field)
   assert_kind_of Array, value
   assert(value.length > 0, "the field '#{field}' must be a non-empty array")
 end
@@ -301,7 +301,7 @@ end
 # @step_input regex [String] The regex to test against
 Then('the payload field {string} matches the regex {string}') do |field, regex_string|
   regex = Regexp.new(regex_string)
-  value = read_key_path(Server.instance.errors.current[:body], field)
+  value = read_key_path(Server.errors.current[:body], field)
   assert_match(regex, value)
 end
 
@@ -309,7 +309,7 @@ end
 #
 # @step_input field [String] The payload element to test
 Then('the payload field {string} is a parsable timestamp in seconds') do |field|
-  value = read_key_path(Server.instance.errors.current[:body], field)
+  value = read_key_path(Server.errors.current[:body], field)
   begin
     int = value.to_i
     parsed_time = Time.at(int)
@@ -323,7 +323,7 @@ end
 # @step_input key_path [String] The path to the tested array
 # @step_input element_key_path [String] The key for the expected element inside the array
 Then('each element in payload field {string} has {string}') do |key_path, element_key_path|
-  value = read_key_path(Server.instance.errors.current[:body], key_path)
+  value = read_key_path(Server.errors.current[:body], key_path)
   assert_kind_of Array, value
   value.each do |element|
     assert_not_nil(read_key_path(element, element_key_path),

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -27,7 +27,7 @@ Then('I wait to receive {int} error(s)') do |request_count|
   end
   raise "Errors not received in 30s (received #{Server.instance.errors.size})" unless received
 
-  assert_equal(request_count, Server.errors.size, "#{Server.instance.errors.size} requests received")
+  assert_equal(request_count, Server.instance.errors.size, "#{Server.instance.errors.size} requests received")
 end
 
 # Assert that the test Server hasn't received any errors.

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -9,8 +9,8 @@ include Test::Unit::Assertions
 # @!group Request assertion steps
 
 # Shortcut to waiting to receive a single request
-Then('I wait to receive a request') do
-  step 'I wait to receive 1 request'
+Then('I wait to receive an error') do
+  step 'I wait to receive 1 error'
 end
 
 # Continually checks to see if the required amount of requests have been received. Times out after 30 seconds.

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -37,7 +37,18 @@ end
 
 # Moves to the next error
 Then('I discard the oldest error') do
+  STDOUT.puts 'Discarding oldest error'
+  STDOUT.puts 'All before'
+  STDOUT.puts JSON.pretty_generate Server.instance.errors.all
+  STDOUT.puts 'Current before'
+  STDOUT.puts JSON.pretty_generate Server.instance.errors.current
+
   Server.instance.errors.next
+
+  STDOUT.puts 'All after'
+  STDOUT.puts JSON.pretty_generate Server.instance.errors.all
+  STDOUT.puts 'Current after'
+  STDOUT.puts JSON.pretty_generate Server.instance.errors.current
 end
 
 #

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -72,7 +72,7 @@ end
 #   Uses the regex /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
 #
 # @step_input header_name [String] The header to test
-Then('the error {string} header is a timestamp') do |header_name|
+Then('the {string} header is a timestamp') do |header_name|
   header = Server.instance.errors.current[:request][header_name]
   assert_match(TIMESTAMP_REGEX, header)
 end

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -37,18 +37,7 @@ end
 
 # Moves to the next error
 Then('I discard the oldest error') do
-  STDOUT.puts 'Discarding oldest error'
-  STDOUT.puts 'All before'
-  STDOUT.puts JSON.pretty_generate Server.instance.errors.all
-  STDOUT.puts 'Current before'
-  STDOUT.puts JSON.pretty_generate Server.instance.errors.current
-
   Server.instance.errors.next
-
-  STDOUT.puts 'All after'
-  STDOUT.puts JSON.pretty_generate Server.instance.errors.all
-  STDOUT.puts 'Current after'
-  STDOUT.puts JSON.pretty_generate Server.instance.errors.current
 end
 
 #

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -79,7 +79,7 @@ end
 
 # Tests that a payload has an appropriately structured session array
 Then("the payload has a valid sessions array") do
-  if sessions = Server.current_request[:body]["sessions"]
+  if sessions = Server.instance.sessions.current[:body]["sessions"]
     steps %Q{
       Then the session "id" is not null
       And the session "startedAt" is a timestamp

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -79,7 +79,7 @@ end
 
 # Tests that a payload has an appropriately structured session array
 Then("the payload has a valid sessions array") do
-  if sessions = Server.instance.sessions.current[:body]["sessions"]
+  if sessions = Server.sessions.current[:body]["sessions"]
     steps %Q{
       Then the session "id" is not null
       And the session "startedAt" is a timestamp

--- a/lib/features/steps/value_steps.rb
+++ b/lib/features/steps/value_steps.rb
@@ -4,7 +4,7 @@
 #
 # @step_input field [String] The payload field to store
 # @step_input key [String] The key to store the value against
-Then('the error payload field {string} is stored as the value {string}') do |field, key|
+Then('the payload field {string} is stored as the value {string}') do |field, key|
   value = read_key_path(Server.instance.errors.current[:body], field)
   Store.values[key] = value.dup
 end
@@ -13,7 +13,7 @@ end
 #
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
-Then('the error payload field {string} equals the stored value {string}') do |field, key|
+Then('the payload field {string} equals the stored value {string}') do |field, key|
   payload_value = read_key_path(Server.instance.errors.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)
@@ -24,7 +24,7 @@ end
 #
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
-Then('the error payload field {string} does not equal the stored value {string}') do |field, key|
+Then('the payload field {string} does not equal the stored value {string}') do |field, key|
   payload_value = read_key_path(Server.instance.errors.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)

--- a/lib/features/steps/value_steps.rb
+++ b/lib/features/steps/value_steps.rb
@@ -4,8 +4,8 @@
 #
 # @step_input field [String] The payload field to store
 # @step_input key [String] The key to store the value against
-Then("the payload field {string} is stored as the value {string}") do |field, key|
-  value = read_key_path(Server.current_request[:body], field)
+Then('the error payload field {string} is stored as the value {string}') do |field, key|
+  value = read_key_path(Server.instance.errors.current[:body], field)
   Store.values[key] = value.dup
 end
 
@@ -13,8 +13,8 @@ end
 #
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
-Then("the payload field {string} equals the stored value {string}") do |field, key|
-  payload_value = read_key_path(Server.current_request[:body], field)
+Then('the error payload field {string} equals the stored value {string}') do |field, key|
+  payload_value = read_key_path(Server.instance.errors.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)
   assert_true(result.equal?, "Payload value: #{payload_value} does not equal stored value: #{stored_value}")
@@ -24,8 +24,8 @@ end
 #
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
-Then("the payload field {string} does not equal the stored value {string}") do |field, key|
-  payload_value = read_key_path(Server.current_request[:body], field)
+Then('the error payload field {string} does not equal the stored value {string}') do |field, key|
+  payload_value = read_key_path(Server.instance.errors.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)
   assert_false(result.equal?, "Payload value: #{payload_value} equals stored value: #{stored_value}")

--- a/lib/features/steps/value_steps.rb
+++ b/lib/features/steps/value_steps.rb
@@ -5,7 +5,7 @@
 # @step_input field [String] The payload field to store
 # @step_input key [String] The key to store the value against
 Then('the payload field {string} is stored as the value {string}') do |field, key|
-  value = read_key_path(Server.instance.errors.current[:body], field)
+  value = read_key_path(Server.errors.current[:body], field)
   Store.values[key] = value.dup
 end
 
@@ -14,7 +14,7 @@ end
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
 Then('the payload field {string} equals the stored value {string}') do |field, key|
-  payload_value = read_key_path(Server.instance.errors.current[:body], field)
+  payload_value = read_key_path(Server.errors.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)
   assert_true(result.equal?, "Payload value: #{payload_value} does not equal stored value: #{stored_value}")
@@ -25,7 +25,7 @@ end
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
 Then('the payload field {string} does not equal the stored value {string}') do |field, key|
-  payload_value = read_key_path(Server.instance.errors.current[:body], field)
+  payload_value = read_key_path(Server.errors.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)
   assert_false(result.equal?, "Payload value: #{payload_value} equals stored value: #{stored_value}")

--- a/lib/features/support/request_list.rb
+++ b/lib/features/support/request_list.rb
@@ -8,6 +8,14 @@ class RequestList
     @current = 0
   end
 
+  def empty?
+    @requests.empty?
+  end
+
+  def size
+    @requests.size
+  end
+
   # Add a request to the list
   #
   # @param request The new request, from which a clone is made

--- a/lib/features/support/request_list.rb
+++ b/lib/features/support/request_list.rb
@@ -41,5 +41,6 @@ class RequestList
   # Clears the list
   def clear
     @requests.clear
+    @current = 0
   end
 end

--- a/lib/features/support/request_list.rb
+++ b/lib/features/support/request_list.rb
@@ -28,12 +28,25 @@ class RequestList
     @requests[@current] if @requests.size > @current
   end
 
+  # Requests yet to be processed - i.e. from current onwards
+  #  Return an empty array if there are no requests outstanding.
+  def remaining
+    requests = []
+    to_add = current
+    until to_add.nil?
+      requests.append to_add
+      self.next
+      to_add = current
+    end
+    requests
+  end
+
   # Moves to the next request, if there is one
   def next
     @current += 1 if @current < @requests.size
   end
 
-  # A frozen clone of all requests held
+  # A frozen clone of all requests held, including those already orocessed
   def all
     @requests.clone.freeze
   end

--- a/lib/features/support/request_list.rb
+++ b/lib/features/support/request_list.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# An abstraction for storing a list of requests (e.g. Errors, Sessions),
+# keeping track of the "current" request (i.e. the one being inspected).
+class RequestList
+  def initialize
+    @requests = []
+    @current = 0
+  end
+
+  # Add a request to the list
+  #
+  # @param request The new request, from which a clone is made
+  def add(request)
+    @requests.append request.clone
+  end
+
+  # The current request
+  def current
+    @requests[@current] if @requests.size > @current
+  end
+
+  # Moves to the next request, if there is one
+  def next
+    @current += 1 if @current < @requests.size
+  end
+
+  # A frozen clone of all requests held
+  def all
+    @requests.clone.freeze
+  end
+
+  # Clears the list
+  def clear
+    @requests.clear
+  end
+end

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'singleton'
 require 'webrick'
 require_relative './servlet'
 require_relative './logger'
@@ -9,65 +8,73 @@ require_relative './request_list'
 
 # Receives and stores requests through a WEBrick HTTPServer
 class Server
-  include Singleton
 
-  # There are some constraints on the port from driving remote browsers on BrowserStack.
-  # E.g. the ports/ranges that Safari will access on "localhost" urls are restricted to the following:
-  #   80, 3000, 4000, 5000, 8000, 8080 or 9000-9999 [ from https://stackoverflow.com/a/28678652 ]
-  PORT = 9339
+  class << self
 
-  attr_reader :errors
-  attr_reader :sessions
+    # There are some constraints on the port from driving remote browsers on BrowserStack.
+    # E.g. the ports/ranges that Safari will access on "localhost" urls are restricted to the following:
+    #   80, 3000, 4000, 5000, 8000, 8080 or 9000-9999 [ from https://stackoverflow.com/a/28678652 ]
+    PORT = 9339
 
-  def initialize
-    @errors = RequestList.new
-    @sessions = RequestList.new
-  end
-
-  # Whether the server thread is running
-  #
-  # @return [Boolean] If the server is running
-  def running?
-    @thread&.alive?
-  end
-
-  # Starts the WEBrick server in a separate thread
-  def start
-    attempts = 0
-    $logger.info 'Starting mock server'
-    loop do
-      @thread = Thread.new do
-        server = WEBrick::HTTPServer.new(
-          Port: PORT,
-          Logger: $logger,
-          AccessLog: []
-        )
-        server.mount '/notify', Servlet, errors
-        server.mount '/sessions', Servlet, sessions
-        server.start
-      rescue StandardError => e
-        $logger.warn "Failed to start mock server: #{e.message}"
-      ensure
-        server&.shutdown
-      end
-
-      # Need a short sleep here as a dying thread is still alive momentarily
-      sleep 1
-      break if running?
-
-      # Bail out after 3 attempts
-      attempts += 1
-      raise 'Too many failed attempts to start mock server' if attempts == 3
-
-      # Failed to start - sleep before retrying
-      $logger.info 'Retrying in 5 seconds'
-      sleep 5
+    # A list of error requests received
+    #
+    # @return [RequestList] Received error requests
+    def errors
+      @errors ||= RequestList.new
     end
-  end
 
-  # Stops the WEBrick server thread if it's running
-  def stop
-    @thread&.kill if @thread&.alive?
-    @thread = nil
+    # A list of session requests received
+    #
+    # @return [RequestList] Received error requests
+    def sessions
+      @sessions ||= RequestList.new
+    end
+
+    # Whether the server thread is running
+    #
+    # @return [Boolean] If the server is running
+    def running?
+      @thread&.alive?
+    end
+
+    # Starts the WEBrick server in a separate thread
+    def start
+      attempts = 0
+      $logger.info 'Starting mock server'
+      loop do
+        @thread = Thread.new do
+          server = WEBrick::HTTPServer.new(
+            Port: PORT,
+            Logger: $logger,
+            AccessLog: []
+          )
+          server.mount '/notify', Servlet, errors
+          server.mount '/sessions', Servlet, sessions
+          server.start
+        rescue StandardError => e
+          $logger.warn "Failed to start mock server: #{e.message}"
+        ensure
+          server&.shutdown
+        end
+
+        # Need a short sleep here as a dying thread is still alive momentarily
+        sleep 1
+        break if running?
+
+        # Bail out after 3 attempts
+        attempts += 1
+        raise 'Too many failed attempts to start mock server' if attempts == 3
+
+        # Failed to start - sleep before retrying
+        $logger.info 'Retrying in 5 seconds'
+        sleep 5
+      end
+    end
+
+    # Stops the WEBrick server thread if it's running
+    def stop
+      @thread&.kill if @thread&.alive?
+      @thread = nil
+    end
   end
 end

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -9,12 +9,12 @@ require_relative './request_list'
 # Receives and stores requests through a WEBrick HTTPServer
 class Server
 
-  class << self
+  # There are some constraints on the port from driving remote browsers on BrowserStack.
+  # E.g. the ports/ranges that Safari will access on "localhost" urls are restricted to the following:
+  #   80, 3000, 4000, 5000, 8000, 8080 or 9000-9999 [ from https://stackoverflow.com/a/28678652 ]
+  PORT = 9339
 
-    # There are some constraints on the port from driving remote browsers on BrowserStack.
-    # E.g. the ports/ranges that Safari will access on "localhost" urls are restricted to the following:
-    #   80, 3000, 4000, 5000, 8000, 8080 or 9000-9999 [ from https://stackoverflow.com/a/28678652 ]
-    PORT = 9339
+  class << self
 
     # A list of error requests received
     #

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -6,7 +6,6 @@ require 'webrick'
 require_relative './servlet'
 require_relative './logger'
 require_relative './request_list'
-require_relative './request_list'
 
 # Receives and stores requests through a WEBrick HTTPServer
 class Server

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -43,7 +43,7 @@ class Server
           AccessLog: []
         )
         server.mount '/notify', Servlet, errors
-        server.mount '/session', Servlet, sessions
+        server.mount '/sessions', Servlet, sessions
         server.start
       rescue StandardError => e
         $logger.warn "Failed to start mock server: #{e.message}"

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -1,86 +1,87 @@
 # frozen_string_literal: true
 
-require 'webrick'
 require 'json'
+require 'singleton'
+require 'webrick'
 require_relative './servlet'
 require_relative './logger'
 
-# This port number is semi-arbitrary. It doesn't matter for the sake of
-# the application what it is, but there are some constraints due to some
-# of the environments that we know this will be used in - namely, driving
-# remote browsers on BrowserStack. The ports/ranges that Safari will access
-# on "localhost" urls are restricted to the following:
-#
-#   80, 3000, 4000, 5000, 8000, 8080 or 9000-9999
-#   [ from https://stackoverflow.com/a/28678652 ]
-#
-MOCK_API_PORT = 9339
-
 # Receives and stores requests through a WEBrick HTTPServer
 class Server
-  class << self
-    # Whether the server thread is running
-    #
-    # @return [Boolean] If the server is running
-    def running?
-      @thread&.alive?
-    end
+  include Singleton
 
-    # An array of requests received.
-    # Each request is hash consisting of:
-    #   body: The parsed body of the request
-    #   request: The original HTTPRequest object
-    #
-    # @return [Array] An array of received requests
-    def stored_requests
-      @stored_requests ||= []
-    end
+  # There are some constraints on the port from driving remote browsers on BrowserStack.
+  # E.g. the ports/ranges that Safari will access on "localhost" urls are restricted to the following:
+  #   80, 3000, 4000, 5000, 8000, 8080 or 9000-9999 [ from https://stackoverflow.com/a/28678652 ]
+  PORT = 9339
 
-    # The first request received by the server.
-    #
-    # @return [Hash|nil] The first request
-    def current_request
-      stored_requests.first
-    end
+  def initialize
+    @all_notify_requests = []
+    @remaining_notify_requests = []
+  end
 
-    # Starts the WEBrick server in a separate thread
-    def start_server
-      attempts = 0
-      $logger.info 'Starting mock server'
-      loop do
-        @thread = Thread.new do
-          server = WEBrick::HTTPServer.new(
-            Port: MOCK_API_PORT,
-            Logger: $logger,
-            AccessLog: []
-          )
-          server.mount '/', Servlet
-          server.start
-        rescue StandardError => e
-          $logger.warn "Failed to start mock server: #{e.message}"
-        ensure
-          server&.shutdown
-        end
+  # Whether the server thread is running
+  #
+  # @return [Boolean] If the server is running
+  def running?
+    @thread&.alive?
+  end
 
-        # Need a short sleep here as a dying thread is still alive momentarily
-        sleep 1
-        break if running?
+  def store_notify_request(request)
+    @all_notify_requests.append request.clone
+    @remaining_notify_requests.append request.clone
+  end
 
-        # Bail out after 3 attempts
-        attempts += 1
-        raise 'Too many failed attempts to start mock server' if attempts == 3
+  def take_next_notify_request
+    @remaining_notify_requests.shift
+  end
 
-        # Failed to start - sleep before retrying
-        $logger.info 'Retrying in 5 seconds'
-        sleep 5
+  def all_notify_requests
+    @all_notify_requests.clone.freeze
+  end
+
+  def clear_all_requests
+    @all_notify_requests.clear
+    @remaining_notify_requests.clear
+  end
+
+  # Starts the WEBrick server in a separate thread
+  def start_server
+    attempts = 0
+    $logger.info 'Starting mock server'
+    loop do
+      @thread = Thread.new do
+        server = WEBrick::HTTPServer.new(
+          Port: MOCK_API_PORT,
+          Logger: $logger,
+          AccessLog: []
+        )
+        server.mount '/', Servlet
+        server.start
+      rescue StandardError => e
+        $logger.warn "Failed to start mock server: #{e.message}"
+      ensure
+        server&.shutdown
       end
-    end
 
-    # Stops the WEBrick server thread if it's running
-    def stop_server
-      @thread&.kill if @thread&.alive?
-      @thread = nil
+      # Need a short sleep here as a dying thread is still alive momentarily
+      sleep 1
+      break if running?
+
+      # Bail out after 3 attempts
+      attempts += 1
+      raise 'Too many failed attempts to start mock server' if attempts == 3
+
+      # Failed to start - sleep before retrying
+      $logger.info 'Retrying in 5 seconds'
+      sleep 5
     end
+  end
+
+  # Stops the WEBrick server thread if it's running
+  def stop_server
+    @thread&.kill if @thread&.alive?
+    @thread = nil
   end
 end
 

--- a/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -14,7 +14,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         val button = findViewById<Button>(R.id.trigger_error)
-        button.setOnClickListener { 
+        button.setOnClickListener {
             Bugsnag.notify(Exception("HandledException!"), {
                 val error = it.error!!
                 error.metaData.addToTab("test", "boolean_false", false)
@@ -33,7 +33,7 @@ class MainActivity : AppCompatActivity() {
     private fun initialiseBugsnag() {
         val config = Configuration("12312312312312312312312312312312")
         config.autoCaptureSessions = false
-        config.setEndpoints("http://localhost:9339", "http://localhost:9339")
+        config.setEndpoints("http://localhost:9339/notify", "http://localhost:9339/sessions")
 
         Bugsnag.init(this, config)
         Bugsnag.setLoggingEnabled(true)

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -3,7 +3,7 @@ Feature: Android support
 Scenario: Test Handled Android Exception
   Given the element "trigger_error" is present
   When I click the element "trigger_error"
-  Then I wait to receive a request
+  Then I wait to receive an error
   And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
   And the exception "errorClass" equals "java.lang.Exception"
   And the exception "message" equals "HandledException!"
@@ -13,7 +13,7 @@ Scenario: Test Handled Android Exception
 Scenario: Verify "equals the correct platform value" step
   Given the element "trigger_error" is present within 30 seconds
   When I click the element "trigger_error"
-  Then I wait to receive a request
+  Then I wait to receive an error
   And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
   # Verify string comparisons
   And the event "exceptions.0.errorClass" equals the platform-dependent string:

--- a/test/fixtures/comparison/features/compare_requests_json_fixtures.feature
+++ b/test/fixtures/comparison/features/compare_requests_json_fixtures.feature
@@ -2,42 +2,42 @@ Feature: Comparing JSON payloads to fixture files
 
     Scenario: The request body matches the template text exactly
         When I send a "equal"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the payload body matches the JSON fixture in "features/fixtures/exact_match.json"
         And the payload body matches the JSON fixture in "features/fixtures/fuzzy_match.json"
 
     Scenario: The request body matches the template when ignoring fields
         When I send an "ignore"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the payload body matches the JSON fixture in "features/fixtures/ignore_apple.json"
         And the payload body does not match the JSON fixture in "features/fixtures/exact_match.json"
         And the payload body does not match the JSON fixture in "features/fixtures/fuzzy_match.json"
 
     Scenario: The request body fuzzy matches the template
         When I send an "fuzzy match"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the payload body does not match the JSON fixture in "features/fixtures/exact_match.json"
         And the payload body matches the JSON fixture in "features/fixtures/fuzzy_match.json"
 
     Scenario: A subset of the request body matches a template
         When I send an "subset"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the payload field "items.0.subset" matches the JSON fixture in "features/fixtures/exact_match.json"
         And the payload field "items.0.subset" matches the JSON fixture in "features/fixtures/fuzzy_match.json"
 
     Scenario: The request body matches the template using "NUMBER" wildcards
         When I send a "numerics"-type request
-        And I wait to receive a request
+        And I wait to receive an error
         Then the payload body matches the JSON fixture in "features/fixtures/numerics.json"
 
     Scenario: The request body does not match the template using "NUMBER" wildcards
         When I send an "ignore"-type request
-        And I wait to receive a request
+        And I wait to receive an error
         Then the payload body does not match the JSON fixture in "features/fixtures/numerics.json"
 
     Scenario Outline: The request body does not match the template
         When I send an "<request_type>"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the payload body does not match the JSON fixture in "features/fixtures/exact_match.json"
         And the payload body does not match the JSON fixture in "features/fixtures/fuzzy_match.json"
 

--- a/test/fixtures/comparison/features/scripts/send_request.sh
+++ b/test/fixtures/comparison/features/scripts/send_request.sh
@@ -3,7 +3,7 @@
 require 'net/http'
 
 http = Net::HTTP.new('localhost', ENV['MOCK_API_PORT'])
-request = Net::HTTP::Post.new('/')
+request = Net::HTTP::Post.new('/notify')
 request['Content-Type'] = 'application/json'
 
 request.body = case ENV['request_type']

--- a/test/fixtures/comparison/features/steps/scripting_steps.rb
+++ b/test/fixtures/comparison/features/steps/scripting_steps.rb
@@ -7,6 +7,6 @@ When(/^I send an? "(.+)"-type request$/) do |request_type|
 end
 
 Then('the requests match the following:') do |data_table|
-  requests = Server.instance.errors.all
+  requests = Server.errors.all
   RequestSetAssertions.assert_requests_match requests, data_table
 end

--- a/test/fixtures/comparison/features/steps/scripting_steps.rb
+++ b/test/fixtures/comparison/features/steps/scripting_steps.rb
@@ -6,7 +6,7 @@ When(/^I send an? "(.+)"-type request$/) do |request_type|
   }
 end
 
-Then('the tests match the following:') do |data_table|
-  requests = Server.stored_requests
+Then('the requests match the following:') do |data_table|
+  requests = Server.instance.errors.all
   RequestSetAssertions.assert_requests_match requests, data_table
 end

--- a/test/fixtures/comparison/features/test_across_requests.feature
+++ b/test/fixtures/comparison/features/test_across_requests.feature
@@ -5,7 +5,7 @@ Feature: Comparing elements from one payload to another
         And I send a "equal"-type request
         Then I wait to receive 2 errors
         And the payload field "animals.0" is stored as the value "animal_zero"
-        And I discard the oldest request
+        And I discard the oldest error
         And the payload field "animals.0" equals the stored value "animal_zero"
 
     Scenario: Testing two elements don't match
@@ -13,5 +13,5 @@ Feature: Comparing elements from one payload to another
         And I send a "equal"-type request
         Then I wait to receive 2 errors
         And the payload field "animals.0" is stored as the value "animal_zero"
-        And I discard the oldest request
+        And I discard the oldest error
         And the payload field "animals.1" does not equal the stored value "animal_zero"

--- a/test/fixtures/comparison/features/test_across_requests.feature
+++ b/test/fixtures/comparison/features/test_across_requests.feature
@@ -3,7 +3,7 @@ Feature: Comparing elements from one payload to another
     Scenario: Testing two elements match
         When I send a "equal"-type request
         And I send a "equal"-type request
-        Then I wait to receive 2 requests
+        Then I wait to receive 2 errors
         And the payload field "animals.0" is stored as the value "animal_zero"
         And I discard the oldest request
         And the payload field "animals.0" equals the stored value "animal_zero"
@@ -11,7 +11,7 @@ Feature: Comparing elements from one payload to another
     Scenario: Testing two elements don't match
         When I send a "equal"-type request
         And I send a "equal"-type request
-        Then I wait to receive 2 requests
+        Then I wait to receive 2 errors
         And the payload field "animals.0" is stored as the value "animal_zero"
         And I discard the oldest request
         And the payload field "animals.1" does not equal the stored value "animal_zero"

--- a/test/fixtures/comparison/features/test_unordered_requests.feature
+++ b/test/fixtures/comparison/features/test_unordered_requests.feature
@@ -3,7 +3,7 @@ Feature: Unordered requests can be tested using a table
     Scenario: Testing payloads pass regardless of order
         When I send a "ordered 1"-type request
         And I send a "ordered 2"-type request
-        And I wait to receive 2 requests
+        And I wait to receive 2 errors
         Then the tests match the following:
           | foo | bar |
           | a   | b   |

--- a/test/fixtures/comparison/features/test_unordered_requests.feature
+++ b/test/fixtures/comparison/features/test_unordered_requests.feature
@@ -4,11 +4,11 @@ Feature: Unordered requests can be tested using a table
         When I send a "ordered 1"-type request
         And I send a "ordered 2"-type request
         And I wait to receive 2 errors
-        Then the tests match the following:
+        Then the requests match the following:
           | foo | bar |
           | a   | b   |
           | b   | a   |
-        And the tests match the following:
+        And the requests match the following:
           | foo | bar |
           | b   | a   |
           | a   | b   |

--- a/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
@@ -2,20 +2,20 @@ Feature: Breadcrumb helper steps
 
     Scenario: The payload contains a breadcrumb with a type and name
         When I send a "breadcrumbs"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the event has a "process" breadcrumb named "foo"
 
     Scenario: The payload contains a breadcrumb with a type and message
         When I send a "breadcrumbs"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the event has a "process" breadcrumb with message "Foobar"
 
     Scenario: The payload does not contain a type of breadcrumb
         When I send a "breadcrumbs"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the event does not have a "request" breadcrumb
 
     Scenario: The payload has a breadcrumb which matches a JSON fixture
         When I send a "breadcrumbs"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/breadcrumb_match.json"

--- a/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
@@ -2,46 +2,46 @@ Feature: Testing helper methods respond correctly
 
     Scenario: The request body matches an expected error payload
         When I send a "payload"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the request is valid for the error reporting API version "4.0" for the "Maze-runner" notifier
 
     Scenario: The request body matches an expected session payload
         When I send a "session"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the request is valid for the session reporting API version "1.0" for the "Maze-runner" notifier
 
     Scenario: The request body is correct for an unhandled payload
         When I send a "unhandled"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And event 0 is unhandled
 
     Scenario: The request body is correct for an unhandled payload with session data
         When I send an "unhandled-with-session"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And event 0 is unhandled
 
     Scenario: The request body is correct for an unhandled payload with a custom severity
         When I send an "unhandled-with-severity"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And event 0 is unhandled with the severity "info"
 
     Scenario: The request body is correct for a handled payload
         When I send a "handled"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And event 0 is handled
 
     Scenario: The request body is correct for a handled payload with session data
         When I send a "handled-with-session"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And event 0 is handled
 
     Scenario: The request body is correct for a handled payload with a custom severity
         When I send a "handled-with-severity"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And event 0 is handled with the severity "error"
 
     Scenario: The request body is correct for a payload with mixed events
         When I send a "handled-then-unhandled"-type request
-        Then I wait to receive a request
+        Then I wait to receive an error
         And event 0 is handled
         And event 1 is unhandled

--- a/test/fixtures/payload-helpers/features/scripts/send_request.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_request.sh
@@ -4,7 +4,7 @@ require 'net/http'
 require 'json'
 
 http = Net::HTTP.new('localhost', ENV['MOCK_API_PORT'])
-request = Net::HTTP::Post.new('/')
+request = Net::HTTP::Post.new('/notify')
 request['Content-Type'] = 'application/json'
 
 templates = {

--- a/test/fixtures/proxy/features/proxy.feature
+++ b/test/fixtures/proxy/features/proxy.feature
@@ -3,14 +3,14 @@ Feature: Using the different varieties of proxy server
     Scenario: Basic HTTP proxy
         When I start an http proxy
         And I run the script "features/scripts/http.sh"
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
         And the proxy handled a request for "localhost:9339"
 
     Scenario: Authenticated HTTP proxy with creds
         When I start an authenticated http proxy
         And I run the script "features/scripts/http_with_creds.sh"
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
         And the proxy handled a request for "localhost:9339"
 
@@ -23,14 +23,14 @@ Feature: Using the different varieties of proxy server
     Scenario: Basic HTTPS proxy use
         When I start an https proxy
         And I run the script "features/scripts/https.sh"
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
         And the proxy handled a request for "localhost:9339"
 
     Scenario: Authenticated HTTPS proxy with creds
         When I start an authenticated https proxy
         And I run the script "features/scripts/https_with_creds.sh"
-        Then I wait to receive a request
+        Then I wait to receive an error
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
         And the proxy handled a request for "localhost:9339"
 

--- a/test/fixtures/proxy/features/proxy.feature
+++ b/test/fixtures/proxy/features/proxy.feature
@@ -18,7 +18,7 @@ Feature: Using the different varieties of proxy server
         When I start an authenticated http proxy
         And I run the script "features/scripts/http.sh"
         Then I wait for 5 seconds
-        And I should receive no requests
+        And I should receive no errors
 
     Scenario: Basic HTTPS proxy use
         When I start an https proxy
@@ -38,4 +38,4 @@ Feature: Using the different varieties of proxy server
         When I start an authenticated https proxy
         And I run the script "features/scripts/https.sh"
         Then I wait for 5 seconds
-        And I should receive no requests
+        And I should receive no errors

--- a/test/fixtures/proxy/features/scripts/http.sh
+++ b/test/fixtures/proxy/features/scripts/http.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -x http://localhost:9000 http://localhost:9339
+curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -x http://localhost:9000 http://localhost:9339/notify

--- a/test/fixtures/proxy/features/scripts/http_with_creds.sh
+++ b/test/fixtures/proxy/features/scripts/http_with_creds.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -U user:password -x http://localhost:9000 http://localhost:9339
+curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -U user:password -x http://localhost:9000 http://localhost:9339/notify

--- a/test/fixtures/proxy/features/scripts/https.sh
+++ b/test/fixtures/proxy/features/scripts/https.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -x https://localhost:9000 --proxy-insecure http://localhost:9339
+curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -x https://localhost:9000 --proxy-insecure http://localhost:9339/notify

--- a/test/fixtures/proxy/features/scripts/https_with_creds.sh
+++ b/test/fixtures/proxy/features/scripts/https_with_creds.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -U user:password -x https://localhost:9000 --proxy-insecure http://localhost:9339
+curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -U user:password -x https://localhost:9000 --proxy-insecure http://localhost:9339/notify

--- a/test/request_list_test.rb
+++ b/test/request_list_test.rb
@@ -81,11 +81,17 @@ class RequestListTest < Test::Unit::TestCase
     list.add item2
     list.add item3
     assert_equal [item1, item2, item3], list.all
-    assert_equal item1, list.current
+    list.next
+    list.next
+    assert_equal item3, list.current
 
     list.clear
     assert_equal [], list.all
     assert_nil list.current
+
+    # Re-ddd something - checks internal pointer was reset
+    list.add item1
+    assert_equal item1, list.current
   end
 
   def test_too_many_nexts

--- a/test/request_list_test.rb
+++ b/test/request_list_test.rb
@@ -107,4 +107,20 @@ class RequestListTest < Test::Unit::TestCase
     list.add item2
     assert_equal item2, list.current
   end
+
+  def test_remaining
+    item1 = build_item 1
+    item2 = build_item 2
+    item3 = build_item 3
+
+    list = RequestList.new
+    list.add item1
+    list.add item2
+    list.add item3
+
+    list.next
+    remaining = list.remaining
+
+    assert_equal [item2, item3], remaining
+  end
 end

--- a/test/request_list_test.rb
+++ b/test/request_list_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../lib/features/support/request_list'
+
+# noinspection RubyNilAnalysis
+class RequestListTest < Test::Unit::TestCase
+
+  def build_item(id)
+    hash = {
+      id: id,
+      body: "{id: '#{id}'}"
+    }
+  end
+
+  def test_fresh_state
+    list = RequestList.new
+    assert_nil list.current
+    assert_empty list
+    assert_equal 0, list.size
+    assert_equal [], list.all
+  end
+
+  def test_add_and_next
+    list = RequestList.new
+
+    # Add 2
+    item1 = build_item 1
+    item2 = build_item 2
+    list.add item1
+    list.add item2
+
+    # Check current and state
+    assert_not_empty list
+    assert_equal 2, list.size
+    assert_equal item1, list.current
+    assert_not_equal item2, list.current
+    assert_equal [item1, item2], list.all
+
+    # Next => item2
+    list.next
+    assert_equal item2, list.current
+    assert_equal [item1, item2], list.all
+
+    # Next => nil
+    list.next
+    assert_nil list.current
+  end
+
+  def test_add_after_next
+    item1 = build_item 1
+    item2 = build_item 2
+    item3 = build_item 3
+    item4 = build_item 4
+    item5 = build_item 5
+
+    list = RequestList.new
+    list.add item1
+    list.add item2
+    list.add item3
+    list.next
+    list.next
+
+    assert_equal item3, list.current
+
+    list.add item4
+    list.add item5
+    assert_equal item3, list.current
+
+    list.next
+    assert_equal item4, list.current
+  end
+
+  def test_clear
+    item1 = build_item 1
+    item2 = build_item 2
+    item3 = build_item 3
+
+    list = RequestList.new
+    list.add item1
+    list.add item2
+    list.add item3
+    assert_equal [item1, item2, item3], list.all
+    assert_equal item1, list.current
+
+    list.clear
+    assert_equal [], list.all
+    assert_nil list.current
+  end
+
+  def test_too_many_nexts
+    item1 = build_item 1
+    item2 = build_item 2
+
+    list = RequestList.new
+    list.add item1
+
+    3.times { list.next }
+    assert_nil list.current
+
+    list.add item2
+    assert_equal item2, list.current
+  end
+end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -32,11 +32,11 @@ class ServerTest < Test::Unit::TestCase
                                            AccessLog: []).returns(mock_http_server)
 
     # End of first and only loop
-    Server.instance.expects(:sleep).with(1)
-    Server.instance.expects(:running?).returns(true)
+    Server.expects(:sleep).with(1)
+    Server.expects(:running?).returns(true)
 
     # Call the method
-    Server.instance.start
+    Server.start
   end
 
   def test_start_on_retry
@@ -63,12 +63,12 @@ class ServerTest < Test::Unit::TestCase
                                            AccessLog: []).returns(mock_http_server)
 
     # End of loop
-    Server.instance.expects(:sleep).with(1).twice
-    Server.instance.expects(:sleep).with(5)
-    Server.instance.expects(:running?).twice.returns(false).then.returns(true)
+    Server.expects(:sleep).with(1).twice
+    Server.expects(:sleep).with(5)
+    Server.expects(:running?).twice.returns(false).then.returns(true)
 
     # Call the method
-    Server.instance.start
+    Server.start
   end
 
   def test_start_fails
@@ -95,13 +95,13 @@ class ServerTest < Test::Unit::TestCase
                                            AccessLog: []).throws('Failed to start')
 
     # End of loop
-    Server.instance.expects(:sleep).with(1).times(3)
-    Server.instance.expects(:sleep).with(5).twice
-    Server.instance.expects(:running?).twice.returns(false).times(3)
+    Server.expects(:sleep).with(1).times(3)
+    Server.expects(:sleep).with(5).twice
+    Server.expects(:running?).twice.returns(false).times(3)
 
     # Call the method
     assert_raise RuntimeError do
-      Server.instance.start
+      Server.start
     end
   end
 end


### PR DESCRIPTION
## Goal

Initial separation of the `session` and `notify` (error) endpoints in the `Server` class.

## Design

This change is definitely not complete (e.g. verification of sessions is currently completely unsupported), but I am trying to make reviews relatively manageable by working iteratively.  This iteration performs the initial separation of a single `requests` list into `sessions` and `errors` (for notify) in the `Server` class and `Servlet` is updated to be parameterised via a constructor, allowing separate instances to be mounted on `/notify` and `/sessions`.

Until I look more closely at the notifier repos, I'm unsure which Cucumber steps will be needed only for errors, which only apply to session and which might apply to both (and potentially others over time).  I've therefore tended to default to making them `error` specific, in the knowledge that I may need to rework/refactor them on a subsequent iteration.

My next iteration will come as a result of starting to run our Android/Cocoa/JavaScript pipelines against this.

## Changeset

Changes revolve around the `server` class, with the introduction of a new abstraction, `RequestList`, that will allow us to have as many different endpoints as we want, all operating in the same way.

I've started an upgrade guide, which of course will continue to evolve and changes are performed.

I have added some TODOs in some areas where I believe there is scope for separating steps into new and smaller files, which will make maintenance easier.  I'll present a PR in due course with just those steps moved for ease of review.

## Tests

Testing of this integration branch will continue over a series of PRs - most notably when notifier pipelines are updated (on branch) to start using it.
