### PR TITLE
Add proxy functionality

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,6 +44,12 @@ steps:
         run: comparison-tests
     command: 'bundle exec bugsnag-maze-runner'
 
+  - label: 'Proxy tests'
+    plugins:
+      docker-compose#v3.3.0:
+        run: proxy-tests
+    command: 'bundle exec bugsnag-maze-runner'
+
   - label: 'Browserstack app-automate test - Android 6'
     env:
       DEVICE_TYPE: ANDROID_6_0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.5.0 - TBD
+
+## Enhancements
+
+- Ability to run an HTTP/S proxy added
+  [#128](https://github.com/bugsnag/maze-runner/pull/128)
+
 # 2.4.0 - 2020/09/01
 
 ## Enhancements

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,12 @@ services:
       args:
         BRANCH_NAME:
 
+  proxy-tests:
+    build:
+      context: test/fixtures/proxy
+      args:
+        BRANCH_NAME:
+
   payload-helper-tests:
     build:
       context: test/fixtures/payload-helpers

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -27,6 +27,8 @@ After do |scenario|
   # so future tests are run from a clean slate.
   Runner.kill_running_scripts
 
+  Proxy.instance.stop
+
   # Log unprocessed requests if the scenario fails
   if scenario.failed?
     STDOUT.puts '^^^ +++'

--- a/lib/features/steps/proxy_steps.rb
+++ b/lib/features/steps/proxy_steps.rb
@@ -27,7 +27,7 @@ end
 # Test the proxy server handled a request for a host.
 #
 # @step_input host [String] Destination host to check
-Then('the proxy handles a request for {string}') do |host|
+Then('the proxy handled a request for {string}') do |host|
   Test::Unit::Assertions.assert_true(Proxy.instance.handled_host?(host),
                                      "The proxy did not handle a request for #{host}")
 end

--- a/lib/features/steps/proxy_steps.rb
+++ b/lib/features/steps/proxy_steps.rb
@@ -1,0 +1,29 @@
+# @!group Proxy steps
+
+# Starts an HTTP proxy server.
+#
+Then('I start an http proxy') do
+  Proxy.instance.start :Http
+end
+
+# Starts an authenticated HTTP proxy server.
+#
+Then('I start an authenticated http proxy') do
+  Proxy.instance.start :Http, true
+end
+
+# Starts an HTTPS proxy server.
+#
+Then('I start an https proxy') do
+  Proxy.instance.start :Https
+end
+
+# Test the proxy server handled a request for a host.
+#
+# @step_input host [String] Destination host to check
+Then('the proxy handled a request for {string}') do |host|
+  Test::Unit::Assertions.assert_true(Proxy.instance.handled_host?(host),
+                                     "The proxy did not handle a request for #{host}")
+end
+
+# @!endgroup

--- a/lib/features/steps/proxy_steps.rb
+++ b/lib/features/steps/proxy_steps.rb
@@ -18,10 +18,16 @@ Then('I start an https proxy') do
   Proxy.instance.start :Https
 end
 
+# Starts an authenticated HTTPS proxy server.
+#
+Then('I start an authenticated https proxy') do
+  Proxy.instance.start :Https, true
+end
+
 # Test the proxy server handled a request for a host.
 #
 # @step_input host [String] Destination host to check
-Then('the proxy handled a request for {string}') do |host|
+Then('the proxy handles a request for {string}') do |host|
   Test::Unit::Assertions.assert_true(Proxy.instance.handled_host?(host),
                                      "The proxy did not handle a request for #{host}")
 end

--- a/lib/features/support/.gitignore
+++ b/lib/features/support/.gitignore
@@ -1,0 +1,1 @@
+htpasswd

--- a/lib/features/support/proxy.rb
+++ b/lib/features/support/proxy.rb
@@ -6,7 +6,9 @@ require 'webrick'
 require 'webrick/https'
 require 'webrick/httpproxy'
 
-# Provides the ability to run a proxy server, using the WEBrick proxy server
+# Provides the ability to run a proxy server, using the WEBrick proxy server.
+# Note that for an HTTPS proxy a self-signed certificate will be used.  If using curl, for example, this
+# means having to employ the --proxy-insecure option.
 class Proxy
   include Singleton
 
@@ -33,8 +35,11 @@ class Proxy
   end
 
   # Starts the WEBrick proxy in a separate thread
+  # If authentication if requested, then the credentials used are simply 'user' with 'password'.
+  #
+  # @param protocol [Symbol] :Http or Https
+  # @param authenticated [Boolean] Whether basic authentication should be applied.
   def start(protocol, authenticated = false)
-    stop if running?
     @hosts.clear
 
     attempts = 0
@@ -46,6 +51,7 @@ class Proxy
           req.header['host'].each { |host| @hosts.append(host) }
         end
         config = {
+          Logger: $logger,
           Port: PORT,
           ProxyContentHandler: handler
         }

--- a/lib/features/support/proxy.rb
+++ b/lib/features/support/proxy.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require 'singleton'
+require 'webrick'
+require 'webrick/https'
+require 'webrick/httpproxy'
 
 # Provides the ability to run a proxy server, using the WEBrick proxy server
 class Proxy
-  include 'singleton'
+  include Singleton
 
   # There are some constraints on the port from driving remote browsers on BrowserStack.
   # E.g. the ports/ranges that Safari will access on "localhost" urls are restricted to the following:
@@ -19,7 +22,7 @@ class Proxy
   end
 
   # Starts the WEBrick proxy in a separate thread
-  def start(protocol, authenticated)
+  def start(protocol, authenticated = false)
     attempts = 0
     $logger.info 'Starting proxy server'
     loop do

--- a/lib/features/support/proxy.rb
+++ b/lib/features/support/proxy.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'singleton'
+
+# Provides the ability to run a proxy server, using the WEBrick proxy server
+class Proxy
+  include 'singleton'
+
+  # There are some constraints on the port from driving remote browsers on BrowserStack.
+  # E.g. the ports/ranges that Safari will access on "localhost" urls are restricted to the following:
+  #   80, 3000, 4000, 5000, 8000, 8080 or 9000-9999 [ from https://stackoverflow.com/a/28678652 ]
+  PORT = 9000
+
+  # Whether the proxy server thread is running
+  #
+  # @return [Boolean] If the server is running
+  def running?
+    @thread&.alive?
+  end
+
+  # Starts the WEBrick proxy in a separate thread
+  def start(protocol, authenticated)
+    attempts = 0
+    $logger.info 'Starting proxy server'
+    loop do
+      @thread = Thread.new do
+
+        handler = proc do |req, res|
+          $logger.info 'PROXY: TODO Capture something interesting'
+          $logger.info req
+        end
+        config = {
+          Port: @port,
+          ProxyContentHandler: handler
+        }
+
+        # Setup protocol
+        if protocol == :Http
+          puts 'Starting HTTP proxy'
+        elsif protocol == :Https
+          cert_name = [
+            %w[CN localhost]
+          ]
+          config[:SSLCertName] = cert_name
+          config[:SSLEnable] = true
+        else
+          raise "Unsupported protocol #{protocol}: :Http and :Https are supported"
+        end
+
+        # Authentication required?
+        if authenticated
+          # Apache compatible Password manager
+          htpasswd = WEBrick::HTTPAuth::Htpasswd.new File.expand_path('htpasswd', __dir__)
+          htpasswd.set_passwd 'Proxy Realm', 'user', 'password'
+          htpasswd.flush
+          authenticator = WEBrick::HTTPAuth::ProxyBasicAuth.new Realm: 'Proxy Realm',
+                                                                UserDB: htpasswd
+          config[:ProxyAuthProc] = authenticator.method(:authenticate).to_proc
+        end
+
+        server.start
+      rescue StandardError => e
+        $logger.warn "Failed to start proxy server: #{e.message}"
+      ensure
+        server&.shutdown
+      end
+
+      # Need a short sleep here as a dying thread is still alive momentarily
+      sleep 1
+      break if running?
+
+      # Bail out after 3 attempts
+      attempts += 1
+      raise 'Too many failed attempts to start proxy server' if attempts == 3
+
+      # Failed to start - sleep before retrying
+      $logger.info 'Retrying in 5 seconds'
+      sleep 5
+    end
+  end
+
+  # Stops the WEBrick proxy thread if it's running
+  def stop
+    @thread&.kill if @thread&.alive?
+    @thread = nil
+  end
+end

--- a/lib/features/support/proxy.rb
+++ b/lib/features/support/proxy.rb
@@ -34,6 +34,7 @@ class Proxy
 
   # Starts the WEBrick proxy in a separate thread
   def start(protocol, authenticated = false)
+    stop if running?
     @hosts.clear
 
     attempts = 0
@@ -51,8 +52,9 @@ class Proxy
 
         # Setup protocol
         if protocol == :Http
-          puts 'Starting HTTP proxy'
+          $logger.info 'Starting HTTP proxy'
         elsif protocol == :Https
+          $logger.info 'Starting HTTPS proxy'
           cert_name = [
             %w[CN localhost]
           ]

--- a/test/fixtures/proxy/Dockerfile
+++ b/test/fixtures/proxy/Dockerfile
@@ -1,0 +1,7 @@
+ARG BRANCH_NAME
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+
+RUN apk add bash curl
+
+COPY . /app
+WORKDIR /app

--- a/test/fixtures/proxy/Gemfile
+++ b/test/fixtures/proxy/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'bugsnag-maze-runner', path: '../../..'

--- a/test/fixtures/proxy/features/fixtures/payload.json
+++ b/test/fixtures/proxy/features/fixtures/payload.json
@@ -1,0 +1,16 @@
+{
+    "animals": [
+        "bear",
+        "fox",
+        "goat",
+        "parrot"
+    ],
+    "fruits": {
+        "apple": {
+            "color": "red"
+        },
+        "cherry": {
+            "color": "black"
+        }
+    }
+}

--- a/test/fixtures/proxy/features/proxy.feature
+++ b/test/fixtures/proxy/features/proxy.feature
@@ -6,3 +6,10 @@ Feature: Using the different varieties of proxy server
         Then I wait to receive a request
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
         And the proxy handled a request for "localhost:9339"
+
+    Scenario: Testing basic HTTPS proxy
+        When I start an https proxy
+        And I run the script "features/scripts/https.sh"
+        Then I wait to receive a request
+        And the payload body matches the JSON fixture in "features/fixtures/payload.json"
+        And the proxy handled a request for "localhost:9339"

--- a/test/fixtures/proxy/features/proxy.feature
+++ b/test/fixtures/proxy/features/proxy.feature
@@ -1,15 +1,34 @@
 Feature: Using the different varieties of proxy server
 
-    Scenario: Testing basic HTTP proxy
+    Scenario: Basic HTTP proxy
         When I start an http proxy
         And I run the script "features/scripts/http.sh"
         Then I wait to receive a request
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
-        And the proxy handled a request for "localhost:9339"
+        And the proxy handles a request for "localhost:9339"
 
-    Scenario: Testing basic HTTPS proxy
+    Scenario: Authenticated HTTP proxy with creds
+        When I start an authenticated http proxy
+        And I run the script "features/scripts/http_with_creds.sh"
+        Then I wait to receive a request
+        And the payload body matches the JSON fixture in "features/fixtures/payload.json"
+        And the proxy handles a request for "localhost:9339"
+
+    Scenario: Authenticated HTTP proxy without creds
+        When I start an authenticated http proxy
+        And I run the script "features/scripts/http.sh"
+        Then I wait for 5 seconds
+        And I should receive no requests
+
+    Scenario: Basic HTTPS proxy use
         When I start an https proxy
         And I run the script "features/scripts/https.sh"
         Then I wait to receive a request
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
-        And the proxy handled a request for "localhost:9339"
+        And the proxy handles a request for "localhost:9339"
+
+    Scenario: Authenticated HTTPS proxy without creds
+        When I start an authenticated https proxy
+        And I run the script "features/scripts/https.sh"
+        Then I wait for 5 seconds
+        And I should receive no requests

--- a/test/fixtures/proxy/features/proxy.feature
+++ b/test/fixtures/proxy/features/proxy.feature
@@ -5,14 +5,14 @@ Feature: Using the different varieties of proxy server
         And I run the script "features/scripts/http.sh"
         Then I wait to receive a request
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
-        And the proxy handles a request for "localhost:9339"
+        And the proxy handled a request for "localhost:9339"
 
     Scenario: Authenticated HTTP proxy with creds
         When I start an authenticated http proxy
         And I run the script "features/scripts/http_with_creds.sh"
         Then I wait to receive a request
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
-        And the proxy handles a request for "localhost:9339"
+        And the proxy handled a request for "localhost:9339"
 
     Scenario: Authenticated HTTP proxy without creds
         When I start an authenticated http proxy
@@ -25,14 +25,14 @@ Feature: Using the different varieties of proxy server
         And I run the script "features/scripts/https.sh"
         Then I wait to receive a request
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
-        And the proxy handles a request for "localhost:9339"
+        And the proxy handled a request for "localhost:9339"
 
     Scenario: Authenticated HTTPS proxy with creds
         When I start an authenticated https proxy
         And I run the script "features/scripts/https_with_creds.sh"
         Then I wait to receive a request
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
-        And the proxy handles a request for "localhost:9339"
+        And the proxy handled a request for "localhost:9339"
 
     Scenario: Authenticated HTTPS proxy without creds
         When I start an authenticated https proxy

--- a/test/fixtures/proxy/features/proxy.feature
+++ b/test/fixtures/proxy/features/proxy.feature
@@ -1,0 +1,8 @@
+Feature: Using the different varieties of proxy server
+
+    Scenario: Testing basic HTTP proxy
+        When I start an http proxy
+        And I run the script "features/scripts/http.sh"
+        Then I wait to receive a request
+        And the payload body matches the JSON fixture in "features/fixtures/payload.json"
+        And the proxy handled a request for "localhost:9339"

--- a/test/fixtures/proxy/features/proxy.feature
+++ b/test/fixtures/proxy/features/proxy.feature
@@ -27,6 +27,13 @@ Feature: Using the different varieties of proxy server
         And the payload body matches the JSON fixture in "features/fixtures/payload.json"
         And the proxy handles a request for "localhost:9339"
 
+    Scenario: Authenticated HTTPS proxy with creds
+        When I start an authenticated https proxy
+        And I run the script "features/scripts/https_with_creds.sh"
+        Then I wait to receive a request
+        And the payload body matches the JSON fixture in "features/fixtures/payload.json"
+        And the proxy handles a request for "localhost:9339"
+
     Scenario: Authenticated HTTPS proxy without creds
         When I start an authenticated https proxy
         And I run the script "features/scripts/https.sh"

--- a/test/fixtures/proxy/features/scripts/http.sh
+++ b/test/fixtures/proxy/features/scripts/http.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -x localhost:9000 http://localhost:9339

--- a/test/fixtures/proxy/features/scripts/http.sh
+++ b/test/fixtures/proxy/features/scripts/http.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -x localhost:9000 http://localhost:9339
+curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -x http://localhost:9000 http://localhost:9339

--- a/test/fixtures/proxy/features/scripts/http_with_creds.sh
+++ b/test/fixtures/proxy/features/scripts/http_with_creds.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -U user:password -x http://localhost:9000 http://localhost:9339

--- a/test/fixtures/proxy/features/scripts/https.sh
+++ b/test/fixtures/proxy/features/scripts/https.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -x https://localhost:9000 --proxy-insecure http://localhost:9339

--- a/test/fixtures/proxy/features/scripts/https_with_creds.sh
+++ b/test/fixtures/proxy/features/scripts/https_with_creds.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -X POST -d @features/fixtures/payload.json -H "Content-Type: application/json" -U user:password -x https://localhost:9000 --proxy-insecure http://localhost:9339


### PR DESCRIPTION
## Goal

Provides HTTP/S proxy functionality with and without basic authentication.

## Design

Having determined that the Ruby standard library provides support for HTTP/S proxies, it was the natural choice for implementing the functionality.  The proxy class is more than large enough to warrant its own file, although I have also deliberately avoided touching the existing `Server` class in the knowledge that it is being refactored as part of separating the Notify and Session endpoints.

## Changeset

New class for running a proxy on demand, supporting Cucumber steps and test scenarios.

## Tests

Tested using a new set of "proxy" Cucumber scenarios, each driven my a simple `curl` command.
