### PR TITLE
Provide intended OS version

### DIFF
--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -169,6 +169,8 @@ class MazeRunnerEntry
     when :local then
       raise "option --#{OPTION_OS} must be specified" if options[OPTION_OS].nil?
       raise "option --#{OPTION_OS_VERSION} must be specified" if options[OPTION_OS_VERSION].nil?
+      # Ensure OS version is a valid float so that notifier tests can perform numeric checks, e.g:
+      # 'MazeRunner.config.os_version > 7'
       unless /^[1-9][0-9]*(\.[0-9])?/.match? options[OPTION_OS_VERSION]
         raise "option --#{OPTION_OS_VERSION} must be a valid OS version matching '/^[1-9][0-9]*(\\.[0-9])?/'"
       end

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -14,7 +14,9 @@ class MazeRunnerEntry
   OPTION_APP = 'app'
   OPTION_BS_LOCAL = 'bs-local'
   OPTION_FARM = 'farm'
-  OPTION_DEVICE = 'device'
+  OPTION_BS_DEVICE = 'device'
+  OPTION_OS = 'os'
+  OPTION_OS_VERSION = 'os-version'
   OPTION_USERNAME = 'username'
   OPTION_ACCESS_KEY = 'access-key'
   OPTION_APPIUM_SERVER = 'appium-server'
@@ -44,8 +46,16 @@ class MazeRunnerEntry
           type: :string,
           default: '/BrowserStackLocal'
       opt OPTION_FARM, 'Device farm to use: "bs" (BrowserStack) or "local"', short: :none, type: :string
-      opt OPTION_DEVICE,
-          'Device type to use ("ios", "android" or a Devices.DEVICE_HASH key)',
+      opt OPTION_BS_DEVICE,
+          'BrowserStack device to use (a key of Devices.DEVICE_HASH)',
+          short: :none,
+          type: :string
+      opt OPTION_OS,
+          'OS type to use ("ios", "android")',
+          short: :none,
+          type: :string
+      opt OPTION_OS_VERSION,
+          'The intended OS version when running on a local device',
           short: :none,
           type: :string
       opt OPTION_APPLE_TEAM_ID, 'Apple Team Id, required for local iOS testing', short: :none, type: :string
@@ -80,7 +90,9 @@ class MazeRunnerEntry
       OPTION_SEPARATE_SESSIONS,
       OPTION_APP,
       OPTION_BS_LOCAL,
-      OPTION_DEVICE,
+      OPTION_BS_DEVICE,
+      OPTION_OS,
+      OPTION_OS_VERSION,
       OPTION_FARM,
       OPTION_USERNAME,
       OPTION_ACCESS_KEY,
@@ -128,7 +140,6 @@ class MazeRunnerEntry
     config.appium_session_isolation = options[OPTION_SEPARATE_SESSIONS]
     config.app_location = options[OPTION_APP]
     farm = options[OPTION_FARM]
-    device_type = config.device_type = options[OPTION_DEVICE]
     config.farm = case farm
                   when nil then :none
                   when 'bs' then :bs
@@ -142,20 +153,32 @@ class MazeRunnerEntry
     when :bs then
       raise "option --#{OPTION_USERNAME} must be specified" if options[OPTION_USERNAME].nil?
       raise "option --#{OPTION_ACCESS_KEY} must be specified" if options[OPTION_ACCESS_KEY].nil?
-      unless Devices::DEVICE_HASH.key? device_type
-        raise "Device type '#{device}' not known on BrowserStack.  Must be one of #{Devices::DEVICE_HASH.keys}"
+
+      bs_device = options[OPTION_BS_DEVICE]
+      raise "option --#{OPTION_BS_DEVICE} must be specified" if bs_device.nil?
+      unless Devices::DEVICE_HASH.key? bs_device
+        raise "Device type '#{bs_device}' not known on BrowserStack.  Must be one of #{Devices::DEVICE_HASH.keys}"
       end
 
+      config.bs_device = bs_device
+      config.os_version = Devices::DEVICE_HASH[config.bs_device]['os_version'].to_f
       config.bs_local = options[OPTION_BS_LOCAL]
       username = config.username = options[OPTION_USERNAME]
       access_key = config.access_key = options[OPTION_ACCESS_KEY]
       config.appium_server_url = "http://#{username}:#{access_key}@hub-cloud.browserstack.com/wd/hub"
     when :local then
-      config.appium_server_url = options[OPTION_APPIUM_SERVER]
-      device_type = device_type.downcase
-      raise 'device must be ios or android' unless %w[ios android].include? device_type
+      raise "option --#{OPTION_OS} must be specified" if options[OPTION_OS].nil?
+      raise "option --#{OPTION_OS_VERSION} must be specified" if options[OPTION_OS_VERSION].nil?
+      unless /^[1-9][0-9]*(\.[0-9])?/.match? options[OPTION_OS_VERSION]
+        raise "option --#{OPTION_OS} (#{options[OPTION_OS_VERSION]}) must be a valid OS version (X.Y)"
+      end
 
-      if device_type == 'ios'
+      os = options[OPTION_OS].downcase
+      MazeRunner.config.os_version = options[OPTION_OS_VERSION].to_f
+      raise 'os must be ios or android' unless %w[ios android].include? os
+
+      config.appium_server_url = options[OPTION_APPIUM_SERVER]
+      if os == 'ios'
         raise 'option --apple-team-id must be specified for iOS' if options[OPTION_APPLE_TEAM_ID].nil?
         raise 'option --udid must be specified for iOS' if options[OPTION_UDID].nil?
 

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -124,7 +124,7 @@ class MazeRunnerEntry
 
     # Process CL options
     init if options[:init]
-    config = MazeRunner.configuration
+    config = MazeRunner.config
     config.appium_session_isolation = options[OPTION_SEPARATE_SESSIONS]
     config.app_location = options[OPTION_APP]
     farm = options[OPTION_FARM]

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -170,7 +170,7 @@ class MazeRunnerEntry
       raise "option --#{OPTION_OS} must be specified" if options[OPTION_OS].nil?
       raise "option --#{OPTION_OS_VERSION} must be specified" if options[OPTION_OS_VERSION].nil?
       unless /^[1-9][0-9]*(\.[0-9])?/.match? options[OPTION_OS_VERSION]
-        raise "option --#{OPTION_OS} (#{options[OPTION_OS_VERSION]}) must be a valid OS version (X.Y)"
+        raise "option --#{OPTION_OS_VERSION} must be a valid OS version matching '/^[1-9][0-9]*(\\.[0-9])?/'"
       end
 
       os = options[OPTION_OS].downcase

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -8,7 +8,7 @@ AfterConfiguration do |config|
 
   # Start mock server
   Server.start_server
-  config = MazeRunner.configuration
+  config = MazeRunner.config
   next if config.farm == :none
 
   # Setup Appium capabilities.  Note that the 'app' capability is
@@ -57,9 +57,9 @@ Before do |scenario|
   Server.stored_requests.clear
   Store.values.clear
 
-  next if MazeRunner.configuration.farm == :none
+  next if MazeRunner.config.farm == :none
 
-  MazeRunner.driver.start_driver if MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.start_driver if MazeRunner.config.appium_session_isolation
 end
 
 # After each scenario
@@ -91,9 +91,9 @@ After do |scenario|
     end
   end
 
-  next if MazeRunner.configuration.farm == :none
+  next if MazeRunner.config.farm == :none
 
-  if MazeRunner.configuration.appium_session_isolation
+  if MazeRunner.config.appium_session_isolation
     MazeRunner.driver.driver_quit
   else
     MazeRunner.driver.reset_with_timeout 2
@@ -110,9 +110,9 @@ at_exit do
   # future test runs are from a clean slate.
   Docker.down_all_services
 
-  next if MazeRunner.configuration.farm == :none
+  next if MazeRunner.config.farm == :none
 
   # Stop the Appium session
-  MazeRunner.driver.driver_quit unless MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.driver_quit unless MazeRunner.config.appium_session_isolation
 end
 

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -17,7 +17,7 @@ AfterConfiguration do |config|
   # BrowserStack specific setup
   if config.farm == :bs
     tunnel_id = SecureRandom.uuid
-    config.capabilities = Capabilities.for_browser_stack config.device_type,
+    config.capabilities = Capabilities.for_browser_stack config.bs_device,
                                                          tunnel_id
 
     config.app_location = BrowserStackUtils.upload_app config.username,
@@ -27,7 +27,7 @@ AfterConfiguration do |config|
                                          tunnel_id,
                                          config.access_key
   elsif config.farm == :local
-    config.capabilities = Capabilities.for_local config.device_type,
+    config.capabilities = Capabilities.for_local config.os,
                                                  config.apple_team_id,
                                                  config.device_id
   end

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -136,7 +136,7 @@ end
 def get_expected_platform_value(platform_values)
   raise('This step should only be used when running tests with Appium') if MazeRunner.driver.nil?
 
-  os = MazeRunner.configuration.capabilities['os']
+  os = MazeRunner.config.capabilities['os']
   expected_value = Hash[platform_values.raw][os]
   raise("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
 

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -23,8 +23,14 @@ class Configuration
   # Apple Team Id
   attr_accessor :apple_team_id
 
-  # Device type
+  # A key from @see Devices.DEVICE_HASH
   attr_accessor :device_type
+
+  # BrowserStack device type
+  attr_accessor :bs_device
+
+  # OS version
+  attr_accessor :os_version
 
   # Device id for running on local iOS devices
   attr_accessor :device_id

--- a/lib/features/support/maze_runner.rb
+++ b/lib/features/support/maze_runner.rb
@@ -7,8 +7,8 @@ require_relative './configuration'
 class MazeRunner
   class << self
     attr_accessor :driver
-    def configuration
-      @configuration ||= Configuration.new
+    def config
+      @config ||= Configuration.new
     end
   end
 end

--- a/test/capabilities/devices_test.rb
+++ b/test/capabilities/devices_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../../lib/features/support/capabilities/devices'
+
+class DevicesTest < Test::Unit::TestCase
+
+  def test_os_version
+    # Ensure that every entry in the hash has a meaningful OS version
+    Devices::DEVICE_HASH.each do |key, value|
+      os_version = value['os_version']
+      regex = /[1-9][0-9]*(\.[0-9])?/
+      assert_match(regex, os_version)
+    end
+  end
+
+end

--- a/test/capabilities/devices_test.rb
+++ b/test/capabilities/devices_test.rb
@@ -9,7 +9,7 @@ class DevicesTest < Test::Unit::TestCase
     # Ensure that every entry in the hash has a meaningful OS version
     Devices::DEVICE_HASH.each do |key, value|
       os_version = value['os_version']
-      regex = /[1-9][0-9]*(\.[0-9])?/
+      regex = /^[1-9][0-9]*(\.[0-9])?/
       assert_match(regex, os_version)
     end
   end


### PR DESCRIPTION
## Goal

Ensure that an intended OS version is provided, which is needed by notifier tests in order to know when annotated scenarios should be skipped.

## Design

I was hoping to extract the actual OS (or at least API) version from the device using Appium, but it doesn't seem to be possible to do this with both iOS and Android both locally and on BrowserStack.  I've therefore settled for ensuring that the intended OS version is specified (which is what we've been doing on BrowserStack all along, so it's not a regression in that respect).

I've started a new branch to move the CL option parsing into a separate file, which I'll raise a PR for in itself.  

## Changeset

CL option processing and device/OS configuration.

## Tests

New unit test added to ensure that the `DEVICE_HASH` always contents a float-like OS version.  For now I have informally tested use of the command line options locally, as further testing will be performed before we commit our notifiers to using the new major release.  However, the command line processing now warrants its own set of unit tests, which will be added as part of the forthcoming refactor mentioned above.
