### PR TITLE
Re-add and fix OS version CL option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.0.3 - 2020/10/26
+
+- Roll in OS version changes from [#145](https://github.com/bugsnag/maze-runner/pull/145) somehow lost by Git/hub
+  [#150](https://github.com/bugsnag/maze-runner/pull/150)
+
 # 3.0.2 - 2020/10/21
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (3.0.2)
+    bugsnag-maze-runner (3.0.3)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -8,13 +8,16 @@ require_relative '../lib/features/support/capabilities/capabilities'
 require_relative '../lib/version'
 
 # Encapsulates the MazeRunner entry point
+#
 # TODO: Factor out CL options/processing to reduce overall size
 class MazeRunnerEntry
   OPTION_SEPARATE_SESSIONS = 'separate-sessions'
   OPTION_APP = 'app'
   OPTION_BS_LOCAL = 'bs-local'
   OPTION_FARM = 'farm'
-  OPTION_DEVICE = 'device'
+  OPTION_BS_DEVICE = 'device'
+  OPTION_OS = 'os'
+  OPTION_OS_VERSION = 'os-version'
   OPTION_USERNAME = 'username'
   OPTION_ACCESS_KEY = 'access-key'
   OPTION_APPIUM_SERVER = 'appium-server'
@@ -33,7 +36,8 @@ class MazeRunnerEntry
       opt :init, 'Initialises a new Maze Runner project'
 
       opt :version, 'Display Maze Runner and Cucumber versions'
-      opt OPTION_SEPARATE_SESSIONS, 'Start a new Appium session for each scenario',
+      opt OPTION_SEPARATE_SESSIONS,
+          'Start a new Appium session for each scenario',
           short: :none,
           type: :boolean,
           default: false
@@ -44,8 +48,16 @@ class MazeRunnerEntry
           type: :string,
           default: '/BrowserStackLocal'
       opt OPTION_FARM, 'Device farm to use: "bs" (BrowserStack) or "local"', short: :none, type: :string
-      opt OPTION_DEVICE,
-          'Device type to use ("ios", "android" or a Devices.DEVICE_HASH key)',
+      opt OPTION_BS_DEVICE,
+          'BrowserStack device to use (a key of Devices.DEVICE_HASH)',
+          short: :none,
+          type: :string
+      opt OPTION_OS,
+          'OS type to use ("ios", "android")',
+          short: :none,
+          type: :string
+      opt OPTION_OS_VERSION,
+          'The intended OS version when running on a local device',
           short: :none,
           type: :string
       opt OPTION_APPLE_TEAM_ID, 'Apple Team Id, required for local iOS testing', short: :none, type: :string
@@ -80,7 +92,9 @@ class MazeRunnerEntry
       OPTION_SEPARATE_SESSIONS,
       OPTION_APP,
       OPTION_BS_LOCAL,
-      OPTION_DEVICE,
+      OPTION_BS_DEVICE,
+      OPTION_OS,
+      OPTION_OS_VERSION,
       OPTION_FARM,
       OPTION_USERNAME,
       OPTION_ACCESS_KEY,
@@ -124,11 +138,10 @@ class MazeRunnerEntry
 
     # Process CL options
     init if options[:init]
-    config = MazeRunner.configuration
+    config = MazeRunner.config
     config.appium_session_isolation = options[OPTION_SEPARATE_SESSIONS]
     config.app_location = options[OPTION_APP]
     farm = options[OPTION_FARM]
-    device_type = config.device_type = options[OPTION_DEVICE]
     config.farm = case farm
                   when nil then :none
                   when 'bs' then :bs
@@ -142,20 +155,34 @@ class MazeRunnerEntry
     when :bs then
       raise "option --#{OPTION_USERNAME} must be specified" if options[OPTION_USERNAME].nil?
       raise "option --#{OPTION_ACCESS_KEY} must be specified" if options[OPTION_ACCESS_KEY].nil?
-      unless Devices::DEVICE_HASH.key? device_type
-        raise "Device type '#{device}' not known on BrowserStack.  Must be one of #{Devices::DEVICE_HASH.keys}"
+
+      bs_device = options[OPTION_BS_DEVICE]
+      raise "option --#{OPTION_BS_DEVICE} must be specified" if bs_device.nil?
+      unless Devices::DEVICE_HASH.key? bs_device
+        raise "Device type '#{bs_device}' not known on BrowserStack.  Must be one of #{Devices::DEVICE_HASH.keys}"
       end
 
+      config.bs_device = bs_device
+      config.os_version = Devices::DEVICE_HASH[config.bs_device]['os_version'].to_f
       config.bs_local = options[OPTION_BS_LOCAL]
       username = config.username = options[OPTION_USERNAME]
       access_key = config.access_key = options[OPTION_ACCESS_KEY]
       config.appium_server_url = "http://#{username}:#{access_key}@hub-cloud.browserstack.com/wd/hub"
     when :local then
-      config.appium_server_url = options[OPTION_APPIUM_SERVER]
-      device_type = device_type.downcase
-      raise 'device must be ios or android' unless %w[ios android].include? device_type
+      raise "option --#{OPTION_OS} must be specified" if options[OPTION_OS].nil?
+      raise "option --#{OPTION_OS_VERSION} must be specified" if options[OPTION_OS_VERSION].nil?
+      # Ensure OS version is a valid float so that notifier tests can perform numeric checks, e.g:
+      # 'MazeRunner.config.os_version > 7'
+      unless /^[1-9][0-9]*(\.[0-9])?/.match? options[OPTION_OS_VERSION]
+        raise "option --#{OPTION_OS_VERSION} must be a valid OS version matching '/^[1-9][0-9]*(\\.[0-9])?/'"
+      end
 
-      if device_type == 'ios'
+      os = options[OPTION_OS].downcase
+      MazeRunner.config.os_version = options[OPTION_OS_VERSION].to_f
+      raise 'os must be ios or android' unless %w[ios android].include? os
+
+      config.appium_server_url = options[OPTION_APPIUM_SERVER]
+      if os == 'ios'
         raise 'option --apple-team-id must be specified for iOS' if options[OPTION_APPLE_TEAM_ID].nil?
         raise 'option --udid must be specified for iOS' if options[OPTION_UDID].nil?
 

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -177,7 +177,7 @@ class MazeRunnerEntry
         raise "option --#{OPTION_OS_VERSION} must be a valid OS version matching '/^[1-9][0-9]*(\\.[0-9])?/'"
       end
 
-      os = options[OPTION_OS].downcase
+      os = MazeRunner.config.os = options[OPTION_OS].downcase
       MazeRunner.config.os_version = options[OPTION_OS_VERSION].to_f
       raise 'os must be ios or android' unless %w[ios android].include? os
 

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -8,7 +8,7 @@ AfterConfiguration do |config|
 
   # Start mock server
   Server.start_server
-  config = MazeRunner.configuration
+  config = MazeRunner.config
   next if config.farm == :none
 
   # Setup Appium capabilities.  Note that the 'app' capability is
@@ -17,7 +17,7 @@ AfterConfiguration do |config|
   # BrowserStack specific setup
   if config.farm == :bs
     tunnel_id = SecureRandom.uuid
-    config.capabilities = Capabilities.for_browser_stack config.device_type,
+    config.capabilities = Capabilities.for_browser_stack config.bs_device,
                                                          tunnel_id
 
     config.app_location = BrowserStackUtils.upload_app config.username,
@@ -27,7 +27,7 @@ AfterConfiguration do |config|
                                          tunnel_id,
                                          config.access_key
   elsif config.farm == :local
-    config.capabilities = Capabilities.for_local config.device_type,
+    config.capabilities = Capabilities.for_local config.os,
                                                  config.apple_team_id,
                                                  config.device_id
   end
@@ -44,16 +44,6 @@ AfterConfiguration do |config|
     $logger.info LogUtil.linkify url, 'BrowserStack session(s)'
   end
   MazeRunner.driver.start_driver unless config.appium_session_isolation
-
-  # TODO: We need to get hold of OS version (or API level) of the actual device that is used.  We used to take this from
-  #   the DEVICE_TYPE provided, but with local device use you can just ask for "iOS" and it will use whatever you have
-  #   plugged in.
-  #   One of these seems to only work on BrowserStack and the other only locally - further investigation needed.
-  # puts "Actual driver capabilities #{MazeRunner.driver.capabilities}"
-  # puts 'Device info:'
-  # puts JSON.pretty_generate MazeRunner.driver.device_info
-  # puts 'Session capabilities:'
-  # puts JSON.pretty_generate MazeRunner.driver.session_capabilities
 end
 
 # Before each scenario
@@ -65,9 +55,9 @@ Before do |scenario|
   Server.stored_requests.clear
   Store.values.clear
 
-  next if MazeRunner.configuration.farm == :none
+  next if MazeRunner.config.farm == :none
 
-  MazeRunner.driver.start_driver if MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.start_driver if MazeRunner.config.appium_session_isolation
 end
 
 # After each scenario
@@ -99,9 +89,9 @@ After do |scenario|
     end
   end
 
-  next if MazeRunner.configuration.farm == :none
+  next if MazeRunner.config.farm == :none
 
-  if MazeRunner.configuration.appium_session_isolation
+  if MazeRunner.config.appium_session_isolation
     MazeRunner.driver.driver_quit
   else
     MazeRunner.driver.reset_with_timeout 2
@@ -118,9 +108,9 @@ at_exit do
   # future test runs are from a clean slate.
   Docker.down_all_services
 
-  next if MazeRunner.configuration.farm == :none
+  next if MazeRunner.config.farm == :none
 
   # Stop the Appium session
-  MazeRunner.driver.driver_quit unless MazeRunner.configuration.appium_session_isolation
+  MazeRunner.driver.driver_quit unless MazeRunner.config.appium_session_isolation
 end
 

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -136,7 +136,7 @@ end
 def get_expected_platform_value(platform_values)
   raise('This step should only be used when running tests with Appium') if MazeRunner.driver.nil?
 
-  os = MazeRunner.configuration.capabilities['os']
+  os = MazeRunner.config.capabilities['os']
   expected_value = Hash[platform_values.raw][os]
   raise("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
 

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -23,8 +23,11 @@ class Configuration
   # Apple Team Id
   attr_accessor :apple_team_id
 
-  # Device type
-  attr_accessor :device_type
+  # BrowserStack device type
+  attr_accessor :bs_device
+
+  # OS version
+  attr_accessor :os_version
 
   # Device id for running on local iOS devices
   attr_accessor :device_id

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -26,6 +26,9 @@ class Configuration
   # BrowserStack device type
   attr_accessor :bs_device
 
+  # OS
+  attr_accessor :os
+
   # OS version
   attr_accessor :os_version
 

--- a/lib/features/support/maze_runner.rb
+++ b/lib/features/support/maze_runner.rb
@@ -7,8 +7,8 @@ require_relative './configuration'
 class MazeRunner
   class << self
     attr_accessor :driver
-    def configuration
-      @configuration ||= Configuration.new
+    def config
+      @config ||= Configuration.new
     end
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.0.3'.freeze
 end

--- a/test/capabilities/devices_test.rb
+++ b/test/capabilities/devices_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../../lib/features/support/capabilities/devices'
+
+class DevicesTest < Test::Unit::TestCase
+
+  def test_os_version
+    # Ensure that every entry in the hash has a meaningful OS version
+    Devices::DEVICE_HASH.each do |key, value|
+      os_version = value['os_version']
+      regex = /^[1-9][0-9]*(\.[0-9])?/
+      assert_match(regex, os_version)
+    end
+  end
+end


### PR DESCRIPTION
## Background

This change re-applies and builds upon #145, where something very strange happened at some point post PR approval.  If you look at that PR, you can see comments on files that no longer show in the diff.  It appears that the bulk of the commits were lost from the PR somehow (perhaps, but only speculation, because #145 itself was a representation of #142 AND involved a revert PR!).  

As it transpires, the changes in #145 were not complete anyway and needed fixing for local run mode.  Basically it was a right mess, so this is a completely fresh branch manually recreating the changes necessary.  The following sections are from the original PR.

## Goal

Ensure that an intended OS version is provided, which is needed by notifier tests in order to know when annotated scenarios should be skipped.

## Design

I was hoping to extract the actual OS (or at least API) version from the device using Appium, but it doesn't seem to be possible to do this with both iOS and Android both locally and on BrowserStack.  I've therefore settled for ensuring that the intended OS version is specified (which is what we've been doing on BrowserStack all along, so it's not a regression in that respect).

I've started a new branch to move the CL option parsing into a separate file, which I'll raise a PR for in itself.  

## Changeset

CL option processing and device/OS configuration.

## Tests

New unit test added to ensure that the `DEVICE_HASH` always contents a float-like OS version.  For now I have informally tested use of the command line options locally, as further testing will be performed before we commit our notifiers to using the new major release.  However, the command line processing now warrants its own set of unit tests, which will be added as part of the forthcoming refactor mentioned above.
