### PR TITLE
Preserve released Docker image and round off v2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -129,40 +129,10 @@ steps:
 
   - wait
 
-  - label: 'Trigger Android build against new master'
-    branches: 'master'
-    trigger: 'android-bugsnag-notifier'
-    build:
-      branch: 'maze-runner-master'
-    async: true
-
-  - label: 'Trigger Cocoa build against new master'
-    branches: 'master'
-    trigger: 'cocoa-bugsnag-notifier'
-    build:
-      branch: 'maze-runner-master'
-    async: true
-
-  - label: 'Trigger JS build against new master'
-    branches: 'master'
-    trigger: 'at-bugsnag-js'
-    build:
-      branch: 'maze-runner-master'
-    async: true
-
-  - label: 'Update docs'
-    if: build.tag =~ /^v[2-9]\.[0-9]+\.[0-9]+\$/
-    plugins:
-      docker-compose#v3.3.0:
-        run: docs
-    command: 'bundle exec rake docs:build_and_publish'
-
   - label: 'Push Docker image for tag'
     if: build.tag =~ /^v[2-9]\.[0-9]+\.[0-9]+\$/
     plugins:
       - docker-compose#v3.3.0:
           push:
-            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BUILDKITE_TAG}-cli
-            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli
-            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli
-
+            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:${BUILDKITE_TAG}-cli
+            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.7.1 - 2020/10/21
+
+## Fixes
+
+- Push released Docker images to separate repository to avoid loss
+  [#149](https://github.com/bugsnag/maze-runner/pull/149)
+
 # 2.7.0 - 2020/09/30
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (2.7.0)
+    bugsnag-maze-runner (2.7.1)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '2.7.0'.freeze
+  VERSION = '2.7.1'.freeze
 end


### PR DESCRIPTION
## Goal

Push the released Docker image to a separate ECR repository so that it doesn't get removed over time.

## Design

I have also removed the build steps relating to merges into `master` and publishing of docs, as v3 now overtakes that.  v2 will now only live on the `v2` branch.

## Changeset

Pipeline steps.

## Tests

Covered by passing CI and subsequent verification that our notifier pipelines continue to work.