### PR TITLE
Do not clear environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.0.2 - 2020/10/21
+
+## Fixes
+
+- Do not clear environment between scenarios (introduced in v2.6.0).
+  [#149](https://github.com/bugsnag/maze-runner/pull/149)
+
 # 3.0.1 - 2020/10/20
 
 ## Fixes
@@ -49,7 +56,7 @@
 
 ## Fixes
 
-- Clear environment as start of scenarios
+- Clear environment at start of scenarios
   [#130](https://github.com/bugsnag/maze-runner/pull/130)
 
 # 2.5.0 - 2020/09/11

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (3.0.1)
+    bugsnag-maze-runner (3.0.2)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -59,7 +59,9 @@ end
 # Before each scenario
 Before do |scenario|
   STDOUT.puts "--- Scenario: #{scenario.name}"
-  Runner.environment.clear
+  # TODO: PLAT-5309 - Building a clear environment for each scenario into MazeRunner would be a good
+  #   thing, but a number of our pipelines rely on certain variables existing throughout (e.g. Ruby).
+  # Runner.environment.clear
   Server.stored_requests.clear
   Store.values.clear
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '3.0.1'.freeze
+  VERSION = '3.0.2'.freeze
 end


### PR DESCRIPTION
## Goal

Do not clear all environment variables between scenarios.

## Design

A change was added towards the end of v2, in response to failures in the Bugsnag Anddroid Gradle Plugin pipeline caused by environment variables being carried across from one scenario to the next.  Whilst a good change in theory, it unfortunately broke the Ruby (and perhaps other) pipeline, as it relies on environment variables for the Ruby test version, etc.

As BAGP is still on v2, I have therefore simply removing the clearing for now and have raised an internal ticket to reintroduce it with more configurability, which in turn is linked to a ticket for updating the BAGP pipeline to v3.

## Changeset

Before scenario Cucumber hook.

## Tests

Passing CI and we have separately verified that the change fixes the issues in the Ruby pipeline.
