### PR TITLE
Allow elements to be located by accessibility id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
+# 3.1.0 - TBD
+
+## Enhancements
+
+- Provide ability to locate elements by accessibility id
+  [#151](https://github.com/bugsnag/maze-runner/pull/151)
+
 # 3.0.3 - 2020/10/26
+
+## Fixes
 
 - Roll in OS version changes from [#145](https://github.com/bugsnag/maze-runner/pull/145) somehow lost by Git/hub
   [#150](https://github.com/bugsnag/maze-runner/pull/150)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (3.0.3)
+    bugsnag-maze-runner (3.1.0)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -21,6 +21,7 @@ class MazeRunnerEntry
   OPTION_USERNAME = 'username'
   OPTION_ACCESS_KEY = 'access-key'
   OPTION_APPIUM_SERVER = 'appium-server'
+  OPTION_A11Y_LOCATOR = 'a11y-locator'
   OPTION_APPLE_TEAM_ID = 'apple-team-id'
   OPTION_UDID = 'udid'
 
@@ -69,6 +70,11 @@ class MazeRunnerEntry
           short: :none,
           type: :string,
           default: 'http://localhost:4723/wd/hub'
+      opt OPTION_A11Y_LOCATOR,
+          'Locate elements by accessibility id rather than id',
+          short: :none,
+          type: :boolean,
+          default: false
 
       version "Maze Runner v#{BugsnagMazeRunner::VERSION} " \
               "(Cucumber v#{Cucumber::VERSION.strip})"
@@ -99,6 +105,7 @@ class MazeRunnerEntry
       OPTION_USERNAME,
       OPTION_ACCESS_KEY,
       OPTION_APPIUM_SERVER,
+      OPTION_A11Y_LOCATOR,
       OPTION_UDID,
       OPTION_APPLE_TEAM_ID
     ]
@@ -149,6 +156,7 @@ class MazeRunnerEntry
                   else
                     raise "Unknown farm '#{farm}'"
                   end
+    config.locator = options[OPTION_A11Y_LOCATOR] ? :accessibility_id : :id
 
     # Farm specific options
     case config.farm

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -34,9 +34,10 @@ AfterConfiguration do |config|
   # Set app location (file or url) in capabilities
   config.capabilities['app'] = config.app_location
 
-  # Create and start the drive
+  # Create and start the driver
   MazeRunner.driver = ResilientAppiumDriver.new config.appium_server_url,
-                                                config.capabilities
+                                                config.capabilities,
+                                                config.locator
   if config.farm == :bs
     # Log a link to the BrowserStack session search dashboard
     build = MazeRunner.driver.caps[:build]

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -38,6 +38,9 @@ class Configuration
   # URL of the Appium server
   attr_accessor :appium_server_url
 
+  # Element locator strategy, :id or :accessibility_id
+  attr_accessor :locator
+
   # Appium capabilities
   attr_accessor :capabilities
 

--- a/lib/features/support/resilient_driver.rb
+++ b/lib/features/support/resilient_driver.rb
@@ -11,9 +11,11 @@ class ResilientAppiumDriver
   #
   # @param server_url [String] URL of the Appium server
   # @param capabilities [Hash] a hash of capabilities to be used in this test run
-  def initialize(server_url, capabilities)
+  # @param locator [Symbol] the primary locator strategy Appium should use to find elements
+  def initialize(server_url, capabilities, locator = :id)
     @driver = AppiumDriver.new server_url,
-                               capabilities
+                               capabilities,
+                               locator
   end
 
   def respond_to_missing?(method_name, include_private = false)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '3.0.3'.freeze
+  VERSION = '3.1.0'.freeze
 end


### PR DESCRIPTION
## Goal

Provides the ability to configure the Appium driver to locate elements by accessibility id.  This appears to be required for React Native and slipped through the cracks on the initial move to v3.

## Design

Following the existing pattern, a new command line switch is added and configuration set based on that.

## Changeset

Gem entry point, configuration and new (defaulted) parameter added to `ResilientAppiumDriver`.

## Tests

The CI tests should be sufficient to guard against any regression and I have been running the React Native tests mostly successfully against the development image that gets pushed (the issues I'm seeing now do not relate to element location).
