### PR TITLE
Allow app location to be given by url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Allow BrowserStackLocal path to be provided in environment.
   [#137](https://github.com/bugsnag/maze-runner/pull/137)
+- Allow URLs to be provided for app location to avoid duplicate uploads.
+  [#136](https://github.com/bugsnag/maze-runner/pull/136)
 - Addition of ResilientAppiumDriver to catch and restart broken Appium sessions.
   [#134](https://github.com/bugsnag/maze-runner/pull/134)
 - Added option to start a new Appium session for every scenario.

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -34,7 +34,13 @@ class AppAutomateDriver < Appium::Driver
     @element_locator = locator
     @access_key = access_key
     @local_id = local_id
-    app_url = upload_app(username, access_key, app_location)
+    if app_location.start_with? 'bs://'
+      app_url = app_location
+    else
+      app_url = upload_app(username, access_key, app_location)
+      $logger.info "app uploaded to: #{app_url}"
+      $logger.info 'You can use this url to avoid uploading the same app more than once.'
+    end
 
     # Sets up identifiers for ease of connecting jobs
     name_capabilities = project_name_capabilities(target_device)

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -9,7 +9,7 @@ class AppAutomateDriverTest < Test::Unit::TestCase
   USERNAME = 'Username'
   ACCESS_KEY = 'Access_key'
   LOCAL_ID = 'Local_id'
-  APP_LOCATION = 'App_location'
+  APP_LOCATION = 'app_location'
   TEST_APP_URL = 'Test_app_url'
   TARGET_DEVICE = 'ANDROID_9'
   LOCAL_TUNNEL_COMMAND_OPTIONS = "-d start --key #{ACCESS_KEY} --local-identifier #{LOCAL_ID} --force-local"
@@ -26,6 +26,8 @@ class AppAutomateDriverTest < Test::Unit::TestCase
   def start_logger_mock
     logger_mock = mock('logger')
     $logger = logger_mock
+    logger_mock.expects(:info).with("app uploaded to: #{TEST_APP_URL}").once
+    logger_mock.expects(:info).with('You can use this url to avoid uploading the same app more than once.').once
     logger_mock.expects(:info).with('Appium driver initialised for:').once
     logger_mock.expects(:info).with('    project : local').once
     logger_mock.expects(:info).with(regexp_matches(/^\s{4}build\s{3}:\s\S{36}$/))
@@ -232,9 +234,9 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     mocked_element = mock('element')
     mocked_element.expects(:clear)
 
-    driver.expects(:find_element).with(:id, "test_text_entry").returns(mocked_element)
+    driver.expects(:find_element).with(:id, 'test_text_entry').returns(mocked_element)
 
-    driver.clear_element("test_text_entry")
+    driver.clear_element('test_text_entry')
   end
 
   def test_send_keys_to_element_defaults
@@ -257,11 +259,11 @@ class AppAutomateDriverTest < Test::Unit::TestCase
 
     mocked_element = mock('element')
     mocked_element.expects(:clear)
-    mocked_element.expects(:send_keys).with("Test_text")
+    mocked_element.expects(:send_keys).with('Test_text')
 
-    driver.expects(:find_element).with(:id, "test_text_entry").returns(mocked_element)
+    driver.expects(:find_element).with(:id, 'test_text_entry').returns(mocked_element)
 
-    driver.clear_and_send_keys_to_element("test_text_entry", "Test_text")
+    driver.clear_and_send_keys_to_element('test_text_entry', 'Test_text')
   end
 
   def test_clear_element_locator
@@ -272,9 +274,9 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     mocked_element = mock('element')
     mocked_element.expects(:clear)
 
-    driver.expects(:find_element).with(:accessibility_id, "test_text_entry").returns(mocked_element)
+    driver.expects(:find_element).with(:accessibility_id, 'test_text_entry').returns(mocked_element)
 
-    driver.clear_element("test_text_entry")
+    driver.clear_element('test_text_entry')
   end
 
   def test_send_keys_to_element_locator
@@ -297,11 +299,11 @@ class AppAutomateDriverTest < Test::Unit::TestCase
 
     mocked_element = mock('element')
     mocked_element.expects(:clear)
-    mocked_element.expects(:send_keys).with("Test_text")
+    mocked_element.expects(:send_keys).with('Test_text')
 
-    driver.expects(:find_element).with(:accessibility_id, "test_text_entry").returns(mocked_element)
+    driver.expects(:find_element).with(:accessibility_id, 'test_text_entry').returns(mocked_element)
 
-    driver.clear_and_send_keys_to_element("test_text_entry", "Test_text")
+    driver.clear_and_send_keys_to_element('test_text_entry', 'Test_text')
   end
 
   def test_start_driver_no_env
@@ -343,6 +345,8 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     ENV['BUILDKITE_STEP_KEY'] = 'tests-05'
     logger_mock = mock('logger')
     $logger = logger_mock
+    logger_mock.expects(:info).with("app uploaded to: #{TEST_APP_URL}").once
+    logger_mock.expects(:info).with('You can use this url to avoid uploading the same app more than once.').once
     logger_mock.expects(:info).with('Appium driver initialised for:').once
     logger_mock.expects(:info).with('    project : TEST').once
     logger_mock.expects(:info).with('    build   : 156 TEST BRANCH')


### PR DESCRIPTION
## Goal

Avoids having to upload the same app to BrowserStack more than once.

## Tests

Passing CI and unit tests sufficient to show that the standard case works.  Tested manually locally to verify that a BrowserStack URL can be specified.