### PR TITLE
Update Appium driver logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - BrowserStack specific elements separated from AppAutomateDriver (now simply AppiumDriver),
   providing the ability to use MazeRunner with local devices.
+  [#139](https://github.com/bugsnag/maze-runner/pull/139)
+- Logging improvements when starting Appium driver (including BrowserStack link)
+  [#141](https://github.com/bugsnag/maze-runner/pull/141)
 
 ## Fixes
 

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -37,6 +37,12 @@ AfterConfiguration do |config|
   # Create and start the drive
   MazeRunner.driver = ResilientAppiumDriver.new config.appium_server_url,
                                                 config.capabilities
+  if config.farm == :bs
+    # Log a link to the BrowserStack session search dashboard
+    build = MazeRunner.driver.caps[:build]
+    url = "https://app-automate.browserstack.com/dashboard/v2/?searchQuery=#{build}"
+    $logger.info LogUtil.linkify url, 'BrowserStack session(s)'
+  end
   MazeRunner.driver.start_driver unless config.appium_session_isolation
 
   # TODO: We need to get hold of OS version (or API level) of the actual device that is used.  We used to take this from

--- a/lib/features/support/appium_driver.rb
+++ b/lib/features/support/appium_driver.rb
@@ -26,13 +26,6 @@ class AppiumDriver < Appium::Driver
     # Sets up identifiers for ease of connecting jobs
     name_capabilities = project_name_capabilities
 
-    $logger.info 'Appium driver initialized for:'
-    $logger.info "    project : #{name_capabilities[:project]}"
-    $logger.info "    build   : #{name_capabilities[:build]}"
-    # TODO This existing "name" needed to change as part of making MR more device farm
-    #   agnostic, but is currently broken and will be fixed in a follow-up change.
-    # $logger.info "    capabilities    : #{name_capabilities[:name]}"
-
     @element_locator = locator
     @capabilities = capabilities
     @capabilities.merge! name_capabilities
@@ -43,6 +36,10 @@ class AppiumDriver < Appium::Driver
         server_url: server_url
       }
     }, true)
+
+    $logger.info 'Appium driver initialized for:'
+    $logger.info "    project : #{name_capabilities[:project]}"
+    $logger.info "    build   : #{name_capabilities[:build]}"
   end
 
   # Starts the BrowserStackLocal tunnel and the Appium driver
@@ -114,42 +111,27 @@ class AppiumDriver < Appium::Driver
 
   # Determines and returns sensible project, build, and name capabilities
   #
-  # @return [Hash] A hash containing the 'project', 'build', and 'name' capabilities
+  # @return [Hash] A hash containing the 'project' and 'build' capabilities
   def project_name_capabilities
     # Default to values for running locally
     project = 'local'
-    name = 'local'
     build = SecureRandom.uuid
 
     if ENV['BUILDKITE']
       # Project
       project = ENV['BUILDKITE_PIPELINE_NAME']
-
-      # Build
-      bk_build_array = []
-      bk_build_array << ENV['BUILDKITE_BUILD_NUMBER'] if ENV['BUILDKITE_BUILD_NUMBER']
-      bk_build_array << ENV['BRANCH_NAME'] if ENV['BRANCH_NAME']
-      bk_build = bk_build_array.join(' ').strip
-      build = bk_build unless bk_build.nil? || bk_build.empty?
-
-      # Name
-      bk_name_array = []
-      bk_name_array << ENV['BUILDKITE_STEP_KEY'] if ENV['BUILDKITE_STEP_KEY']
-      bk_name_array << ENV['BUILDKITE_RETRY_COUNT'] if ENV['BUILDKITE_RETRY_COUNT']
-      name = bk_name_array.join(' ')
     end
     {
       project: project,
-      build: build,
-      name: name
+      build: build
     }
   end
 
   def device_info
-    @driver.execute_script('mobile:deviceInfo')
+    execute_script('mobile:deviceInfo')
   end
 
   def session_capabilities
-    @driver.session_capabilities
+    session_capabilities
   end
 end

--- a/lib/features/support/appium_driver.rb
+++ b/lib/features/support/appium_driver.rb
@@ -130,10 +130,10 @@ class AppiumDriver < Appium::Driver
   end
 
   def device_info
-    execute_script('mobile:deviceInfo')
+    driver.execute_script('mobile:deviceInfo')
   end
 
   def session_capabilities
-    session_capabilities
+    driver.session_capabilities
   end
 end

--- a/lib/features/support/appium_driver.rb
+++ b/lib/features/support/appium_driver.rb
@@ -44,8 +44,10 @@ class AppiumDriver < Appium::Driver
 
   # Starts the BrowserStackLocal tunnel and the Appium driver
   def start_driver
-    $logger.info 'Starting Appium driver'
+    $logger.info 'Starting Appium driver...'
+    time = Time.now
     super
+    $logger.info "Appium driver started in #{(Time.now - time).to_i}s"
   end
 
   # Checks for an element, waiting until it is present or the method times out

--- a/lib/features/support/browser_stack_utils.rb
+++ b/lib/features/support/browser_stack_utils.rb
@@ -13,7 +13,7 @@ class BrowserStackUtils
       #   - what if app_location doesn't exist locally
       if app_location.start_with? 'bs://'
         app_url = app_location
-        $logger.info "Skipping upload for pre-uploaded app #{app_location}"
+        $logger.info "Using pre-uploaded app from #{app_location}"
       else
         url = 'https://api-cloud.browserstack.com/app-automate/upload'
         res = `curl -u "#{username}:#{access_key}" -X POST "#{url}" -F "file=@#{app_location}"`

--- a/lib/features/support/logger.rb
+++ b/lib/features/support/logger.rb
@@ -57,5 +57,12 @@ class LogUtil
         end
       end
     end
+
+    # Produces a clickable link when logged in Buildkite
+    # @param url [String] Link URL
+    # @param text [String] Link text
+    def linkify(url, text)
+      "\033]1339;url='#{url}';content='#{text}'\a"
+    end
   end
 end

--- a/test/appium_driver_test.rb
+++ b/test/appium_driver_test.rb
@@ -218,30 +218,6 @@ class AppiumDriverTest < Test::Unit::TestCase
     driver.clear_and_send_keys_to_element('test_text_entry', 'Test_text')
   end
 
-  # TODO Tests will follow in a subsequent PR after properly reassessing the logging
-  # def test_environment_ids
-  #   ENV['BRANCH_NAME'] = 'TEST BRANCH'
-  #   ENV['BUILDKITE'] = 'true'
-  #   ENV['BUILDKITE_PIPELINE_NAME'] = 'TEST'
-  #   ENV['BUILDKITE_BUILD_NUMBER'] = '156'
-  #   ENV['BUILDKITE_RETRY_COUNT'] = '5'
-  #   ENV['BUILDKITE_STEP_KEY'] = 'tests-05'
-  #   logger_mock = mock('logger')
-  #   $logger = logger_mock
-  #   logger_mock.expects(:info).with("app uploaded to: #{TEST_APP_URL}").once
-  #   logger_mock.expects(:info).with('You can use this url to avoid uploading the same app more than once.').once
-  #   logger_mock.expects(:info).with('Appium driver initialised for:').once
-  #   logger_mock.expects(:info).with('    project : TEST').once
-  #   logger_mock.expects(:info).with('    build   : 156 TEST BRANCH')
-  #   logger_mock.expects(:info).with("    name    : #{TARGET_DEVICE} tests-05 5")
-  #
-  #   driver = AppiumDriver.new SERVER_URL, @capabilities
-  #
-  #   assert_equal('TEST', driver.caps[:project])
-  #   assert_equal('156 TEST BRANCH', driver.caps[:build])
-  #   assert_equal("#{TARGET_DEVICE} tests-05 5", driver.caps[:name])
-  # end
-
   def test_project_name_capabilities_local
     # BUILDKITE environment variable is cleared in setup
     start_logger_mock

--- a/test/browser_stack_utils_test.rb
+++ b/test/browser_stack_utils_test.rb
@@ -20,7 +20,7 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
   end
 
   def test_upload_app_skip
-    $logger.expects(:info).with("Skipping upload for pre-uploaded app #{TEST_APP_URL}")
+    $logger.expects(:info).with("Using pre-uploaded app from #{TEST_APP_URL}")
 
     url = BrowserStackUtils.upload_app USERNAME, ACCESS_KEY, TEST_APP_URL
     assert_equal(TEST_APP_URL, url)


### PR DESCRIPTION
## Goal

Review the details logged when creating the Appium driver.

## Design

For now I've just logged the project (pipeline name) and a build UUID that can be used to get hold of device logs etc from BrowserStack (and a sensible link to the dashboard is now also logged).  Details of the device in use will be added in a subsequent PR, as extra work is needed to get that working for both BrowserStack and local devices.

## Changeset

Logging calls, including a new util to make use of Buildkite's ANSI escape sequence capability.

## Tests

Unit testing and manual inspection of the new logs.
