### PR TITLE
Separate appium sessions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,13 +50,13 @@ steps:
         run: proxy-tests
     command: 'bundle exec bugsnag-maze-runner'
 
-  - label: 'Browserstack app-automate test - Android 6 (separate Appium sessions)'
+  - label: 'Browserstack app-automate test - Android 6'
     env:
       DEVICE_TYPE: ANDROID_6_0
     plugins:
       docker-compose#v3.3.0:
         run: browserstack-app-automate
-    command: 'bundle exec bugsnag-maze-runner --separate-sessions'
+    command: 'bundle exec bugsnag-maze-runner'
     concurrency: 10
     concurrency_group: 'browserstack-app'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,23 +50,23 @@ steps:
         run: proxy-tests
     command: 'bundle exec bugsnag-maze-runner'
 
-  - label: 'Browserstack app-automate test - Android 6'
+  - label: 'Browserstack app-automate test - Android 6 (separate Appium sessions)'
     env:
       DEVICE_TYPE: ANDROID_6_0
     plugins:
       docker-compose#v3.3.0:
         run: browserstack-app-automate
-    command: 'bundle exec bugsnag-maze-runner'
+    command: 'bundle exec bugsnag-maze-runner --separate-sessions'
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: 'Browserstack app-automate test - Android 7.1'
+  - label: 'Browserstack app-automate test - Android 7.1 (separate Appium sessions)'
     env:
       DEVICE_TYPE: ANDROID_7_1
     plugins:
       docker-compose#v3.3.0:
         run: browserstack-app-automate
-    command: 'bundle exec bugsnag-maze-runner'
+    command: 'bundle exec bugsnag-maze-runner --separate-sessions'
     concurrency: 10
     concurrency_group: 'browserstack-app'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -90,23 +90,23 @@ steps:
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: 'Browserstack app-automate test - Android 10'
+  - label: 'Browserstack app-automate test - Android 10 (separate Appium sessions)'
     env:
       DEVICE_TYPE: ANDROID_10_0
     plugins:
       docker-compose#v3.3.0:
         run: browserstack-app-automate
-    command: 'bundle exec bugsnag-maze-runner'
+    command: 'bundle exec bugsnag-maze-runner --separate-sessions'
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: 'Browserstack app-automate test - Android 11'
+  - label: 'Browserstack app-automate test - Android 11 (separate Appium sessions)'
     env:
       DEVICE_TYPE: ANDROID_11_0
     plugins:
       docker-compose#v3.3.0:
         run: browserstack-app-automate
-    command: 'bundle exec bugsnag-maze-runner'
+    command: 'bundle exec bugsnag-maze-runner --separate-sessions'
     concurrency: 10
     concurrency_group: 'browserstack-app'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Enhancements
 
 - Added option to start a new Appium session for every scenario.
-  [#XYZ](https://github.com/bugsnag/maze-runner/pull/XYZ)
+  [#133](https://github.com/bugsnag/maze-runner/pull/133)
 
 # 2.6.0 - 2020/09/14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.7.0 - TBD
+
+## Enhancements
+
+- Added option to start a new Appium session for every scenario.
+  [#XYZ](https://github.com/bugsnag/maze-runner/pull/XYZ)
+
 # 2.6.0 - 2020/09/14
 
 ## Enhancements

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,42 @@
+## Upgrading Guide
+
+### Upgrading from 2.6.0 to 2.7.0
+
+#### Separate Appium sessions option
+
+If using the new `--separate-sessions` option to have each Cucumber scenario run in its own Appium session, you may
+need to review your use of the Appium `$driver` variable.  For example, an `env.rb` file may typically contain some code
+to reset the app between scenarios and start/stop the driver at the start and end of the whole run:
+
+```ruby
+AfterConfiguration do |config|
+  AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
+  $driver.start_driver
+end
+
+After do |scenario|
+  $driver.reset
+end
+
+at_exit do
+  $driver.driver_quit
+end
+```
+
+When using the `--separate-sessions` option, Maze Runner with start and stop the driver for you, so the above should be
+modified to:
+
+```ruby
+AfterConfiguration do |config|
+  AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
+  $driver.start_driver unless MazeRunner.configuration.appium_session_isolation
+end
+
+After do |scenario|
+  $driver.reset unless MazeRunner.configuration.appium_session_isolation
+end
+
+at_exit do
+  $driver.driver_quit unless MazeRunner.configuration.appium_session_isolation
+end
+```

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -3,10 +3,12 @@
 
 require 'cucumber/cli/main'
 require 'optimist'
+require_relative '../lib/features/support/maze_runner'
 require_relative '../lib/version'
 
 # Encapsulates the MazeRunner entry point
-class MazeRunner
+class MazeRunnerEntry
+
   def initialize
     @parser = Optimist::Parser.new do
       text 'Maze Runner extends the functionality of Cucumber, ' \
@@ -19,6 +21,7 @@ class MazeRunner
       opt :init, 'Initialises a new Maze Runner project'
 
       opt :version, 'Display Maze Runner and Cucumber versions'
+      opt 'separate-sessions', 'Start a new Appium session for each scenario', short: :none
       version "Maze Runner v#{BugsnagMazeRunner::VERSION} " \
               "(Cucumber v#{Cucumber::VERSION.strip})"
       text ''
@@ -62,6 +65,9 @@ class MazeRunner
     options = @parser.parse args
 
     init if options[:init]
+    MazeRunner.configuration.appium_session_isolation = true if options['separate-sessions']
+
+    puts MazeRunner.configuration.appium_session_isolation
 
     # Call down to Cucumber
     add_maze_runner_options
@@ -78,4 +84,4 @@ class MazeRunner
   end
 end
 
-MazeRunner.new.start(ARGV)
+MazeRunnerEntry.new.start(ARGV)

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -9,6 +9,8 @@ require_relative '../lib/version'
 # Encapsulates the MazeRunner entry point
 class MazeRunnerEntry
 
+  OPTION_SEPARATE_SESSIONS = 'separate-sessions'
+
   def initialize
     @parser = Optimist::Parser.new do
       text 'Maze Runner extends the functionality of Cucumber, ' \
@@ -21,13 +23,14 @@ class MazeRunnerEntry
       opt :init, 'Initialises a new Maze Runner project'
 
       opt :version, 'Display Maze Runner and Cucumber versions'
-      opt 'separate-sessions', 'Start a new Appium session for each scenario', short: :none
+      opt OPTION_SEPARATE_SESSIONS, 'Start a new Appium session for each scenario', short: :none
       version "Maze Runner v#{BugsnagMazeRunner::VERSION} " \
               "(Cucumber v#{Cucumber::VERSION.strip})"
       text ''
       text 'The Cucumber help follows:'
       text ''
     end
+    # Allow for options destined for Cucumber
     @parser.ignore_invalid_options = true
   end
 
@@ -36,7 +39,15 @@ class MazeRunnerEntry
     exit 0
   end
 
-  def add_maze_runner_options
+  # Removes Maze Runner specific args from the array, as these will cause Cucumber to error.
+  def remove_maze_runner_args
+    [
+      OPTION_SEPARATE_SESSIONS
+    ].each { |arg| @args.delete "--#{arg}" }
+  end
+
+  # Adds arguments to the Cucumber
+  def add_cucumber_args
     @args << 'features' if @args.empty?
 
     # Add strict mode unless any no/strict option is given,
@@ -65,13 +76,13 @@ class MazeRunnerEntry
     options = @parser.parse args
 
     init if options[:init]
-    MazeRunner.configuration.appium_session_isolation = true if options['separate-sessions']
+    MazeRunner.configuration.appium_session_isolation = true if options[OPTION_SEPARATE_SESSIONS]
 
     puts MazeRunner.configuration.appium_session_isolation
 
-    # Call down to Cucumber
-    add_maze_runner_options
-
+    # Adjust CL options before calling down to Cucumber
+    remove_maze_runner_args
+    add_cucumber_args
     Cucumber::Cli::Main.new(@args).execute!
 
   rescue Optimist::HelpNeeded

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -13,10 +13,14 @@ Before do |scenario|
   Runner.environment.clear
   Server.stored_requests.clear
   Store.values.clear
+
+  $driver.start_driver if MazeRunner.configuration.appium_session_isolation
 end
 
 # After each scenario
 After do |scenario|
+
+  $driver.driver_quit if MazeRunner.configuration.appium_session_isolation
 
   # This is here to stop sessions from one test hitting another.
   # However this does mean that tests take longer.

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# MazeRunner configuration
+class Configuration
+
+  def initialize
+    @appium_session_isolation = false
+  end
+
+  # Whether each scenario should have its own Appium session
+  attr_accessor :appium_session_isolation
+end

--- a/lib/features/support/maze_runner.rb
+++ b/lib/features/support/maze_runner.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative './configuration'
+
+# Glues the various parts of MazeRunner together that need to be accessed globally,
+# providing an alternative to the proliferation of global variables or singletons.
+class MazeRunner
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
+end

--- a/test/fixtures/browserstack-app/features/support/env.rb
+++ b/test/fixtures/browserstack-app/features/support/env.rb
@@ -15,9 +15,9 @@ AfterConfiguration do |config|
 end
 
 After do
-  $driver.reset_with_timeout
+  $driver.reset_with_timeout unless MazeRunner.configuration.appium_session_isolation
 end
 
 at_exit do
-  $driver.driver_quit
+  $driver.driver_quit unless MazeRunner.configuration.appium_session_isolation
 end

--- a/test/fixtures/browserstack-app/features/support/env.rb
+++ b/test/fixtures/browserstack-app/features/support/env.rb
@@ -5,13 +5,13 @@ bs_local_id = ENV['BROWSER_STACK_LOCAL_IDENTIFIER'] || 'maze_browser_stack_test_
 bs_device = ENV['DEVICE_TYPE']
 app_location = 'app/build/outputs/apk/release/app-release.apk'
 
-$api_key = "12312312312312312312312312312312"
+$api_key = '12312312312312312312312312312312'
 
-ENV["BUGSNAG_API_KEY"] = $api_key
+ENV['BUGSNAG_API_KEY'] = $api_key
 
 AfterConfiguration do |config|
   AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
-  $driver.start_driver
+  $driver.start_driver unless MazeRunner.configuration.appium_session_isolation
 end
 
 After do


### PR DESCRIPTION
## Goal

Adds a new command line option that allows each Cucumber scenario to be run in its own Appium session.

## Design

This provides one option for dealing with underlying stability issues in Appium based test infrastructure.  It's not mandated and disabled by default, as there are potential drawbacks such as additional length of tests (which seems to vary depending on the device/OS version).

## Changeset

New command line option and associated handled.
New `Configuration` class to store options selected for later access.
New `MazeRunner` "binder" class, providing a central point for accessing features of MazeRunner - over time potentially removing the use of slightly messy global variables.

## Tests

I've enabled the option on a few of the pipeline steps, so that we have some coverage of it both on and off.