### PR TITLE
Allow path to BrowserStackLocal binary to be provided in environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Enhancements
 
+- Allow BrowserStackLocal path to be provided in environment.
+  [#137](https://github.com/bugsnag/maze-runner/pull/137)
 - Addition of ResilientAppiumDriver to catch and restart broken Appium sessions.
   [#134](https://github.com/bugsnag/maze-runner/pull/134)
 - Added option to start a new Appium session for every scenario.

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -66,6 +66,7 @@ class AppAutomateDriver < Appium::Driver
   # Starts the BrowserStackLocal tunnel and the Appium driver
   def start_driver
     start_local_tunnel
+    $logger.info 'Starting Appium driver'
     super
   end
 
@@ -180,6 +181,7 @@ class AppAutomateDriver < Appium::Driver
   end
 
   def start_local_tunnel
+    $logger.info 'Starting BrowserStack local tunnel'
     status = nil
     bs_local = ENV['BROWSER_STACK_LOCAL'] || '/BrowserStackLocal'
     command = "#{bs_local} -d start --key #{@access_key} --local-identifier #{@local_id} --force-local"

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -181,7 +181,9 @@ class AppAutomateDriver < Appium::Driver
 
   def start_local_tunnel
     status = nil
-    Open3.popen2("/BrowserStackLocal -d start --key #{@access_key} --local-identifier #{@local_id} --force-local") do |stdin, stdout, wait|
+    bs_local = ENV['BROWSER_STACK_LOCAL'] || '/BrowserStackLocal'
+    command = "#{bs_local} -d start --key #{@access_key} --local-identifier #{@local_id} --force-local"
+    Open3.popen2(command) do |_stdin, _stdout, wait|
       status = wait.value
     end
     status

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -306,6 +306,8 @@ class AppAutomateDriverTest < Test::Unit::TestCase
 
   def test_start_driver_no_env
     start_logger_mock
+    $logger.expects(:info).with('Starting BrowserStack local tunnel').once
+    $logger.expects(:info).with('Starting Appium driver').once
     AppAutomateDriver.any_instance.stubs(:upload_app).returns(TEST_APP_URL)
     driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION)
 
@@ -320,6 +322,8 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     my_path = '/my/path'
     ENV['BROWSER_STACK_LOCAL'] = my_path
     start_logger_mock
+    $logger.expects(:info).with('Starting BrowserStack local tunnel').once
+    $logger.expects(:info).with('Starting Appium driver').once
     AppAutomateDriver.any_instance.stubs(:upload_app).returns(TEST_APP_URL)
     driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION)
 

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -12,7 +12,7 @@ class AppAutomateDriverTest < Test::Unit::TestCase
   APP_LOCATION = 'App_location'
   TEST_APP_URL = 'Test_app_url'
   TARGET_DEVICE = 'ANDROID_9'
-  LOCAL_TUNNEL_COMMAND = "/BrowserStackLocal -d start --key #{ACCESS_KEY} --local-identifier #{LOCAL_ID} --force-local"
+  LOCAL_TUNNEL_COMMAND_OPTIONS = "-d start --key #{ACCESS_KEY} --local-identifier #{LOCAL_ID} --force-local"
 
   def setup
     ENV.delete('BRANCH_NAME')
@@ -304,14 +304,28 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     driver.clear_and_send_keys_to_element("test_text_entry", "Test_text")
   end
 
-  def test_start_driver
+  def test_start_driver_no_env
     start_logger_mock
     AppAutomateDriver.any_instance.stubs(:upload_app).returns(TEST_APP_URL)
     driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION)
 
     Appium::Driver.any_instance.expects(:start_driver)
     waiter = mock('Process::Waiter', value: mock('Process::Status'))
-    Open3.expects(:popen2).with(LOCAL_TUNNEL_COMMAND).yields(mock('stdin'), mock('stdout'), waiter)
+    Open3.expects(:popen2).with("/BrowserStackLocal #{LOCAL_TUNNEL_COMMAND_OPTIONS}").yields(mock('stdin'), mock('stdout'), waiter)
+
+    driver.start_driver
+  end
+
+  def test_start_driver_with_env
+    my_path = '/my/path'
+    ENV['BROWSER_STACK_LOCAL'] = my_path
+    start_logger_mock
+    AppAutomateDriver.any_instance.stubs(:upload_app).returns(TEST_APP_URL)
+    driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION)
+
+    Appium::Driver.any_instance.expects(:start_driver)
+    waiter = mock('Process::Waiter', value: mock('Process::Status'))
+    Open3.expects(:popen2).with("#{my_path} #{LOCAL_TUNNEL_COMMAND_OPTIONS}").yields(mock('stdin'), mock('stdout'), waiter)
 
     driver.start_driver
   end


### PR DESCRIPTION
## Goal

Allow a path to the BrowserStackLocal binary to be provided in the environment.  

## Design

With this in place it is then possible to run Maze Runner locally under `bundle exec` only and not having to build or pull the Docker image first.  This makes using the tool much quicker to use and easier to develop for.

## Changeset

Simple change to Appium driver class.

## Tests

Unit tests updated to show use of the environment, together with local testing.  Passing CI also shows the standard case continues to work.
