### PR TITLE
Resilient Appium driver

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,11 +32,11 @@ steps:
 
   - wait
 
-  - label: 'Unit tests'
-    plugins:
-      docker-compose#v3.3.0:
-        run: ci
-    command: 'bundle exec rake'
+#  - label: 'Unit tests'
+#    plugins:
+#      docker-compose#v3.3.0:
+#        run: ci
+#    command: 'bundle exec rake'
 
   - label: 'Comparison tests'
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,11 +32,11 @@ steps:
 
   - wait
 
-#  - label: 'Unit tests'
-#    plugins:
-#      docker-compose#v3.3.0:
-#        run: ci
-#    command: 'bundle exec rake'
+  - label: 'Unit tests'
+    plugins:
+      docker-compose#v3.3.0:
+        run: ci
+    command: 'bundle exec rake'
 
   - label: 'Comparison tests'
     plugins:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Enhancements
 
+- Addition of ResilientAppiumDriver to catch and restart broken Appium sessions.
+  [#134](https://github.com/bugsnag/maze-runner/pull/134)
 - Added option to start a new Appium session for every scenario.
   [#133](https://github.com/bugsnag/maze-runner/pull/133)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,19 +24,22 @@ end
 ```
 
 When using the `--separate-sessions` option, Maze Runner with start and stop the driver for you, so the above should be
-modified to:
+modified to the following.
+
+`MazeRunner.driver` is also preferred to using `$driver` as it wraps the raw driver in a facade with restart-on-error
+functionality.
 
 ```ruby
 AfterConfiguration do |config|
   AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
-  $driver.start_driver unless MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.start_driver unless MazeRunner.configuration.appium_session_isolation
 end
 
 After do |scenario|
-  $driver.reset unless MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.reset unless MazeRunner.configuration.appium_session_isolation
 end
 
 at_exit do
-  $driver.driver_quit unless MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.driver_quit unless MazeRunner.configuration.appium_session_isolation
 end
 ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,32 @@
 
 ### Upgrading from 2.6.0 to 2.7.0
 
+#### Resilient Appium Driver
+
+The new `ResilientAppiumDriver` class can be used to handle flaky Appium sessions.  It simply wraps each call to an
+underlying `AppAutomateDriver` instance, restarting the Appium session in response to any of the following errors:
+- Selenium::WebDriver::Error::UnknownError
+- Selenium::WebDriver::Error::WebDriverError
+
+To use, simply instantiate in place of `AppAutomateDriver`.  It's also preferable to access the driver via 
+`MazeRunner.driver` rather than the global `$driver` variable:
+
+```ruby
+AfterConfiguration do |config|
+  AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
+  $driver.start_driver
+end
+```
+
+Becomes:
+
+```ruby
+AfterConfiguration do |config|
+  ResilientAppiumDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
+  MazeRunner.driver.start_driver
+end
+```
+
 #### Separate Appium sessions option
 
 If using the new `--separate-sessions` option to have each Cucumber scenario run in its own Appium session, you may
@@ -23,11 +49,8 @@ at_exit do
 end
 ```
 
-When using the `--separate-sessions` option, Maze Runner with start and stop the driver for you, so the above should be
+When using the `--separate-sessions` option, Maze Runner will start and stop the driver for you, so the above should be
 modified to the following.
-
-`MazeRunner.driver` is also preferred to using `$driver` as it wraps the raw driver in a facade with restart-on-error
-functionality.
 
 ```ruby
 AfterConfiguration do |config|

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -14,13 +14,13 @@ Before do |scenario|
   Server.stored_requests.clear
   Store.values.clear
 
-  $driver.start_driver if MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.start_driver if MazeRunner.configuration.appium_session_isolation
 end
 
 # After each scenario
 After do |scenario|
 
-  $driver.driver_quit if MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.driver_quit if MazeRunner.configuration.appium_session_isolation
 
   # This is here to stop sessions from one test hitting another.
   # However this does mean that tests take longer.

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -4,7 +4,7 @@
 # Requires a running Appium driver
 #
 # @step_input element_id [String] The locator id
-Given("the element {string} is present") do |element_id|
+Given('the element {string} is present') do |element_id|
   present = MazeRunner.driver.wait_for_element(element_id)
   assert(present, "The element #{element_id} could not be found")
 end
@@ -14,8 +14,8 @@ end
 #
 # @step_input element_id [String] The locator id
 # @step_input timeout [Int] The number of seconds to wait before timing out
-Given("the element {string} is present within {int} seconds") do |element_id, timeout|
-  present = $driver.wait_for_element(element_id, timeout)
+Given('the element {string} is present within {int} seconds') do |element_id, timeout|
+  present = MazeRunner.driver.wait_for_element(element_id, timeout)
   assert(present, "The element #{element_id} could not be found")
 end
 
@@ -23,24 +23,24 @@ end
 # Requires a running Appium driver
 #
 # @step_input element_id [String] The locator id
-When("I click the element {string}") do |element_id|
-  $driver.click_element(element_id)
+When('I click the element {string}') do |element_id|
+  MazeRunner.driver.click_element(element_id)
 end
 
 # Sends the app to the background for a number of seconds
 # Requires a running Appium driver
 #
 # @step_input timeout [Integer] The amount of time the app is in the background in seconds
-When("I send the app to the background for {int} seconds") do |timeout|
-  $driver.background_app(timeout)
+When('I send the app to the background for {int} seconds') do |timeout|
+  MazeRunner.driver.background_app(timeout)
 end
 
 # Clears a given element
 # Requires a running Appium driver
 #
 # @step_input element_id [String] The locator id
-When("I clear the element {string}") do |element_id|
-  $driver.clear(element_id, keys)
+When('I clear the element {string}') do |element_id|
+  MazeRunner.driver.clear(element_id, keys)
 end
 
 # Sends keys to a given element
@@ -48,8 +48,8 @@ end
 #
 # @step_input keys [String] The keys to send to the element
 # @step_input element_id [String] The locator id
-When("I send the keys {string} to the element {string}") do |keys, element_id|
-  $driver.send_keys_to_element(element_id, keys)
+When('I send the keys {string} to the element {string}') do |keys, element_id|
+  MazeRunner.driver.send_keys_to_element(element_id, keys)
 end
 
 # Tests that the given payload value is correct for the target BrowserStack platform.
@@ -64,7 +64,7 @@ end
 #
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then("the payload field {string} equals the platform-dependent string:") do |field_path, platform_values|
+Then('the payload field {string} equals the platform-dependent string:') do |field_path, platform_values|
   testStringPlatformValues(field_path, platform_values)
 end
 
@@ -72,7 +72,7 @@ end
 #
 # @step_input field_path [String] The field to test, prepended with "events.0"
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then("the event {string} equals the platform-dependent string:") do |field_path, platform_values|
+Then('the event {string} equals the platform-dependent string:') do |field_path, platform_values|
   testStringPlatformValues("events.0.#{field_path}", platform_values)
 end
 
@@ -88,7 +88,7 @@ end
 #
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then("the payload field {string} equals the platform-dependent numeric:") do |field_path, platform_values|
+Then('the payload field {string} equals the platform-dependent numeric:') do |field_path, platform_values|
   testNumericPlatformValues(field_path, platform_values)
 end
 
@@ -96,7 +96,7 @@ end
 #
 # @step_input field_path [String] The field to test, prepended with "events.0"
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then("the event {string} equals the platform-dependent numeric:") do |field_path, platform_values|
+Then('the event {string} equals the platform-dependent numeric:') do |field_path, platform_values|
   testNumericPlatformValues("events.0.#{field_path}", platform_values)
 end
 
@@ -112,7 +112,7 @@ end
 #
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then("the payload field {string} equals the platform-dependent boolean:") do |field_path, platform_values|
+Then('the payload field {string} equals the platform-dependent boolean:') do |field_path, platform_values|
   testBooleanPlatformValues(field_path, platform_values)
 end
 
@@ -120,7 +120,7 @@ end
 #
 # @step_input field_path [String] The field to test, prepended with "events.0"
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then("the event {string} equals the platform-dependent boolean:") do |field_path, platform_values|
+Then('the event {string} equals the platform-dependent boolean:') do |field_path, platform_values|
   testBooleanPlatformValues("events.0.#{field_path}", platform_values)
 end
 
@@ -129,22 +129,24 @@ end
 #
 # @step_input keys [String] The keys to send to the element
 # @step_input element_id [String] The locator id
-When("I clear and send the keys {string} to the element {string}") do |keys, element_id|
-  $driver.clear_and_send_keys_to_element(element_id, keys)
+When('I clear and send the keys {string} to the element {string}') do |keys, element_id|
+  MazeRunner.driver.clear_and_send_keys_to_element(element_id, keys)
 end
 
 def getExpectedValueForPlatform(platform_values)
-  if !defined?($driver) || $driver.nil?
-    fail("This step should only be used if the AppAutomateDriver is present")
+  if !defined?($driver) || MazeRunner.driver.nil?
+    raise('This step should only be used if the AppAutomateDriver is present')
   end
-  os = $driver.capabilities['os']
+
+  os = MazeRunner.driver.capabilities['os']
   expected_value = Hash[platform_values.raw][os]
-  fail("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
+  raise("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
+
   expected_value
 end
 
 def shouldSkipPlatformCheck(expected_value)
-  expected_value.eql?("@skip")
+  expected_value.eql?('@skip')
 end
 
 def testStringPlatformValues(field_path, platform_values)
@@ -157,17 +159,17 @@ end
 
 def testBooleanPlatformValues(field_path, platform_values)
   expected_value = getExpectedValueForPlatform(platform_values)
-  unless shouldSkipPlatformCheck(expected_value)
-    if expected_value.downcase == 'true'
-      expected_bool = true
-    elsif expected_value.downcase == 'false'
-      expected_bool = false
-    else
-      expected_bool = expected_value
-    end
-    payload_value = read_key_path(Server.current_request[:body], field_path)
-    assert_equal(expected_bool, payload_value)
-  end
+  return if shouldSkipPlatformCheck(expected_value)
+
+  expected_bool = if expected_value.downcase == 'true'
+                    true
+                  elsif expected_value.downcase == 'false'
+                    false
+                  else
+                    expected_value
+                  end
+  payload_value = read_key_path(Server.current_request[:body], field_path)
+  assert_equal(expected_bool, payload_value)
 end
 
 def testNumericPlatformValues(field_path, platform_values)

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -134,9 +134,7 @@ When('I clear and send the keys {string} to the element {string}') do |keys, ele
 end
 
 def getExpectedValueForPlatform(platform_values)
-  if MazeRunner.driver.nil?
-    raise('This step should only be used if the AppAutomateDriver is present')
-  end
+  raise('This step should only be used if the AppAutomateDriver is present') if MazeRunner.driver.nil?
 
   os = MazeRunner.driver.capabilities['os']
   expected_value = Hash[platform_values.raw][os]
@@ -151,10 +149,10 @@ end
 
 def testStringPlatformValues(field_path, platform_values)
   expected_value = getExpectedValueForPlatform(platform_values)
-  unless shouldSkipPlatformCheck(expected_value)
-    payload_value = read_key_path(Server.current_request[:body], field_path)
-    assert_equal(expected_value, payload_value)
-  end
+  return if shouldSkipPlatformCheck(expected_value)
+
+  payload_value = read_key_path(Server.current_request[:body], field_path)
+  assert_equal(expected_value, payload_value)
 end
 
 def testBooleanPlatformValues(field_path, platform_values)

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -5,7 +5,7 @@
 #
 # @step_input element_id [String] The locator id
 Given("the element {string} is present") do |element_id|
-  present = $driver.wait_for_element(element_id)
+  present = MazeRunner.driver.wait_for_element(element_id)
   assert(present, "The element #{element_id} could not be found")
 end
 

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -134,7 +134,7 @@ When('I clear and send the keys {string} to the element {string}') do |keys, ele
 end
 
 def getExpectedValueForPlatform(platform_values)
-  if !defined?($driver) || MazeRunner.driver.nil?
+  if MazeRunner.driver.nil?
     raise('This step should only be used if the AppAutomateDriver is present')
   end
 

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -59,6 +59,8 @@ class AppAutomateDriver < Appium::Driver
         server_url: "http://#{username}:#{access_key}@hub-cloud.browserstack.com/wd/hub"
       }
     }, true)
+
+    MazeRunner.driver = self
   end
 
   # Starts the BrowserStackLocal tunnel and the Appium driver

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -59,8 +59,6 @@ class AppAutomateDriver < Appium::Driver
         server_url: "http://#{username}:#{access_key}@hub-cloud.browserstack.com/wd/hub"
       }
     }, true)
-
-    MazeRunner.driver = ResilientDriver.new(self)
   end
 
   # Starts the BrowserStackLocal tunnel and the Appium driver

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -3,6 +3,7 @@ require 'open3'
 require 'securerandom'
 require_relative './fast_selenium'
 require_relative './logger'
+require_relative './maze_runner'
 
 # Wraps Appium::Driver to enable control of a BrowserStack app-automate session
 class AppAutomateDriver < Appium::Driver
@@ -28,6 +29,7 @@ class AppAutomateDriver < Appium::Driver
   # @param locator [Symbol] the primary locator strategy Appium should use to find elements
   # @param additional_capabilities [Hash] a hash of additional capabilities to be used in this test run
   def initialize(username, access_key, local_id, target_device, app_location, locator = :id, additional_capabilities = {})
+    MazeRunner.driver = self
     @device_type = target_device
     @element_locator = locator
     @access_key = access_key

--- a/lib/features/support/maze_runner.rb
+++ b/lib/features/support/maze_runner.rb
@@ -6,6 +6,7 @@ require_relative './configuration'
 # providing an alternative to the proliferation of global variables or singletons.
 class MazeRunner
   class << self
+    attr_accessor :driver
     def configuration
       @configuration ||= Configuration.new
     end

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -3,15 +3,20 @@ require_relative './fast_selenium'
 require_relative './logger'
 
 # Handles Appium driver restarts and retries in the case of failure
-class ResilientDriver
+class ResilientDriver < AppAutomateDriver
 
-  def initialize(driver)
-    @driver = driver
-  end
-
-  # Deliberately no error handling here
-  def start_driver
-    @driver.start_driver
+  # Creates the ResilientDriver
+  #
+  # @param username [String] the BrowserStack username
+  # @param access_key [String] the BrowserStack access key
+  # @param local_id [String] the identifier for the BrowserStackLocal tunnel
+  # @param target_device [String] a key from the Devices array selecting which device capabilities to target
+  # @param app_location [String] the location of the test-app to upload
+  # @param locator [Symbol] the primary locator strategy Appium should use to find elements
+  # @param additional_capabilities [Hash] a hash of additional capabilities to be used in this test run
+  def initialize(username, access_key, local_id, target_device, app_location, locator = :id, additional_capabilities = {})
+    super username, access_key, local_id, target_device, app_location, locator, additional_capabilities
+    MazeRunner.driver = self
   end
 
   # Checks for an element, waiting until it is present or the method times out
@@ -20,7 +25,7 @@ class ResilientDriver
   # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
   # @param retry_if_stale [Boolean] enables the method to retry acquiring the element if a StaleObjectException occurs
   def wait_for_element(element_id, timeout = 15, retry_if_stale = true)
-    @driver.wait_for_element element_id, timeout, retry_if_stale
+    super.wait_for_element element_id, timeout, retry_if_stale
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { wait_for_element element_id, timeout, retry_if_stale }
   end
@@ -28,7 +33,7 @@ class ResilientDriver
   # Resets the app
   def reset
     $logger.info 'Resetting app'
-    @driver.reset
+    super.reset
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { reset }
   end
@@ -37,7 +42,7 @@ class ResilientDriver
   #
   # @param element_id [String] the element to click using the @element_locator strategy
   def click_element(element_id)
-    @driver.click_element element_id
+    super.click_element element_id
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { click_element element_id }
   end
@@ -46,7 +51,7 @@ class ResilientDriver
   #
   # @param element_id [String] the element to clear, found using the @element_locator strategy
   def clear_element(element_id)
-    @driver.clear_element element_id
+    super.clear_element element_id
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { clear_element element_id }
   end
@@ -56,7 +61,7 @@ class ResilientDriver
   # @param element_id [String] the element to send text to using the @element_locator strategy
   # @param text [String] the text to send
   def send_keys_to_element(element_id, text)
-    @driver.send_keys_to_element element_id, text
+    super.send_keys_to_element element_id, text
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { send_keys_to_element element_id, text }
   end
@@ -66,7 +71,7 @@ class ResilientDriver
   # @param element_id [String] the element to clear and send text to using the @element_locator strategy
   # @param text [String] the text to send
   def clear_and_send_keys_to_element(element_id, text)
-    @driver.clear_and_send_keys_to_element element_id, text
+    super.clear_and_send_keys_to_element element_id, text
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { clear_and_send_keys_to_element element_id, text }
   end
@@ -75,7 +80,7 @@ class ResilientDriver
   #
   # @param timeout [Number] the amount of time in seconds to wait before resetting
   def reset_with_timeout(timeout=0.1)
-    @driver.reset_with_timeout timeout
+    super.reset_with_timeout timeout
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { reset_with_timeout timeout }
   end
@@ -87,7 +92,7 @@ class ResilientDriver
     # sufficient each time the error occurs.  CI step timeouts are also in place to guard
     # against an infinite loop.
     $logger.warn 'Appium Error occurred - restarting driver.'
-    @driver.restart
+    super.restart
     sleep 5 # Only to avoid a possible tight loop
     yield
   end

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -17,6 +17,7 @@ class ResilientDriver < AppAutomateDriver
   def initialize(username, access_key, local_id, target_device, app_location, locator = :id, additional_capabilities = {})
     MazeRunner.driver = self
     super
+    @@counter = 0
   end
 
   # Checks for an element, waiting until it is present or the method times out
@@ -25,9 +26,13 @@ class ResilientDriver < AppAutomateDriver
   # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
   # @param retry_if_stale [Boolean] enables the method to retry acquiring the element if a StaleObjectException occurs
   def wait_for_element(element_id, timeout = 15, retry_if_stale = true)
-    if rand(5) == 1
-      puts 'Oops - raising'
+    $logger.info 'Oops - raising'
+    @@counter += 1
+    if @@counter % 2 == 1
+      $logger.info 'Oops - raising'
       raise Selenium::WebDriver::Error::UnknownError
+    else
+      $logger.info 'Not raising'
     end
     super
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -16,7 +16,7 @@ class ResilientDriver < AppAutomateDriver
   # @param additional_capabilities [Hash] a hash of additional capabilities to be used in this test run
   def initialize(username, access_key, local_id, target_device, app_location, locator = :id, additional_capabilities = {})
     MazeRunner.driver = self
-    super username, access_key, local_id, target_device, app_location, locator, additional_capabilities
+    super
   end
 
   # Checks for an element, waiting until it is present or the method times out
@@ -25,7 +25,7 @@ class ResilientDriver < AppAutomateDriver
   # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
   # @param retry_if_stale [Boolean] enables the method to retry acquiring the element if a StaleObjectException occurs
   def wait_for_element(element_id, timeout = 15, retry_if_stale = true)
-    super.wait_for_element(element_id, timeout, retry_if_stale)
+    super
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { wait_for_element element_id, timeout, retry_if_stale }
   end
@@ -33,7 +33,7 @@ class ResilientDriver < AppAutomateDriver
   # Resets the app
   def reset
     $logger.info 'Resetting app'
-    super.reset
+    super
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { reset }
   end
@@ -42,7 +42,7 @@ class ResilientDriver < AppAutomateDriver
   #
   # @param element_id [String] the element to click using the @element_locator strategy
   def click_element(element_id)
-    super.click_element(element_id)
+    super
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { click_element element_id }
   end
@@ -51,7 +51,7 @@ class ResilientDriver < AppAutomateDriver
   #
   # @param element_id [String] the element to clear, found using the @element_locator strategy
   def clear_element(element_id)
-    super.clear_element(element_id)
+    super
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { clear_element element_id }
   end
@@ -61,7 +61,7 @@ class ResilientDriver < AppAutomateDriver
   # @param element_id [String] the element to send text to using the @element_locator strategy
   # @param text [String] the text to send
   def send_keys_to_element(element_id, text)
-    super.send_keys_to_element(element_id, text)
+    super
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { send_keys_to_element element_id, text }
   end
@@ -71,7 +71,7 @@ class ResilientDriver < AppAutomateDriver
   # @param element_id [String] the element to clear and send text to using the @element_locator strategy
   # @param text [String] the text to send
   def clear_and_send_keys_to_element(element_id, text)
-    super.clear_and_send_keys_to_element(element_id, text)
+    super
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { clear_and_send_keys_to_element element_id, text }
   end
@@ -80,7 +80,7 @@ class ResilientDriver < AppAutomateDriver
   #
   # @param timeout [Number] the amount of time in seconds to wait before resetting
   def reset_with_timeout(timeout=0.1)
-    super.reset_with_timeout(timeout)
+    super
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { reset_with_timeout timeout }
   end

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -3,9 +3,9 @@ require_relative './fast_selenium'
 require_relative './logger'
 
 # Handles Appium driver restarts and retries in the case of failure
-class ResilientDriver < AppAutomateDriver
+class ResilientAppiumDriver < AppAutomateDriver
 
-  # Creates the ResilientDriver
+  # Creates the ResilientAppiumDriver
   #
   # @param username [String] the BrowserStack username
   # @param access_key [String] the BrowserStack access key

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -3,94 +3,51 @@ require_relative './fast_selenium'
 require_relative './logger'
 
 # Handles Appium driver restarts and retries in the case of failure
-class ResilientAppiumDriver < AppAutomateDriver
-  
-  # Checks for an element, waiting until it is present or the method times out
+class ResilientAppiumDriver
+  # Creates the ResilientAppiumDriver
   #
-  # @param element_id [String] the element to search for using the @element_locator strategy
-  # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
-  # @param retry_if_stale [Boolean] enables the method to retry acquiring the element if a StaleObjectException occurs
-  def wait_for_element(element_id, timeout = 15, retry_if_stale = true)
-    super
-  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
-    recover { wait_for_element element_id, timeout, retry_if_stale }
+  # @param username [String] the BrowserStack username
+  # @param access_key [String] the BrowserStack access key
+  # @param local_id [String] the identifier for the BrowserStackLocal tunnel
+  # @param target_device [String] a key from the Devices array selecting which device capabilities to target
+  # @param app_location [String] the location of the test-app to upload
+  # @param locator [Symbol] the primary locator strategy Appium should use to find elements
+  # @param additional_capabilities [Hash] a hash of additional capabilities to be used in this test run
+  def initialize(username, access_key, local_id, target_device, app_location, locator = :id, additional_capabilities = {})
+    @driver = AppAutomateDriver.new username,
+                                    access_key,
+                                    local_id,
+                                    target_device,
+                                    app_location,
+                                    locator,
+                                    additional_capabilities
   end
 
-  # Resets the app
-  def reset
-    $logger.info 'Resetting app'
-    super
-  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
-    recover { reset }
+  def respond_to_missing?(method_name, include_private = false)
+    @driver.respond_to_missing? method_name
   end
 
-  # Clicks a given element
-  #
-  # @param element_id [String] the element to click using the @element_locator strategy
-  def click_element(element_id)
-    super
-  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
-    recover { click_element element_id }
+  # rubocop: disable MethodMissingSuper
+  def method_missing(method, *args, &block)
+    raise "Method '#{method}' does not exist" unless @driver.respond_to?(method)
+
+    retries = 0
+    until retries >= 5
+      begin
+        @driver.send(method, *args, &block)
+        return
+      rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError => error
+        retries += 1
+        recover
+      end
+    end
+
+    # Re-raise the last error, although it might be better to re-raise the
+    # first error instead.  Review based on whther we ever hit this.
+    raise error unless error.nil?
   end
 
-  # Clears a given element
-  #
-  # @param element_id [String] the element to clear, found using the @element_locator strategy
-  def clear_element(element_id)
-    super
-  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
-    recover { clear_element element_id }
-  end
-
-  # Sends keys to a given element
-  #
-  # @param element_id [String] the element to send text to using the @element_locator strategy
-  # @param text [String] the text to send
-  def send_keys_to_element(element_id, text)
-    super
-  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
-    recover { send_keys_to_element element_id, text }
-  end
-
-  # Sends keys to a given element, clearing it first
-  #
-  # @param element_id [String] the element to clear and send text to using the @element_locator strategy
-  # @param text [String] the text to send
-  def clear_and_send_keys_to_element(element_id, text)
-    super
-  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
-    recover { clear_and_send_keys_to_element element_id, text }
-  end
-
-  # Reset the currently running application after a given timeout
-  #
-  # @param timeout [Number] the amount of time in seconds to wait before resetting
-  def reset_with_timeout(timeout=0.1)
-    super
-  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
-    recover { reset_with_timeout timeout }
-  end
-
-  # Wraps @see Appium::Device#background_app
-  def background_app(timeout)
-    super
-  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
-    recover { background_app timeout }
-  end
-
-  # Wraps @see Appium::Device#close_app
-  def close_app
-    super
-  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
-    recover { close_app }
-  end
-
-  # Wraps @see Appium::Device#launch_app
-  def launch_app
-    super
-  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
-    recover { launch_app }
-  end
+  private
 
   # Restarts the underlying driver and calls the block given.
   def recover

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -25,7 +25,7 @@ class ResilientDriver < AppAutomateDriver
   # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
   # @param retry_if_stale [Boolean] enables the method to retry acquiring the element if a StaleObjectException occurs
   def wait_for_element(element_id, timeout = 15, retry_if_stale = true)
-    super.wait_for_element element_id, timeout, retry_if_stale
+    super.wait_for_element(element_id, timeout, retry_if_stale)
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { wait_for_element element_id, timeout, retry_if_stale }
   end
@@ -42,7 +42,7 @@ class ResilientDriver < AppAutomateDriver
   #
   # @param element_id [String] the element to click using the @element_locator strategy
   def click_element(element_id)
-    super.click_element element_id
+    super.click_element(element_id)
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { click_element element_id }
   end
@@ -51,7 +51,7 @@ class ResilientDriver < AppAutomateDriver
   #
   # @param element_id [String] the element to clear, found using the @element_locator strategy
   def clear_element(element_id)
-    super.clear_element element_id
+    super.clear_element(element_id)
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { clear_element element_id }
   end
@@ -61,7 +61,7 @@ class ResilientDriver < AppAutomateDriver
   # @param element_id [String] the element to send text to using the @element_locator strategy
   # @param text [String] the text to send
   def send_keys_to_element(element_id, text)
-    super.send_keys_to_element element_id, text
+    super.send_keys_to_element(element_id, text)
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { send_keys_to_element element_id, text }
   end
@@ -71,7 +71,7 @@ class ResilientDriver < AppAutomateDriver
   # @param element_id [String] the element to clear and send text to using the @element_locator strategy
   # @param text [String] the text to send
   def clear_and_send_keys_to_element(element_id, text)
-    super.clear_and_send_keys_to_element element_id, text
+    super.clear_and_send_keys_to_element(element_id, text)
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { clear_and_send_keys_to_element element_id, text }
   end
@@ -80,7 +80,7 @@ class ResilientDriver < AppAutomateDriver
   #
   # @param timeout [Number] the amount of time in seconds to wait before resetting
   def reset_with_timeout(timeout=0.1)
-    super.reset_with_timeout timeout
+    super.reset_with_timeout(timeout)
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { reset_with_timeout timeout }
   end

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -15,8 +15,8 @@ class ResilientDriver < AppAutomateDriver
   # @param locator [Symbol] the primary locator strategy Appium should use to find elements
   # @param additional_capabilities [Hash] a hash of additional capabilities to be used in this test run
   def initialize(username, access_key, local_id, target_device, app_location, locator = :id, additional_capabilities = {})
-    super username, access_key, local_id, target_device, app_location, locator, additional_capabilities
     MazeRunner.driver = self
+    super username, access_key, local_id, target_device, app_location, locator, additional_capabilities
   end
 
   # Checks for an element, waiting until it is present or the method times out

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -25,6 +25,10 @@ class ResilientDriver < AppAutomateDriver
   # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
   # @param retry_if_stale [Boolean] enables the method to retry acquiring the element if a StaleObjectException occurs
   def wait_for_element(element_id, timeout = 15, retry_if_stale = true)
+    if rand(5) == 1
+      puts 'Oops - raising'
+      raise Selenium::WebDriver::Error::UnknownError
+    end
     super
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { wait_for_element element_id, timeout, retry_if_stale }
@@ -92,7 +96,7 @@ class ResilientDriver < AppAutomateDriver
     # sufficient each time the error occurs.  CI step timeouts are also in place to guard
     # against an infinite loop.
     $logger.warn 'Appium Error occurred - restarting driver.'
-    super.restart
+    restart
     sleep 5 # Only to avoid a possible tight loop
     yield
   end

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -85,6 +85,27 @@ class ResilientDriver < AppAutomateDriver
     recover { reset_with_timeout timeout }
   end
 
+  # Wraps @see Appium::Device#background_app
+  def background_app(timeout)
+    super
+  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
+    recover { background_app timeout }
+  end
+
+  # Wraps @see Appium::Device#close_app
+  def close_app
+    super
+  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
+    recover { close_app }
+  end
+
+  # Wraps @see Appium::Device#launch_app
+  def launch_app
+    super
+  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
+    recover { launch_app }
+  end
+
   # Restarts the underlying driver and calls the block given.
   def recover
     # BrowserStack's iOS 10 and 11 iOS devices seemed prone to the underlying Appium connection failing.

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -3,6 +3,7 @@ require_relative './fast_selenium'
 require_relative './logger'
 
 # Handles Appium driver restarts and retries in the case of failure
+# For methods available on this class, @see AppAutomateDriver.
 class ResilientAppiumDriver
   # Creates the ResilientAppiumDriver
   #
@@ -27,9 +28,8 @@ class ResilientAppiumDriver
     @driver.respond_to_missing? method_name
   end
 
-  # rubocop: disable MethodMissingSuper
   def method_missing(method, *args, &block)
-    raise "Method '#{method}' does not exist" unless @driver.respond_to?(method)
+    return super unless @driver.respond_to?(method)
 
     retries = 0
     until retries >= 5

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -9,6 +9,11 @@ class ResilientDriver
     @driver = driver
   end
 
+  # Deliberately no error handling here
+  def start_driver
+    @driver.start_driver
+  end
+
   # Checks for an element, waiting until it is present or the method times out
   #
   # @param element_id [String] the element to search for using the @element_locator strategy

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -17,7 +17,6 @@ class ResilientDriver < AppAutomateDriver
   def initialize(username, access_key, local_id, target_device, app_location, locator = :id, additional_capabilities = {})
     MazeRunner.driver = self
     super
-    @@counter = 0
   end
 
   # Checks for an element, waiting until it is present or the method times out
@@ -26,14 +25,6 @@ class ResilientDriver < AppAutomateDriver
   # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
   # @param retry_if_stale [Boolean] enables the method to retry acquiring the element if a StaleObjectException occurs
   def wait_for_element(element_id, timeout = 15, retry_if_stale = true)
-    $logger.info 'Oops - raising'
-    @@counter += 1
-    if @@counter % 2 == 1
-      $logger.info 'Oops - raising'
-      raise Selenium::WebDriver::Error::UnknownError
-    else
-      $logger.info 'Not raising'
-    end
     super
   rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
     recover { wait_for_element element_id, timeout, retry_if_stale }

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -4,21 +4,7 @@ require_relative './logger'
 
 # Handles Appium driver restarts and retries in the case of failure
 class ResilientAppiumDriver < AppAutomateDriver
-
-  # Creates the ResilientAppiumDriver
-  #
-  # @param username [String] the BrowserStack username
-  # @param access_key [String] the BrowserStack access key
-  # @param local_id [String] the identifier for the BrowserStackLocal tunnel
-  # @param target_device [String] a key from the Devices array selecting which device capabilities to target
-  # @param app_location [String] the location of the test-app to upload
-  # @param locator [Symbol] the primary locator strategy Appium should use to find elements
-  # @param additional_capabilities [Hash] a hash of additional capabilities to be used in this test run
-  def initialize(username, access_key, local_id, target_device, app_location, locator = :id, additional_capabilities = {})
-    MazeRunner.driver = self
-    super
-  end
-
+  
   # Checks for an element, waiting until it is present or the method times out
   #
   # @param element_id [String] the element to search for using the @element_locator strategy

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -1,0 +1,89 @@
+require 'appium_lib'
+require_relative './fast_selenium'
+require_relative './logger'
+
+# Handles Appium driver restarts and retries in the case of failure
+class ResilientDriver
+
+  def initialize(driver)
+    @driver = driver
+  end
+
+  # Checks for an element, waiting until it is present or the method times out
+  #
+  # @param element_id [String] the element to search for using the @element_locator strategy
+  # @param timeout [Integer] the maximum time to wait for an element to be present in seconds
+  # @param retry_if_stale [Boolean] enables the method to retry acquiring the element if a StaleObjectException occurs
+  def wait_for_element(element_id, timeout = 15, retry_if_stale = true)
+    @driver.wait_for_element element_id, timeout, retry_if_stale
+  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
+    recover { wait_for_element element_id, timeout, retry_if_stale }
+  end
+
+  # Resets the app
+  def reset
+    $logger.info 'Resetting app'
+    @driver.reset
+  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
+    recover { reset }
+  end
+
+  # Clicks a given element
+  #
+  # @param element_id [String] the element to click using the @element_locator strategy
+  def click_element(element_id)
+    @driver.click_element element_id
+  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
+    recover { click_element element_id }
+  end
+
+  # Clears a given element
+  #
+  # @param element_id [String] the element to clear, found using the @element_locator strategy
+  def clear_element(element_id)
+    @driver.clear_element element_id
+  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
+    recover { clear_element element_id }
+  end
+
+  # Sends keys to a given element
+  #
+  # @param element_id [String] the element to send text to using the @element_locator strategy
+  # @param text [String] the text to send
+  def send_keys_to_element(element_id, text)
+    @driver.send_keys_to_element element_id, text
+  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
+    recover { send_keys_to_element element_id, text }
+  end
+
+  # Sends keys to a given element, clearing it first
+  #
+  # @param element_id [String] the element to clear and send text to using the @element_locator strategy
+  # @param text [String] the text to send
+  def clear_and_send_keys_to_element(element_id, text)
+    @driver.clear_and_send_keys_to_element element_id, text
+  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
+    recover { clear_and_send_keys_to_element element_id, text }
+  end
+
+  # Reset the currently running application after a given timeout
+  #
+  # @param timeout [Number] the amount of time in seconds to wait before resetting
+  def reset_with_timeout(timeout=0.1)
+    @driver.reset_with_timeout timeout
+  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::WebDriverError
+    recover { reset_with_timeout timeout }
+  end
+
+  # Restarts the underlying driver and calls the block given.
+  def recover
+    # BrowserStack's iOS 10 and 11 iOS devices seemed prone to the underlying Appium connection failing.
+    # There is potential for an infinite loop here, but in reality a single restart seems
+    # sufficient each time the error occurs.  CI step timeouts are also in place to guard
+    # against an infinite loop.
+    $logger.warn 'Appium Error occurred - restarting driver.'
+    @driver.restart
+    sleep 5 # Only to avoid a possible tight loop
+    yield
+  end
+end

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -205,25 +205,6 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     assert_false(response, 'The driver must return false if it does not find an element')
   end
 
-  def test_wait_for_element_unknown_error_restart
-    logger = start_logger_mock
-    AppAutomateDriver.any_instance.stubs(:upload_app).returns(TEST_APP_URL)
-    driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION, :accessibility_id)
-    driver.stubs(:restart)
-    driver.expects(:restart).once
-
-    unknown_error = Selenium::WebDriver::Error::UnknownError.new('Element is stale')
-    mocked_element = mock('element')
-    mocked_element.expects(:displayed?).twice.raises(unknown_error).then.returns(true)
-
-    driver.expects(:find_element).with(:accessibility_id, 'test_button').returns(mocked_element).twice
-
-    logger.expects(:warn).with('Appium Error occurred - restarting driver.')
-
-    response = driver.wait_for_element('test_button', 15, false)
-    assert_true(response, 'The driver must return true after restarting')
-  end
-
   def test_wait_for_element_stale_error_retry_only_once
     logger = start_logger_mock
     AppAutomateDriver.any_instance.stubs(:upload_app).returns(TEST_APP_URL)

--- a/test/fixtures/browserstack-app/features/support/env.rb
+++ b/test/fixtures/browserstack-app/features/support/env.rb
@@ -10,7 +10,7 @@ $api_key = '12312312312312312312312312312312'
 ENV['BUGSNAG_API_KEY'] = $api_key
 
 AfterConfiguration do |config|
-  ResilientDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
+  ResilientAppiumDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
   MazeRunner.driver.start_driver unless MazeRunner.configuration.appium_session_isolation
 end
 

--- a/test/fixtures/browserstack-app/features/support/env.rb
+++ b/test/fixtures/browserstack-app/features/support/env.rb
@@ -10,7 +10,7 @@ $api_key = '12312312312312312312312312312312'
 ENV['BUGSNAG_API_KEY'] = $api_key
 
 AfterConfiguration do |config|
-  AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
+  ResilientDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
   MazeRunner.driver.start_driver unless MazeRunner.configuration.appium_session_isolation
 end
 

--- a/test/fixtures/browserstack-app/features/support/env.rb
+++ b/test/fixtures/browserstack-app/features/support/env.rb
@@ -11,13 +11,13 @@ ENV['BUGSNAG_API_KEY'] = $api_key
 
 AfterConfiguration do |config|
   AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
-  $driver.start_driver unless MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.start_driver unless MazeRunner.configuration.appium_session_isolation
 end
 
 After do
-  $driver.reset_with_timeout unless MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.reset_with_timeout unless MazeRunner.configuration.appium_session_isolation
 end
 
 at_exit do
-  $driver.driver_quit unless MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.driver_quit unless MazeRunner.configuration.appium_session_isolation
 end


### PR DESCRIPTION
## Goal

Provides resilience to flaky Appium sessions by handling exceptions on each method and restarting the driver.

## Design

It didn't seem possible to have a central method for catching all Appium exception, so I've gone for the next best option of adding a class whose single concern is to catch Appium errors of each method and restart the session.

## Changeset

- New `ResilientAppiumDriver` class.
- Addition of `driver` to the central `MazeRunner` class to avoid the need to use global `$driver`.

## Tests

Our Cocoa notifier build suffers the most from flaking Appium session and I have shared internally the results of an extended soak test run against this.  It shows the exception handling code in action and no failed builds as a result.

As always with Maze Runner, tests will also be triggered automatically on our Cocoa, JavaScript and Android notifiers against the new master branch before we perform the next release.
