### PR TITLE
[PLAT-4981] Add Interactive CLI steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,6 +63,11 @@ steps:
       --access-key=$BROWSER_STACK_ACCESS_KEY
     concurrency: 10
     concurrency_group: 'browserstack-app'
+    #
+    # TODO: Remove as soon as possible - working around BrowserStack network problem
+    #
+    soft_fail:
+      - exit_status: "*"
 
   - label: 'Browserstack app-automate test - Android 7.1 (separate Appium sessions)'
     plugins:
@@ -77,6 +82,11 @@ steps:
       --access-key=$BROWSER_STACK_ACCESS_KEY
     concurrency: 10
     concurrency_group: 'browserstack-app'
+    #
+    # TODO: Remove as soon as possible - working around BrowserStack network problem
+    #
+    soft_fail:
+      - exit_status: "*"
 
   - label: 'Browserstack app-automate test - Android 8.1'
     plugins:

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -63,64 +63,70 @@ When('I wait for {int} second(s)') do |seconds|
   sleep(seconds)
 end
 
-# Starts an interactive terminal
-When('I start a new terminal') do
+# Starts an interactive shell
+When('I start a new shell') do
   Runner.stop_interactive_session
   Runner.get_interactive_session
 end
 
-# Stops currently running interactive terminal
-When('I stop the current terminal') do
+# Stops currently running interactive shell
+When('I stop the current shell') do
   Runner.stop_interactive_session
 end
 
-# Run a command on the terminal
+# Run a command on the shell
 #
-# @step_input command [String] The command to run on the terminal
+# @step_input command [String] The command to run on the shell
 When('I input {string} interactively') do |command|
-  current_terminal = Runner.get_interactive_session
-  success = current_terminal.run_command(command)
+  current_shell = Runner.get_interactive_session
+  success = current_shell.run_command(command)
   assert(success, 'The terminal had already closed')
 end
 
-# Get the current buffer values in the terminal
+# Get the current buffer values in the shell
 #
 # @step_input expected_chars [String] The chars present in current buffer
-Then('the terminal is outputting {string}') do |expected_chars|
-  current_terminal = Runner.get_interactive_session
-  assert_equal(expected_chars, current_terminal.current_buffer)
+Then('the current stdout line is {string}') do |expected_chars|
+  current_shell = Runner.get_interactive_session
+  assert_equal(expected_chars, current_shell.current_buffer)
 end
 
 # Verify a string appears in the stdout logs
 #
 # @step_input expected_line [String] The string present in stdout logs
-Then('the terminal has output {string}') do |expected_line|
-  current_terminal = Runner.get_interactive_session
-  match = current_terminal.parsed_output.any? { |line| line == expected_line }
-  assert(match, "No output lines matched #{expected_line}")
+Then('the shell has output {string} to stdout') do |expected_line|
+  current_shell = Runner.get_interactive_session
+  match = current_shell.stdout_lines.any? { |line| line == expected_line }
+  assert(match, "No output lines from #{current_shell.stdout_lines} matched #{expected_line}")
 end
 
 # Verify a string appears in the stderr logs
 #
 # @step_input expected_err [String] The string present in stderr logs
-Then('the terminal has the error message {string}') do |expected_err|
-  current_terminal = Runner.get_interactive_session
-  match = current_terminal.parsed_errors.any? { |line| line == expected_err }
-  assert(match, "No output lines matched #{expected_err}")
+Then('the shell has output {string} to stderr') do |expected_err|
+  current_shell = Runner.get_interactive_session
+  match = current_shell.stderr_lines.any? { |line| line == expected_err }
+  assert(match, "No output lines from #{current_shell.stderr_lines} matched #{expected_err}")
 end
 
-# Verify the exit code of the terminal
-#
-# @step_input exit_code [Integer] The expected exit code
-Then('the terminal exit code equals {int}') do |exit_code|
-  current_terminal = Runner.get_interactive_session
-  assert_equal(exit_code, current_terminal.last_exit_code)
+# Verify the shell exited successfully (assuming a 0 is a success)
+Then('the shell exited successfully') do
+  current_shell = Runner.get_interactive_session
+  assert_equal(0, current_shell.last_exit_code)
 end
 
-# Assert that the terminal exited with an error code
+# Verify the exit code of the shell
 #
 # @step_input exit_code [Integer] The expected exit code
-Then('the terminal exited with an error code') do
-  current_terminal = Runner.get_interactive_session
-  assert(current_terminal.last_exit_code != 0, "Terminal exited with code 0")
+Then('the shell exit code is {int}') do |exit_code|
+  current_shell = Runner.get_interactive_session
+  assert_equal(exit_code, current_shell.last_exit_code)
+end
+
+# Assert that the shell exited with an error code (assuming non-0 is an error)
+#
+# @step_input exit_code [Integer] The expected exit code
+Then('the shell exited with an error code') do
+  current_shell = Runner.get_interactive_session
+  assert(current_shell.last_exit_code != 0, "Shell exited with code 0")
 end

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -83,6 +83,14 @@ When('I run {string} on the current terminal') do |command|
   assert(success, 'The terminal had already closed')
 end
 
+# Get the current buffer values in the terminal
+#
+# @step_input expected_chars [String] The chars present in current buffer
+Then('the terminal is outputting {string}') do |expected_chars|
+  current_terminal = Runner.get_interactive_session
+  assert_equal(expected_chars, current_terminal.current_buffer)
+end
+
 # Verify a string appears in the stdout logs
 #
 # @step_input expected_line [String] The string present in stdout logs

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -62,3 +62,49 @@ When('I wait for {int} second(s)') do |seconds|
   $logger.warn 'Sleep was used! Please avoid using sleep in tests!'
   sleep(seconds)
 end
+
+# Starts an interactive terminal
+When('I start a new terminal') do
+  Runner.stop_interactive_session
+  Runner.get_interactive_session
+end
+
+# Stops currently running interactive terminal
+When('I stop the current terminal') do
+  Runner.stop_interactive_session
+end
+
+# Run a command on the terminal
+#
+# @step_input command [String] The command to run on the terminal
+When('I run {string} on the current terminal') do |command|
+  current_terminal = Runner.get_interactive_session
+  success = current_terminal.run_command(command)
+  assert(success, 'The terminal had already closed')
+end
+
+# Verify a string appears in the stdout logs
+#
+# @step_input expected_line [String] The string present in stdout logs
+Then('the terminal has output {string}') do |expected_line|
+  current_terminal = Runner.get_interactive_session
+  match = current_terminal.parsed_output.any? { |line| line == expected_line }
+  assert(match, "No output lines matched #{expected_line}")
+end
+
+# Verify a string appears in the stderr logs
+#
+# @step_input expected_err [String] The string present in stderr logs
+Then('the terminal has the error message {string}') do |expected_err|
+  current_terminal = Runner.get_interactive_session
+  match = current_terminal.parsed_errors.any? { |line| line == expected_err }
+  assert(match, "No output lines matched #{expected_err}")
+end
+
+# Verify the exit code of the terminal
+#
+# @step_input exit_code [Integer] The expected exit code
+Then('the terminal exit code equals {int}') do |exit_code|
+  current_terminal = Runner.get_interactive_session
+  assert_equal(exit_code, current_terminal.last_exit_code)
+end

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -77,7 +77,7 @@ end
 # Run a command on the terminal
 #
 # @step_input command [String] The command to run on the terminal
-When('I run {string} on the current terminal') do |command|
+When('I input {string} interactively') do |command|
   current_terminal = Runner.get_interactive_session
   success = current_terminal.run_command(command)
   assert(success, 'The terminal had already closed')
@@ -115,4 +115,12 @@ end
 Then('the terminal exit code equals {int}') do |exit_code|
   current_terminal = Runner.get_interactive_session
   assert_equal(exit_code, current_terminal.last_exit_code)
+end
+
+# Assert that the terminal exited with an error code
+#
+# @step_input exit_code [Integer] The expected exit code
+Then('the terminal exited with an error code') do
+  current_terminal = Runner.get_interactive_session
+  assert(current_terminal.last_exit_code != 0, "Terminal exited with code 0")
 end

--- a/lib/features/support/interactive_cli.rb
+++ b/lib/features/support/interactive_cli.rb
@@ -46,10 +46,9 @@ class InteractiveCLI
   end
 
   # Attempts to stop the shell using the preset command
-  #
-  # @return [Boolean] true if the command is executed, false otherwise
   def stop
     run_command(@stop_command)
+    @thread&.join(5)
   end
 
   # Returns whether the shell is running by verifying the in_stream exists and is open
@@ -79,7 +78,6 @@ class InteractiveCLI
     executor = lambda do
       start_shell(shell)
     end
-
     @thread = Thread.new &executor
   end
 

--- a/lib/features/support/interactive_cli.rb
+++ b/lib/features/support/interactive_cli.rb
@@ -1,21 +1,23 @@
+# frozen_string_literal: true
+
 require 'open3'
 
-# Encapsulates a terminal session, retaining state and input streams for interactive tests
+# Encapsulates a shell session, retaining state and input streams for interactive tests
 class InteractiveCLI
-  # @!attribute [r] parsed_output
+  # @!attribute [r] stdout_lines
   #   @return [Array] An array of output strings received from the terminals STDOUT pipe
-  attr_reader :parsed_output
+  attr_reader :stdout_lines
 
-  # @!attribute [r] parsed_error
+  # @!attribute [r] stderr_lines
   #   @return [Array] An array of error strings received from the terminals STDERR pipe
-  attr_reader :parsed_errors
+  attr_reader :stderr_lines
 
   # @!attribute [r] last_exit_code
-  #   @return [Number] The exit code of the last terminal command
+  #   @return [Number, nil] The exit code of the last terminal command
   attr_reader :last_exit_code
 
   # @!attribute [r] pid
-  #   @return [Number] The PID of the running terminal
+  #   @return [Number, nil] The PID of the running terminal
   attr_reader :pid
 
   # @!attribute [r] current_buffer
@@ -25,40 +27,45 @@ class InteractiveCLI
   # Creates an InteractiveCLI instance
   #
   # @param environment [Hash] A hash of environment variables
-  # @param terminal [String] A path to the terminal to run, defaults to `/bin/sh`
-  # @param terminal [String] The stop command, defaults to `exit`
-  def initialize(environment = {}, terminal = '/bin/sh', stop_command = 'exit')
+  # @param shell [String] A path to the shell to run, defaults to `/bin/sh`
+  # @param stop_command [String] The stop command, defaults to `exit`
+  def initialize(environment = {}, shell = '/bin/sh', stop_command = 'exit')
+    @shell = shell
     @env = environment
-    @parsed_output = []
-    @parsed_errors = []
+    @stdout_lines = []
+    @stderr_lines = []
     @current_buffer = ''
     @last_exit_code = nil
     @in_stream = nil
     @pid = nil
     @running = false
     @stop_command = stop_command
-    start_threaded_terminal(terminal)
+    start_threaded_shell(shell)
   end
 
-  # Attempts to stop the terminal using the preset command
+  def start(threaded = true)
+    threaded ? start_threaded_shell(@shell) : start_shell(@shell)
+  end
+
+  # Attempts to stop the shell using the preset command
   #
-  # @return [Boolean] true if successful, false otherwise
+  # @return [Boolean] true if the command is executed, false otherwise
   def stop
     run_command(@stop_command)
   end
 
-  # Returns whether the terminal is running by verifying the in_stream exists and is open
+  # Returns whether the shell is running by verifying the in_stream exists and is open
   #
   # @return [Boolean] Whether the stream is currently running
   def running
     !(@in_stream.nil? || @in_stream.closed?)
   end
 
-  # Runs the given command if the terminal is running
+  # Runs the given command if the shell is running
   #
   # @param command [String] The command to run
   #
-  # @return [Boolean] true if successful, false otherwise
+  # @return [Boolean] true if the command is executed, false otherwise
   def run_command(command)
     return false unless running
     @in_stream.puts(command)
@@ -67,31 +74,30 @@ class InteractiveCLI
 
   private
 
-  # Starts a terminal on another thread
+  # Starts a shell on another thread
   #
-  # @param terminal [String] A path to the terminal to run
-  def start_threaded_terminal(terminal)
+  # @param shell [String] A path to the shell to run
+  def start_threaded_shell(shell)
     executor = lambda do
-      start_terminal(terminal)
+      start_shell(shell)
     end
 
-    Thread.new &executor
+    @thread = Thread.new &executor
   end
 
-  # Starts a terminal
+  # Starts a shell
   #
-  # @param terminal [String] A path to the terminal to run
-  def start_terminal(terminal)
-    Open3.popen3(@env, terminal) do |stdin, stdout, stderr, wait_thr|
+  # @param shell [String] A path to the shell to run
+  def start_shell(shell)
+    Open3.popen3(@env, shell) do |stdin, stdout, stderr, wait_thr|
       @pid = wait_thr.pid
-      $logger.debug(pid) { 'Starting terminal session' }
+      $logger.debug(pid) { "Starting shell session: #{shell}" }
 
       @in_stream = stdin
-      @out_stream = stdout
 
       stdout.each_char do |char|
         if char == "\n"
-          @parsed_output << parse_terminal_line(@current_buffer)
+          @stdout_lines << format_line(@current_buffer)
           $logger.debug(pid) { current_buffer }
           @current_buffer.clear
         else
@@ -100,7 +106,7 @@ class InteractiveCLI
       end
 
       stderr.each do |line|
-        @parsed_errors << parse_terminal_line(line)
+        @stderr_lines << format_line(line)
         $logger.debug(pid) { line }
       end
 
@@ -110,8 +116,8 @@ class InteractiveCLI
     end
   end
 
-  # Strips whitespace from terminal lines, can be used to sanitize further if required
-  def parse_terminal_line(line)
+  # Strips whitespace from shell lines, can be used to sanitize further if required
+  def format_line(line)
     line.strip
   end
 end

--- a/lib/features/support/interactive_cli.rb
+++ b/lib/features/support/interactive_cli.rb
@@ -18,6 +18,7 @@ class InteractiveCLI
   #   @return [Number] The PID of the running terminal
   attr_reader :pid
 
+  attr_reader :current_buffer
   # Creates an InteractiveCLI instance
   #
   # @param environment [Hash] A hash of environment variables
@@ -27,6 +28,7 @@ class InteractiveCLI
     @env = environment
     @parsed_output = []
     @parsed_errors = []
+    @current_buffer = ''
     @last_exit_code = nil
     @running = false
     @stop_command = stop_command
@@ -70,9 +72,16 @@ class InteractiveCLI
         $logger.debug(pid) { 'Starting terminal session' }
 
         @in_stream = stdin
-        stdout.each do |line|
-          @parsed_output << parse_terminal_line(line)
-          $logger.debug(pid) { line }
+        @out_stream = stdout
+
+        stdout.each_char do |char|
+          if char == "\n"
+            @parsed_output << parse_terminal_line(@current_buffer)
+            $logger.debug(pid) { current_buffer }
+            @current_buffer.clear
+          else
+            @current_buffer << char
+          end
         end
 
         stderr.each do |line|

--- a/lib/features/support/interactive_cli.rb
+++ b/lib/features/support/interactive_cli.rb
@@ -1,0 +1,95 @@
+require 'open3'
+
+# Encapsulates a terminal session, retaining state and input streams for interactive tests
+class InteractiveCLI
+  # @!attribute [r] parsed_output
+  #   @return [Array] An array of output strings received from the terminals STDOUT pipe
+  attr_reader :parsed_output
+
+  # @!attribute [r] parsed_error
+  #   @return [Array] An array of error strings received from the terminals STDERR pipe
+  attr_reader :parsed_errors
+
+  # @!attribute [r] last_exit_code
+  #   @return [Number] The exit code of the last terminal command
+  attr_reader :last_exit_code
+
+  # @!attribute [r] pid
+  #   @return [Number] The PID of the running terminal
+  attr_reader :pid
+
+  # Creates an InteractiveCLI instance
+  #
+  # @param environment [Hash] A hash of environment variables
+  # @param terminal [String] A path to the terminal to run, defaults to `/bin/sh`
+  # @param terminal [String] The stop command, defaults to `exit`
+  def initialize(environment = {}, terminal = '/bin/sh', stop_command = 'exit')
+    @env = environment
+    @parsed_output = []
+    @parsed_errors = []
+    @last_exit_code = nil
+    @running = false
+    @stop_command = stop_command
+    start_terminal(terminal)
+  end
+
+  # Attempts to stop the terminal using the preset command
+  #
+  # @return [Boolean] true if successful, false otherwise
+  def stop
+    run_command(@stop_command)
+  end
+
+  # Returns whether the terminal is running by verifying the in_stream exists and is open
+  #
+  # @return [Boolean] Whether the stream is currently running
+  def running
+    @in_stream && !@in_stream.closed?
+  end
+
+  # Runs the given command if the terminal is running
+  #
+  # @param command [String] The command to run
+  #
+  # @return [Boolean] true if successful, false otherwise
+  def run_command(command)
+    return false unless running
+    @in_stream.puts(command)
+    true
+  end
+
+  private
+
+  # Starts a terminal on another thread
+  #
+  # @param terminal [String] A path to the terminal to run
+  def start_terminal(terminal)
+    executor = lambda do
+      Open3.popen3(@env, terminal) do |stdin, stdout, stderr, wait_thr|
+        @pid = wait_thr.pid
+        $logger.debug(pid) { 'Starting terminal session' }
+
+        @in_stream = stdin
+        stdout.each do |line|
+          @parsed_output << parse_terminal_line(line)
+          $logger.debug(pid) { line }
+        end
+
+        stderr.each do |line|
+          @parsed_errors << parse_terminal_line(line)
+          $logger.debug(pid) { line }
+        end
+
+        exit_status = wait_thr.value.to_i
+        @last_exit_code = exit_status
+        $logger.debug(pid) { "exit status: #{exit_status}" }
+      end
+    end
+    Thread.new &executor
+  end
+
+  # Strips whitespace from terminal lines, can be used to sanitize further if required
+  def parse_terminal_line(line)
+    line.strip
+  end
+end

--- a/lib/features/support/interactive_cli.rb
+++ b/lib/features/support/interactive_cli.rb
@@ -98,7 +98,7 @@ class InteractiveCLI
       stdout.each_char do |char|
         if char == "\n"
           @stdout_lines << format_line(@current_buffer)
-          $logger.debug(pid) { current_buffer }
+          $logger.debug(pid) { @current_buffer }
           @current_buffer.clear
         else
           @current_buffer << char

--- a/lib/features/support/interactive_cli.rb
+++ b/lib/features/support/interactive_cli.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'open3'
 
 # Encapsulates a shell session, retaining state and input streams for interactive tests

--- a/lib/features/support/runner.rb
+++ b/lib/features/support/runner.rb
@@ -79,13 +79,17 @@ class Runner
 
     # Stops the interactive session, allowing a new one to be started
     def stop_interactive_session
-      @interactive_session.stop
-      @interactive_session = nil
+      if @interactive_session && @interactive_session.running
+        @interactive_session.stop
+        # Make sure the process is properly ended
+        pids << @interactive_session.pid
+        @interactive_session = nil
+      end
     end
 
     # Stops all script processes previously started by this class.
     def kill_running_scripts
-      pids << @interactive_session.pid if @interactive_session && @interactive_session.running
+      stop_interactive_session
       pids.each {|p|
         begin
           Process.kill("KILL", p)

--- a/lib/features/support/runner.rb
+++ b/lib/features/support/runner.rb
@@ -75,16 +75,22 @@ class Runner
     # @return [InteractiveCLI] The interactiveCLI instance
     def get_interactive_session
       @interactive_session ||= InteractiveCLI.new(environment)
+      attempts = 0
+      until @interactive_session.pid
+        raise "Shell session would not start within 3 seconds" if attempts > 10 # allows 3 seconds of opening
+        attempts += 1
+        sleep(0.3)
+      end
+      @interactive_cli
     end
 
     # Stops the interactive session, allowing a new one to be started
     def stop_interactive_session
-      if @interactive_session && @interactive_session.running
-        @interactive_session.stop
-        # Make sure the process is properly ended
-        pids << @interactive_session.pid
-        @interactive_session = nil
-      end
+      return unless @interactive_session&.running
+      @interactive_session.stop
+      # Make sure the process is properly ended
+      pids << @interactive_session.pid
+      @interactive_session = nil
     end
 
     # Stops all script processes previously started by this class.

--- a/lib/features/support/runner.rb
+++ b/lib/features/support/runner.rb
@@ -81,7 +81,7 @@ class Runner
         attempts += 1
         sleep(0.3)
       end
-      @interactive_cli
+      @interactive_session
     end
 
     # Stops the interactive session, allowing a new one to be started

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../lib/features/support/interactive_cli'
+
+class InteractiveCLITest < Test::Unit::TestCase
+  def setup
+    @capabilities = { key: 'value' }
+
+    ENV.delete('BRANCH_NAME')
+    ENV.delete('BUILDKITE')
+    ENV.delete('BUILDKITE_PIPELINE_NAME')
+    ENV.delete('BUILDKITE_BUILD_NUMBER')
+    ENV.delete('BUILDKITE_RETRY_COUNT')
+    ENV.delete('BUILDKITE_STEP_KEY')
+  end
+
+  def start_logger_mock
+    logger_mock = mock('logger')
+    $logger = logger_mock
+    logger_mock.stubs(:debug)
+    logger_mock
+  end
+
+  def test_default_initialization
+    start_logger_mock
+
+    # Capture and prevent the terminal starting on a secondary thread
+    InteractiveCLI.any_instance.expects(:start_threaded_terminal).with('/bin/sh')
+
+    # Create the cli and verify class variables
+    cli = InteractiveCLI.new
+    assert_equal(cli.parsed_output, [])
+    assert_equal(cli.parsed_errors, [])
+    assert_equal(cli.instance_variable_get(:@env), {})
+    assert_equal(cli.instance_variable_get(:@stop_command), 'exit')
+    assert_nil(cli.last_exit_code)
+    assert_nil(cli.pid)
+    assert_equal(cli.current_buffer, '')
+    assert_false(cli.running)
+    assert_false(cli.run_command('foo'))
+    assert_false(cli.stop)
+
+    Open3.expects(:popen3).with({}, '/bin/sh')
+    cli.send(:start_terminal, '/bin/sh')
+  end
+
+  def test_overridden_initialization
+    start_logger_mock
+    new_terminal_cmd = '/bin/zsh'
+    environment = {
+      'foo': 'bar'
+    }
+    stop_command = 'stop_me_please'
+
+    # Capture and prevent the terminal starting on a secondary thread
+    InteractiveCLI.any_instance.expects(:start_threaded_terminal).with(new_terminal_cmd)
+
+    # Create the cli and verify class variables
+    cli = InteractiveCLI.new(environment, new_terminal_cmd, stop_command)
+    assert_equal(cli.parsed_output, [])
+    assert_equal(cli.parsed_errors, [])
+    assert_equal(cli.instance_variable_get(:@env), environment)
+    assert_equal(cli.instance_variable_get(:@stop_command), stop_command)
+    assert_nil(cli.last_exit_code)
+    assert_nil(cli.pid)
+    assert_equal(cli.current_buffer, '')
+    assert_false(cli.running)
+    assert_false(cli.run_command('foo'))
+    assert_false(cli.stop)
+
+    Open3.expects(:popen3).with(environment, new_terminal_cmd)
+    # Bypass the `private` modifier to call the start terminal method directly
+    cli.send(:start_terminal, new_terminal_cmd)
+  end
+end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -29,7 +29,6 @@ class InteractiveCLITest < Test::Unit::TestCase
     assert_equal(cli.current_buffer, '')
     assert_false(cli.running)
     assert_false(cli.run_command('foo'))
-    assert_false(cli.stop)
 
     Open3.expects(:popen3).with({}, '/bin/sh')
     cli.send(:start_shell, '/bin/sh')
@@ -57,7 +56,6 @@ class InteractiveCLITest < Test::Unit::TestCase
     assert_equal(cli.current_buffer, '')
     assert_false(cli.running)
     assert_false(cli.run_command('foo'))
-    assert_false(cli.stop)
 
     Open3.expects(:popen3).with(environment, new_shell_cmd)
     # Bypass the `private` modifier to call the start shell method directly

--- a/test/fixtures/cli/Gemfile
+++ b/test/fixtures/cli/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'bugsnag-maze-runner', path: '../../..'
+gem 'pry'

--- a/test/fixtures/cli/features/CLI.feature
+++ b/test/fixtures/cli/features/CLI.feature
@@ -1,24 +1,22 @@
 Feature: Interactive CLI support
 
   Scenario: Supports a node script
-    Given I start a new terminal
-    And I wait for 2 seconds
+    Given I start a new shell
     When I input "./features/fixtures/node_script" interactively
     And I wait for 2 seconds
-    Then the terminal has output "Starting node script"
-    And the terminal is outputting "Repeat 5 times "
+    Then the shell has output "Starting node script" to stdout
+    And the current stdout line is "Repeat 5 times "
     When I input "A" interactively
-    And I wait for 2 seconds
-    Then the terminal has output "Repeat 5 times AAAAA"
+    And I wait for 1 seconds
+    Then the shell has output "Repeat 5 times AAAAA" to stdout
 
   Scenario: Allows reading of errors
-    Given I start a new terminal
-    And I wait for 2 seconds
+    Given I start a new shell
     When I input "./features/fixtures/error_script" interactively
     And I wait for 2 seconds
-    Then the terminal has output "Starting error script"
-    And the terminal is outputting "Input anything to error "
+    Then the shell has output "Starting error script" to stdout
+    And the current stdout line is "Input anything to error "
     When I input "A" interactively
-    And I wait for 2 seconds
-    Then the terminal exited with an error code
-    And the terminal has the error message "Oh no it's all gone wrong"
+    And I wait for 1 seconds
+    Then the shell exited with an error code
+    And the shell has output "Error: Oh no it's all gone wrong" to stderr

--- a/test/fixtures/cli/features/CLI.feature
+++ b/test/fixtures/cli/features/CLI.feature
@@ -1,0 +1,24 @@
+Feature: Interactive CLI support
+
+  Scenario: Supports a node script
+    Given I start a new terminal
+    And I wait for 2 seconds
+    When I input "./features/fixtures/node_script" interactively
+    And I wait for 2 seconds
+    Then the terminal has output "Starting node script"
+    And the terminal is outputting "Repeat 5 times "
+    When I input "A" interactively
+    And I wait for 2 seconds
+    Then the terminal has output "Repeat 5 times AAAAA"
+
+  Scenario: Allows reading of errors
+    Given I start a new terminal
+    And I wait for 2 seconds
+    When I input "./features/fixtures/error_script" interactively
+    And I wait for 2 seconds
+    Then the terminal has output "Starting error script"
+    And the terminal is outputting "Input anything to error "
+    When I input "A" interactively
+    And I wait for 2 seconds
+    Then the terminal exited with an error code
+    And the terminal has the error message "Oh no it's all gone wrong"

--- a/test/fixtures/cli/features/fixtures/error_script
+++ b/test/fixtures/cli/features/fixtures/error_script
@@ -9,5 +9,5 @@ const rl = readline.createInterface({
 })
 
 rl.question("Input anything to error ", function(repeater) {
-    throw("Oh no it's all gone wrong")
+    throw new Error("Oh no it's all gone wrong")
 })

--- a/test/fixtures/cli/features/fixtures/error_script
+++ b/test/fixtures/cli/features/fixtures/error_script
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+console.log("Starting error script")
+
+const readline = require("readline")
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+})
+
+rl.question("Input anything to error ", function(repeater) {
+    throw("Oh no it's all gone wrong")
+})

--- a/test/fixtures/cli/features/fixtures/node_script
+++ b/test/fixtures/cli/features/fixtures/node_script
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+console.log("Starting node script")
+
+const readline = require("readline")
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+})
+
+rl.question("Repeat 5 times ", function(repeater) {
+    console.log(repeater + repeater + repeater + repeater + repeater)
+    rl.close()
+})

--- a/test/integration/automation_test.rb
+++ b/test/integration/automation_test.rb
@@ -27,6 +27,10 @@ class SampleTest < Test::Unit::TestCase
     run_scenario("test/fixtures/comparison")
   end
 
+  def test_interactive_cli
+    run_scenario("test/fixtures/cli")
+  end
+
   def test_init_command
     fixture_dir = "test/fixtures/init-test"
     FileUtils.rm_rf fixture_dir


### PR DESCRIPTION
## Goal

Adds a way to interact with a terminal, sending commands and verifying output.  This will enable testing of CLIs (such as the upcoming React-native CLI)

## Design

The `InteractiveCLI` instance will act as a single terminal run, storing the parsed STDOUT and STDERR streams to be tested against.
This will be accessible through the `Runner` class, ensuring only one terminal is running at any given time. While this terminal is running it won't be possible to start another one without explicitly stopping it.

## Tests

Covered by basic unit and e2e tests so far, but more will follow in subsequent PRs as part of the ongoing work.
