### PR TITLE
Add additional Android devices to choose from

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -100,6 +100,16 @@ steps:
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
+  - label: 'Browserstack app-automate test - Android 11'
+    env:
+      DEVICE_TYPE: ANDROID_11_0
+    plugins:
+      docker-compose#v3.3.0:
+        run: browserstack-app-automate
+    command: 'bundle exec bugsnag-maze-runner'
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
   - label: 'Payload helper tests'
     plugins:
       docker-compose#v3.3.0:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Enhancements
 
-- Range of additional Android 6, 8.0 and 8.1 device options provided
+- Range of additional Android 6, 8.0 and 8.1 device options provided, 
+  together with Android 11 and iOS 14.
   [#127](https://github.com/bugsnag/maze-runner/pull/127)
 - Ability to run an HTTP/S proxy added
   [#128](https://github.com/bugsnag/maze-runner/pull/128)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Enhancements
 
+- Range of additional Android 6, 8.0 and 8.1 device options provided
+  [#127](https://github.com/bugsnag/maze-runner/pull/127)
 - Ability to run an HTTP/S proxy added
   [#128](https://github.com/bugsnag/maze-runner/pull/128)
 

--- a/lib/features/support/capabilities/devices.rb
+++ b/lib/features/support/capabilities/devices.rb
@@ -2,68 +2,44 @@
 # noinspection RubyStringKeysInHashInspection
 class Devices
 
+  class << self
+
+    def make_android_hash(device, version)
+      {
+        'device' => device,
+        'os_version' => version,
+        'autoGrantPermissions' => 'true',
+        'platformName' => 'Android',
+        'os' => 'android'
+      }.freeze
+    end
+  end
+
   # The hash of device capabilities, accessible by simple names
-  ANDROID_10_0 = {
-    'autoGrantPermissions' => 'true',
-    'device' => 'Google Pixel 4',
-    'platformName' => 'Android',
-    'os' => 'android',
-    'os_version' => '10.0'
-  }.freeze
-  ANDROID_9_0 = {
-    'autoGrantPermissions' => 'true',
-    'device' => 'Google Pixel 3',
-    'platformName' => 'Android',
-    'os' => 'android',
-    'os_version' => '9.0'
-  }.freeze
-  ANDROID_8_1 = {
-    'autoGrantPermissions' => 'true',
-    'device' => 'Samsung Galaxy Note 9',
-    'platformName' => 'Android',
-    'os' => 'android',
-    'os_version' => '8.1'
-  }.freeze
-  ANDROID_8_0 = {
-    'autoGrantPermissions' => 'true',
-    'device' => 'Google Pixel 2',
-    'platformName' => 'Android',
-    'os' => 'android',
-    'os_version' => '8.0'
-  }.freeze
-  ANDROID_7_1 = {
-    'autoGrantPermissions' => 'true',
-    'device' => 'Google Pixel',
-    'platformName' => 'Android',
-    'os' => 'android',
-    'os_version' => '7.1'
-  }.freeze
-  ANDROID_6_0 = {
-    'autoGrantPermissions' => 'true',
-    'device' => 'Google Nexus 6',
-    'platformName' => 'Android',
-    'os' => 'android',
-    'os_version' => '6.0'
-  }.freeze
-  ANDROID_5_0 = {
-    'autoGrantPermissions' => 'true',
-    'device' => 'Google Nexus 6',
-    'platformName' => 'Android',
-    'os' => 'android',
-    'os_version' => '5.0'
-  }.freeze
-  ANDROID_4_4 = {
-    'autoGrantPermissions' => 'true',
-    'device' => 'Google Nexus 5',
-    'platformName' => 'Android',
-    'os' => 'android',
-    'os_version' => '4.4'
-  }.freeze
+  ANDROID_10_0 = Devices.make_android_hash 'Google Pixel 4', '10.0'
+  ANDROID_9_0 = Devices.make_android_hash 'Google Pixel 3', '9.0'
+  ANDROID_8_1_GALAXY_NOTE_9 = Devices.make_android_hash 'Samsung Galaxy Note 9', '8.1'
+  ANDROID_8_1_GALAXY_J7_PRIME = Devices.make_android_hash 'Samsung Galaxy J7 Prime', '8.1'
+  ANDROID_8_1_GALAXY_TAB_S4 = Devices.make_android_hash 'Samsung Galaxy Tab S4', '8.1'
+  ANDROID_8_1 = ANDROID_8_1_GALAXY_NOTE_9
+  ANDROID_8_0_PIXEL = Devices.make_android_hash 'Google Pixel', '8.0'
+  ANDROID_8_0_PIXEL_2 = Devices.make_android_hash 'Google Pixel 2', '8.0'
+  ANDROID_8_0_GALAXY_S9 = Devices.make_android_hash 'Samsung Galaxy S9', '8.0'
+  ANDROID_8_0_GALAXY_S9_PLUS = Devices.make_android_hash 'Samsung Galaxy S9 Plus', '8.0'
+  ANDROID_8_0_GALAXY_TAB_S3 = Devices.make_android_hash 'Samsung Galaxy Tab S3', '8.0'
+  ANDROID_8_0 = ANDROID_8_0_PIXEL_2
+  ANDROID_7_1 = Devices.make_android_hash 'Google Pixel', '7.1'
+  ANDROID_6_0_MOTO_X_2ND_GEN = Devices.make_android_hash 'Motorola Moto X 2nd Gen', '6.0'
+  ANDROID_6_0_NEXUS_6 = Devices.make_android_hash 'Google Nexus 6', '6.0'
+  ANDROID_6_0_GALAXY_S7 = Devices.make_android_hash 'Samsung Galaxy S7', '6.0'
+  ANDROID_6_0 = ANDROID_6_0_NEXUS_6
+  ANDROID_5_0 = Devices.make_android_hash 'Google Nexus 6', '5.0'
+  ANDROID_4_4 = Devices.make_android_hash 'Google Nexus 5', '4.4'
   IOS_13 = {
-      'device' => 'iPhone 8',
-      'platformName' => 'iOS',
-      'os' => 'ios',
-      'os_version' => '13'
+    'device' => 'iPhone 8',
+    'platformName' => 'iOS',
+    'os' => 'ios',
+    'os_version' => '13'
   }.freeze
   IOS_12 = {
     'device' => 'iPhone 8',
@@ -87,9 +63,20 @@ class Devices
     'ANDROID_10_0' => ANDROID_10_0,
     'ANDROID_9_0' => ANDROID_9_0,
     'ANDROID_8_1' => ANDROID_8_1,
+    'ANDROID_8_1_GALAXY_J7_PRIME' => ANDROID_8_1_GALAXY_J7_PRIME,
+    'ANDROID_8_1_GALAXY_NOTE_9' => ANDROID_8_1_GALAXY_NOTE_9,
+    'ANDROID_8_1_GALAXY_TAB_S4' => ANDROID_8_1_GALAXY_TAB_S4,
     'ANDROID_8_0' => ANDROID_8_0,
+    'ANDROID_8_0_GALAXY_S9' => ANDROID_8_0_GALAXY_S9,
+    'ANDROID_8_0_GALAXY_S9_PLUS' => ANDROID_8_0_GALAXY_S9_PLUS,
+    'ANDROID_8_0_GALAXY_TAB_S3' => ANDROID_8_0_GALAXY_TAB_S3,
+    'ANDROID_8_0_PIXEL' => ANDROID_8_0_PIXEL,
+    'ANDROID_8_0_PIXEL_2' => ANDROID_8_0_PIXEL_2,
     'ANDROID_7_1' => ANDROID_7_1,
     'ANDROID_6_0' => ANDROID_6_0,
+    'ANDROID_6_0_NEXUS_6' => ANDROID_6_0_NEXUS_6,
+    'ANDROID_6_0_GALAXY_S7' => ANDROID_6_0_GALAXY_S7,
+    'ANDROID_6_0_MOTO_X_2ND_GEN' => ANDROID_6_0_MOTO_X_2ND_GEN,
     'ANDROID_4_4' => ANDROID_4_4,
     'IOS_13' => IOS_13,
     'IOS_12' => IOS_12,

--- a/lib/features/support/capabilities/devices.rb
+++ b/lib/features/support/capabilities/devices.rb
@@ -32,6 +32,7 @@ class Devices
     def create_hash
       hash = {
         # Classic, non-specific devices for each Android version
+        'ANDROID_11_0' => make_android_hash('Google Pixel 4', '11.0'),
         'ANDROID_10_0' => make_android_hash('Google Pixel 4', '10.0'),
         'ANDROID_9_0' => make_android_hash('Google Pixel 3', '9.0'),
         'ANDROID_8_1' => make_android_hash('Samsung Galaxy Note 9', '8.1'),

--- a/lib/features/support/capabilities/devices.rb
+++ b/lib/features/support/capabilities/devices.rb
@@ -14,6 +14,9 @@ class Devices
     end
 
     def add_android(device, version, hash)
+      # Key format is "ANDROID_<version>_<device>", with:
+      # - dots in versions and all spaces replaced with underscores
+      # - device made upper case
       name = device.upcase.gsub ' ', '_'
       new_version = version.gsub '.', '_'
       key = "ANDROID_#{new_version}_#{name}"

--- a/lib/features/support/capabilities/devices.rb
+++ b/lib/features/support/capabilities/devices.rb
@@ -13,6 +13,13 @@ class Devices
       }.freeze
     end
 
+    def add_android(device, version, hash)
+      name = device.upcase.gsub ' ', '_'
+      new_version = version.gsub '.', '_'
+      key = "ANDROID_#{new_version}_#{name}"
+      hash[key] = make_android_hash device, version
+    end
+
     def make_ios_hash(device, version)
       {
         'device' => device,
@@ -21,67 +28,52 @@ class Devices
         'os' => 'ios'
       }.freeze
     end
+
+    def create_hash
+      hash = {
+        # Classic, non-specific devices for each Android version
+        'ANDROID_10_0' => make_android_hash('Google Pixel 4', '10.0'),
+        'ANDROID_9_0' => make_android_hash('Google Pixel 3', '9.0'),
+        'ANDROID_8_1' => make_android_hash('Samsung Galaxy Note 9', '8.1'),
+        'ANDROID_8_0' => make_android_hash('Google Pixel 2', '8.0'),
+        'ANDROID_7_1' => make_android_hash('Google Pixel', '7.1'),
+        'ANDROID_6_0' => make_android_hash('Google Nexus 6', '6.0'),
+        'ANDROID_5_0' => make_android_hash('Google Nexus 6', '5.0'),
+        'ANDROID_4_4' => make_android_hash('Google Nexus 5', '4.4'),
+
+        # iOS devices
+        'IOS_14' => make_ios_hash('iPhone 11', '14'),
+        'IOS_13' => make_ios_hash('iPhone 8', '13'),
+        'IOS_12' => make_ios_hash('iPhone 8', '12'),
+        'IOS_11' => make_ios_hash('iPhone 8', '11'),
+        'IOS_10' => make_ios_hash('iPhone 7', '10')
+      }
+      # Deprecated entries
+      hash['ANDROID_9'] = hash['ANDROID_9_0']
+      hash['ANDROID_8'] = hash['ANDROID_8_0']
+      hash['ANDROID_7'] = hash['ANDROID_7_1']
+      hash['ANDROID_6'] = hash['ANDROID_6_0']
+      hash['ANDROID_5'] = hash['ANDROID_5_0']
+      hash['ANDROID_4'] = hash['ANDROID_4_4']
+
+      # Specific Android devices
+      add_android 'Google Pixel 4', '11.0', hash
+      add_android 'Samsung Galaxy Note 9', '8.1', hash
+      add_android 'Samsung Galaxy J7 Prime', '8.1', hash
+      add_android 'Samsung Galaxy Tab S4', '8.1', hash
+      add_android 'Google Pixel', '8.0', hash
+      add_android 'Google Pixel 2', '8.0', hash
+      add_android 'Samsung Galaxy S9', '8.0', hash
+      add_android 'Samsung Galaxy S9 Plus', '8.0', hash
+      add_android 'Samsung Galaxy Tab S3', '8.0', hash
+      add_android 'Motorola Moto X 2nd Gen', '6.0', hash
+      add_android 'Google Nexus 6', '6.0', hash
+      add_android 'Samsung Galaxy S7', '6.0', hash
+
+      hash
+    end
   end
 
   # The hash of device capabilities, accessible by simple names
-  ANDROID_11_0_PIXEL_4 = Devices.make_android_hash 'Google Pixel 4', '11.0'
-  ANDROID_11_0 = ANDROID_11_0_PIXEL_4
-  ANDROID_10_0 = Devices.make_android_hash 'Google Pixel 4', '10.0'
-  ANDROID_9_0 = Devices.make_android_hash 'Google Pixel 3', '9.0'
-  ANDROID_8_1_GALAXY_NOTE_9 = Devices.make_android_hash 'Samsung Galaxy Note 9', '8.1'
-  ANDROID_8_1_GALAXY_J7_PRIME = Devices.make_android_hash 'Samsung Galaxy J7 Prime', '8.1'
-  ANDROID_8_1_GALAXY_TAB_S4 = Devices.make_android_hash 'Samsung Galaxy Tab S4', '8.1'
-  ANDROID_8_1 = ANDROID_8_1_GALAXY_NOTE_9
-  ANDROID_8_0_PIXEL = Devices.make_android_hash 'Google Pixel', '8.0'
-  ANDROID_8_0_PIXEL_2 = Devices.make_android_hash 'Google Pixel 2', '8.0'
-  ANDROID_8_0_GALAXY_S9 = Devices.make_android_hash 'Samsung Galaxy S9', '8.0'
-  ANDROID_8_0_GALAXY_S9_PLUS = Devices.make_android_hash 'Samsung Galaxy S9 Plus', '8.0'
-  ANDROID_8_0_GALAXY_TAB_S3 = Devices.make_android_hash 'Samsung Galaxy Tab S3', '8.0'
-  ANDROID_8_0 = ANDROID_8_0_PIXEL_2
-  ANDROID_7_1 = Devices.make_android_hash 'Google Pixel', '7.1'
-  ANDROID_6_0_MOTO_X_2ND_GEN = Devices.make_android_hash 'Motorola Moto X 2nd Gen', '6.0'
-  ANDROID_6_0_NEXUS_6 = Devices.make_android_hash 'Google Nexus 6', '6.0'
-  ANDROID_6_0_GALAXY_S7 = Devices.make_android_hash 'Samsung Galaxy S7', '6.0'
-  ANDROID_6_0 = ANDROID_6_0_NEXUS_6
-  ANDROID_5_0 = Devices.make_android_hash 'Google Nexus 6', '5.0'
-  ANDROID_4_4 = Devices.make_android_hash 'Google Nexus 5', '4.4'
-  IOS_14 = make_ios_hash('iPhone 11', '14')
-  IOS_13 = make_ios_hash('iPhone 8', '13')
-  IOS_12 = make_ios_hash('iPhone 8', '12')
-  IOS_11 = make_ios_hash('iPhone 8', '11')
-  IOS_10 = make_ios_hash('iPhone 7', '10')
-  DEVICE_HASH = {
-    'ANDROID_11_0' => ANDROID_11_0,
-    'ANDROID_11_0_PIXEL_4' => ANDROID_11_0_PIXEL_4,
-    'ANDROID_10_0' => ANDROID_10_0,
-    'ANDROID_9_0' => ANDROID_9_0,
-    'ANDROID_8_1' => ANDROID_8_1,
-    'ANDROID_8_1_GALAXY_J7_PRIME' => ANDROID_8_1_GALAXY_J7_PRIME,
-    'ANDROID_8_1_GALAXY_NOTE_9' => ANDROID_8_1_GALAXY_NOTE_9,
-    'ANDROID_8_1_GALAXY_TAB_S4' => ANDROID_8_1_GALAXY_TAB_S4,
-    'ANDROID_8_0' => ANDROID_8_0,
-    'ANDROID_8_0_GALAXY_S9' => ANDROID_8_0_GALAXY_S9,
-    'ANDROID_8_0_GALAXY_S9_PLUS' => ANDROID_8_0_GALAXY_S9_PLUS,
-    'ANDROID_8_0_GALAXY_TAB_S3' => ANDROID_8_0_GALAXY_TAB_S3,
-    'ANDROID_8_0_PIXEL' => ANDROID_8_0_PIXEL,
-    'ANDROID_8_0_PIXEL_2' => ANDROID_8_0_PIXEL_2,
-    'ANDROID_7_1' => ANDROID_7_1,
-    'ANDROID_6_0' => ANDROID_6_0,
-    'ANDROID_6_0_NEXUS_6' => ANDROID_6_0_NEXUS_6,
-    'ANDROID_6_0_GALAXY_S7' => ANDROID_6_0_GALAXY_S7,
-    'ANDROID_6_0_MOTO_X_2ND_GEN' => ANDROID_6_0_MOTO_X_2ND_GEN,
-    'ANDROID_4_4' => ANDROID_4_4,
-    'IOS_14' => IOS_14,
-    'IOS_13' => IOS_13,
-    'IOS_12' => IOS_12,
-    'IOS_11' => IOS_11,
-    'IOS_10' => IOS_10,
-    # Deprecated entries
-    'ANDROID_9' => ANDROID_9_0,
-    'ANDROID_8' => ANDROID_8_0,
-    'ANDROID_7' => ANDROID_7_1,
-    'ANDROID_6' => ANDROID_6_0,
-    'ANDROID_5' => ANDROID_5_0,
-    'ANDROID_4' => ANDROID_4_4
-  }.freeze
+  DEVICE_HASH = create_hash
 end

--- a/lib/features/support/capabilities/devices.rb
+++ b/lib/features/support/capabilities/devices.rb
@@ -3,7 +3,6 @@
 class Devices
 
   class << self
-
     def make_android_hash(device, version)
       {
         'device' => device,
@@ -11,6 +10,15 @@ class Devices
         'autoGrantPermissions' => 'true',
         'platformName' => 'Android',
         'os' => 'android'
+      }.freeze
+    end
+
+    def make_ios_hash(device, version)
+      {
+        'device' => device,
+        'os_version' => version,
+        'platformName' => 'iOS',
+        'os' => 'ios'
       }.freeze
     end
   end
@@ -37,30 +45,11 @@ class Devices
   ANDROID_6_0 = ANDROID_6_0_NEXUS_6
   ANDROID_5_0 = Devices.make_android_hash 'Google Nexus 6', '5.0'
   ANDROID_4_4 = Devices.make_android_hash 'Google Nexus 5', '4.4'
-  IOS_13 = {
-    'device' => 'iPhone 8',
-    'platformName' => 'iOS',
-    'os' => 'ios',
-    'os_version' => '13'
-  }.freeze
-  IOS_12 = {
-    'device' => 'iPhone 8',
-    'platformName' => 'iOS',
-    'os' => 'ios',
-    'os_version' => '12'
-  }.freeze
-  IOS_11 = {
-    'device' => 'iPhone 8',
-    'platformName' => 'iOS',
-    'os' => 'ios',
-    'os_version' => '11'
-  }.freeze
-  IOS_10 = {
-    'device' => 'iPhone 7',
-    'platformName' => 'iOS',
-    'os' => 'ios',
-    'os_version' => '10'
-  }.freeze
+  IOS_14 = make_ios_hash('iPhone 11', '14')
+  IOS_13 = make_ios_hash('iPhone 8', '13')
+  IOS_12 = make_ios_hash('iPhone 8', '12')
+  IOS_11 = make_ios_hash('iPhone 8', '11')
+  IOS_10 = make_ios_hash('iPhone 7', '10')
   DEVICE_HASH = {
     'ANDROID_11_0' => ANDROID_11_0,
     'ANDROID_11_0_PIXEL_4' => ANDROID_11_0_PIXEL_4,
@@ -82,6 +71,7 @@ class Devices
     'ANDROID_6_0_GALAXY_S7' => ANDROID_6_0_GALAXY_S7,
     'ANDROID_6_0_MOTO_X_2ND_GEN' => ANDROID_6_0_MOTO_X_2ND_GEN,
     'ANDROID_4_4' => ANDROID_4_4,
+    'IOS_14' => IOS_14,
     'IOS_13' => IOS_13,
     'IOS_12' => IOS_12,
     'IOS_11' => IOS_11,

--- a/lib/features/support/capabilities/devices.rb
+++ b/lib/features/support/capabilities/devices.rb
@@ -16,6 +16,8 @@ class Devices
   end
 
   # The hash of device capabilities, accessible by simple names
+  ANDROID_11_0_PIXEL_4 = Devices.make_android_hash 'Google Pixel 4', '11.0'
+  ANDROID_11_0 = ANDROID_11_0_PIXEL_4
   ANDROID_10_0 = Devices.make_android_hash 'Google Pixel 4', '10.0'
   ANDROID_9_0 = Devices.make_android_hash 'Google Pixel 3', '9.0'
   ANDROID_8_1_GALAXY_NOTE_9 = Devices.make_android_hash 'Samsung Galaxy Note 9', '8.1'
@@ -60,6 +62,8 @@ class Devices
     'os_version' => '10'
   }.freeze
   DEVICE_HASH = {
+    'ANDROID_11_0' => ANDROID_11_0,
+    'ANDROID_11_0_PIXEL_4' => ANDROID_11_0_PIXEL_4,
     'ANDROID_10_0' => ANDROID_10_0,
     'ANDROID_9_0' => ANDROID_9_0,
     'ANDROID_8_1' => ANDROID_8_1,


### PR DESCRIPTION
## Goal

Adds the full range of Android 6.0, 8.0 and 8.1 devices available on BrowaerStack.  The same could be done for other versions, it just hasn't been done at this stage.

## Design

I've created a new function to reduce the repetition in `devices.rb`.  The constant naming convention was agreed up-front and is the device name minus brand, upper-cased and spaces replaced with underscores.

## Changeset

Alternative devices added.

## Tests

The existing CI pipeline is sufficient to prove that I've not broken ANDROID_6_0 through ANDROID_10_0 (to only ones currently in use) and I've informally tested the new entries using a bespoke build of our Android notifier.
