### PR TITLE
Fix logging of requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
-# 2.5.0 - 2020/09/10
+# 2.5.0 - 2020/09/11
 
 ## Enhancements
 
-- Fix broken Build API step syntax
-  [#125](https://github.com/bugsnag/maze-runner/pull/125)
 - Range of additional Android 6, 8.0 and 8.1 device options provided, 
   together with Android 11 and iOS 14.
   [#127](https://github.com/bugsnag/maze-runner/pull/127)
 - Ability to run an HTTP/S proxy added
   [#128](https://github.com/bugsnag/maze-runner/pull/128)
+
+# Fixes
+
+- Fix broken Build API step syntax
+  [#125](https://github.com/bugsnag/maze-runner/pull/125)
+- Fix logging of non-JSON requests
+  [#XYZ](https://github.com/bugsnag/maze-runner/pull/xyz)
+
 
 # 2.4.0 - 2020/09/01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Fix broken Build API step syntax
   [#125](https://github.com/bugsnag/maze-runner/pull/125)
 - Fix logging of non-JSON requests
-  [#XYZ](https://github.com/bugsnag/maze-runner/pull/xyz)
+  [#129](https://github.com/bugsnag/maze-runner/pull/129)
 
 
 # 2.4.0 - 2020/09/01

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -38,7 +38,7 @@ After do |scenario|
       $logger.info 'The following requests were received:'
       Server.stored_requests.each.with_index(1) do |request, number|
         $logger.info "Request #{number}:"
-        LogUtil.log(Logger::Severity::INFO, request)
+        LogUtil.log_hash(Logger::Severity::INFO, request)
       end
     end
   end

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -37,8 +37,8 @@ After do |scenario|
     else
       $logger.info 'The following requests were received:'
       Server.stored_requests.each.with_index(1) do |request, number|
-        json = JSON.pretty_generate request
-        $logger.info "Request #{number}: \n#{json}"
+        $logger.info "Request #{number}:"
+        LogUtil.log(Logger::Severity::INFO, request)
       end
     end
   end

--- a/lib/features/support/logger.rb
+++ b/lib/features/support/logger.rb
@@ -18,3 +18,44 @@ class MazeLogger < Logger
 end
 
 $logger = MazeLogger.instance
+
+# A collection of logging utilities
+class LogUtil
+  class << self
+    # Logs requests and other data, accounting for things file upload requests that are too big to log meaningfully.
+    #
+    # @param severity [Integer] A Logger::Severity
+    # @param data [Hash] The data to log (currently needs to be a Hash)
+    def log(severity, data)
+      return unless data.is_a? Hash
+
+      # Try to pretty print as JSON, if not too big
+      begin
+        json = JSON.pretty_generate data
+        if json.length < 128 * 1024
+          $logger.add severity, json
+        else
+          log_hash_by_field severity, data
+        end
+      rescue Encoding::UndefinedConversionError
+        log_hash_by_field severity, data
+      end
+    end
+
+    # Logs a hash field by field,
+    #
+    # @param severity [Integer] A Logger::Severity
+    # @param hash [Hash] The Hash
+    def log_hash_by_field(severity, hash)
+      hash.keys.each do |key|
+        value = hash[key].to_s
+        if value.length < 512
+          $logger.add severity, "  #{key}: #{value}"
+        else
+          $logger.add severity, "  #{key} (length): #{value.length}"
+          $logger.add severity, "  #{key} (start): #{value[0, 512]}"
+        end
+      end
+    end
+  end
+end

--- a/lib/features/support/logger.rb
+++ b/lib/features/support/logger.rb
@@ -22,11 +22,11 @@ $logger = MazeLogger.instance
 # A collection of logging utilities
 class LogUtil
   class << self
-    # Logs requests and other data, accounting for things file upload requests that are too big to log meaningfully.
+    # Logs Hash-based data, accounting for things like file upload requests that are too big to log meaningfully.
     #
-    # @param severity [Integer] A Logger::Severity
+    # @param severity [Integer] A constant from Logger::Severity
     # @param data [Hash] The data to log (currently needs to be a Hash)
-    def log(severity, data)
+    def log_hash(severity, data)
       return unless data.is_a? Hash
 
       # Try to pretty print as JSON, if not too big
@@ -49,11 +49,11 @@ class LogUtil
     def log_hash_by_field(severity, hash)
       hash.keys.each do |key|
         value = hash[key].to_s
-        if value.length < 512
+        if value.length < 1024
           $logger.add severity, "  #{key}: #{value}"
         else
           $logger.add severity, "  #{key} (length): #{value.length}"
-          $logger.add severity, "  #{key} (start): #{value[0, 512]}"
+          $logger.add severity, "  #{key} (start): #{value[0, 1024]}"
         end
       end
     end

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -27,7 +27,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
       # "content-type" is assumed to be JSON (which mimicks the behaviour of
       # the actual API). This supports browsers that can't set this header for
       # cross-domain requests (IE8/9)
-      Server.stored_requests << { body: JSON.load(request.body),
+      Server.stored_requests << { body: JSON.parse(request.body),
                                   request: request }
     end
     response.header['Access-Control-Allow-Origin'] = '*'
@@ -62,17 +62,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
       boundary = WEBrick::HTTPUtils.dequote(Regexp.last_match(1))
       body = WEBrick::HTTPUtils.parse_form_data(request.body, boundary)
       $logger.debug 'BODY:'
-      body.keys
-      # Even small file uploads could be large enough to make logging
-      # pointless, so limit what we try to log.
-      body.keys.each do |key|
-        if body[key].length < 512
-          $logger.debug "  #{key}: #{body[key]}"
-        else
-          $logger.debug "  #{key} (length): #{body[key].length}"
-          $logger.debug "  #{key} (start): #{body[key][0, 512]}"
-        end
-      end
+      LogUtil.log(Logger::Severity::DEBUG, body)
     else
       $logger.debug "BODY: #{JSON.pretty_generate(JSON.parse(request.body))}"
     end

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -19,21 +19,21 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
   def do_POST(request, response)
     log_request(request)
     case request['Content-Type']
-    when %r{^multipart/form-data; boundary=([^;]+)}
-      boundary = WEBrick::HTTPUtils.dequote(Regexp.last_match(1))
+    when /^multipart\/form-data; boundary=([^;]+)/
+      boundary = WEBrick::HTTPUtils::dequote($1)
       body = WEBrick::HTTPUtils.parse_form_data(request.body(), boundary)
       Server.stored_requests << { body: body, request: request }
     else
-      # "content-type" is assumed to be JSON (which mimics the behaviour of
+      # "content-type" is assumed to be JSON (which mimicks the behaviour of
       # the actual API). This supports browsers that can't set this header for
       # cross-domain requests (IE8/9)
-      Server.stored_requests << { body: JSON.parse(request.body),
+      Server.stored_requests << { body: JSON.load(request.body()),
                                   request: request }
     end
     response.header['Access-Control-Allow-Origin'] = '*'
     response.status = 200
   end
-
+  
   # Logs and returns a set of valid headers for this servlet.
   #
   # @param request [HTTPRequest] The incoming GET request

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -24,7 +24,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
       body = WEBrick::HTTPUtils.parse_form_data(request.body, boundary)
       Server.stored_requests << { body: body, request: request }
     else
-      # "content-type" is assumed to be JSON (which mimicks the behaviour of
+      # "content-type" is assumed to be JSON (which mimics the behaviour of
       # the actual API). This supports browsers that can't set this header for
       # cross-domain requests (IE8/9)
       Server.stored_requests << { body: JSON.parse(request.body),
@@ -62,7 +62,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
       boundary = WEBrick::HTTPUtils.dequote(Regexp.last_match(1))
       body = WEBrick::HTTPUtils.parse_form_data(request.body, boundary)
       $logger.debug 'BODY:'
-      LogUtil.log(Logger::Severity::DEBUG, body)
+      LogUtil.log_hash(Logger::Severity::DEBUG, body)
     else
       $logger.debug "BODY: #{JSON.pretty_generate(JSON.parse(request.body))}"
     end

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -17,7 +17,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
   # @param request [HTTPRequest] The incoming GET request
   # @param response [HTTPResponse] The response to return
   def do_POST(request, response)
-    log_request(request)
+    # log_request(request)
     case request['Content-Type']
     when /^multipart\/form-data; boundary=([^;]+)/
       boundary = WEBrick::HTTPUtils::dequote($1)
@@ -33,7 +33,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
     response.header['Access-Control-Allow-Origin'] = '*'
     response.status = 200
   end
-  
+
   # Logs and returns a set of valid headers for this servlet.
   #
   # @param request [HTTPRequest] The incoming GET request


### PR DESCRIPTION
## Goal

Centralise logging of requests, allowing non-JSON, non-ASCII or just large requests to be handled without error and more meaningfully.  For example, file upload requests can easily swamp the log output and this approach allow us to put some limits and truncation in place.

## Design

The `LogUtil` class added can be made as sophisticated as we want, but for now the intention is to make logging something that is useful and, in particular, does not cause errors during the execution of a test.

## Changeset

Request logging routines refactored.

## Tests

I've tested the branch using a currently failing Android Gradle Plugin test with DEBUG logging on.  This exercises both the logging of requests as they are received and at the end of failing scenario when Maze Runner outputs the requests that it received.  An extra unit test may be desirable, however, to back up the newly added class.
