### PR TITLE
Add BrowserStack Appium version option

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,6 +117,7 @@ steps:
       --device=ANDROID_10_0
       --username=$BROWSER_STACK_USERNAME
       --access-key=$BROWSER_STACK_ACCESS_KEY
+      --appium-version=1.17.0
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -131,6 +132,7 @@ steps:
       --device=ANDROID_11_0
       --username=$BROWSER_STACK_USERNAME
       --access-key=$BROWSER_STACK_ACCESS_KEY
+      --appium-version=1.17.0
     concurrency: 10
     concurrency_group: 'browserstack-app'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Provide ability to locate elements by accessibility id
   [#151](https://github.com/bugsnag/maze-runner/pull/151)
+- Add command line option to set Appium version
+  [#152](https://github.com/bugsnag/maze-runner/pull/152)
 
 # 3.0.3 - 2020/10/26
 

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -11,17 +11,23 @@ require_relative '../lib/version'
 #
 # TODO: Factor out CL options/processing to reduce overall size
 class MazeRunnerEntry
+  # Common options
   OPTION_SEPARATE_SESSIONS = 'separate-sessions'
-  OPTION_APP = 'app'
-  OPTION_BS_LOCAL = 'bs-local'
   OPTION_FARM = 'farm'
+  OPTION_APP = 'app'
+  OPTION_A11Y_LOCATOR = 'a11y-locator'
+
+  # BrowserStack-only options
+  OPTION_BS_LOCAL = 'bs-local'
   OPTION_BS_DEVICE = 'device'
-  OPTION_OS = 'os'
-  OPTION_OS_VERSION = 'os-version'
   OPTION_USERNAME = 'username'
   OPTION_ACCESS_KEY = 'access-key'
+  OPTION_BS_APPIUM_VERSION = 'appium-version'
+
+  # Local-only options
+  OPTION_OS = 'os'
+  OPTION_OS_VERSION = 'os-version'
   OPTION_APPIUM_SERVER = 'appium-server'
-  OPTION_A11Y_LOCATOR = 'a11y-locator'
   OPTION_APPLE_TEAM_ID = 'apple-team-id'
   OPTION_UDID = 'udid'
 
@@ -37,22 +43,39 @@ class MazeRunnerEntry
       opt :init, 'Initialises a new Maze Runner project'
 
       opt :version, 'Display Maze Runner and Cucumber versions'
+
+      # Common options
       opt OPTION_SEPARATE_SESSIONS,
           'Start a new Appium session for each scenario',
           short: :none,
           type: :boolean,
           default: false
+      opt OPTION_FARM, 'Device farm to use: "bs" (BrowserStack) or "local"', short: :none, type: :string
       opt OPTION_APP, 'The app to be installed and run against', short: :none, type: :string
+      opt OPTION_A11Y_LOCATOR,
+          'Locate elements by accessibility id rather than id',
+          short: :none,
+          type: :boolean,
+          default: false
+
+      # BrowserStack-only options
       opt OPTION_BS_LOCAL,
           '(BS only) Path to the BrowserStackLocal binary',
           short: :none,
           type: :string,
           default: '/BrowserStackLocal'
-      opt OPTION_FARM, 'Device farm to use: "bs" (BrowserStack) or "local"', short: :none, type: :string
       opt OPTION_BS_DEVICE,
           'BrowserStack device to use (a key of Devices.DEVICE_HASH)',
           short: :none,
           type: :string
+      opt OPTION_USERNAME, 'Device farm username', short: :none, type: :string
+      opt OPTION_ACCESS_KEY, 'Device farm access key', short: :none, type: :string
+      opt OPTION_BS_APPIUM_VERSION,
+          'The Appium version to use with BrowserStack',
+          short: :none,
+          type: :string
+
+      # Local-only options
       opt OPTION_OS,
           'OS type to use ("ios", "android")',
           short: :none,
@@ -61,20 +84,13 @@ class MazeRunnerEntry
           'The intended OS version when running on a local device',
           short: :none,
           type: :string
-      opt OPTION_APPLE_TEAM_ID, 'Apple Team Id, required for local iOS testing', short: :none, type: :string
-      opt OPTION_UDID, 'Apple UDID, required for local iOS testing', short: :none, type: :string
-      opt OPTION_USERNAME, 'Device farm username', short: :none, type: :string
-      opt OPTION_ACCESS_KEY, 'Device farm access key', short: :none, type: :string
       opt OPTION_APPIUM_SERVER,
           'Appium server URL, only used for --farm=local',
           short: :none,
           type: :string,
           default: 'http://localhost:4723/wd/hub'
-      opt OPTION_A11Y_LOCATOR,
-          'Locate elements by accessibility id rather than id',
-          short: :none,
-          type: :boolean,
-          default: false
+      opt OPTION_APPLE_TEAM_ID, 'Apple Team Id, required for local iOS testing', short: :none, type: :string
+      opt OPTION_UDID, 'Apple UDID, required for local iOS testing', short: :none, type: :string
 
       version "Maze Runner v#{BugsnagMazeRunner::VERSION} " \
               "(Cucumber v#{Cucumber::VERSION.strip})"
@@ -173,6 +189,7 @@ class MazeRunnerEntry
       config.bs_device = bs_device
       config.os_version = Devices::DEVICE_HASH[config.bs_device]['os_version'].to_f
       config.bs_local = options[OPTION_BS_LOCAL]
+      config.appium_version = options[OPTION_BS_APPIUM_VERSION]
       username = config.username = options[OPTION_USERNAME]
       access_key = config.access_key = options[OPTION_ACCESS_KEY]
       config.appium_server_url = "http://#{username}:#{access_key}@hub-cloud.browserstack.com/wd/hub"

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -123,7 +123,8 @@ class MazeRunnerEntry
       OPTION_APPIUM_SERVER,
       OPTION_A11Y_LOCATOR,
       OPTION_UDID,
-      OPTION_APPLE_TEAM_ID
+      OPTION_APPLE_TEAM_ID,
+      OPTION_BS_APPIUM_VERSION
     ]
     remove.each do |opt|
       @args.reject! { |arg| arg == "--#{opt}" || (arg.start_with? "--#{opt}=") }

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -18,7 +18,8 @@ AfterConfiguration do |config|
   if config.farm == :bs
     tunnel_id = SecureRandom.uuid
     config.capabilities = Capabilities.for_browser_stack config.bs_device,
-                                                         tunnel_id
+                                                         tunnel_id,
+                                                         config.appium_version
 
     config.app_location = BrowserStackUtils.upload_app config.username,
                                                        config.access_key,

--- a/lib/features/support/capabilities/capabilities.rb
+++ b/lib/features/support/capabilities/capabilities.rb
@@ -7,7 +7,7 @@ class Capabilities
   class << self
     # @param device_type [String] A key from @see Devices::DEVICE_HASH
     # @param local_id [String] unique key for the tunnel instance
-    def for_browser_stack(device_type, local_id)
+    def for_browser_stack(device_type, local_id, appium_version)
       capabilities = {
         'browserstack.console' => 'errors',
         'browserstack.localIdentifier' => local_id,
@@ -15,6 +15,7 @@ class Capabilities
         'browserstack.networkLogs' => 'true'
       }
       capabilities.merge! Devices::DEVICE_HASH[device_type]
+      capabilities['browserstack.appium_version'] = appium_version unless appium_version.nil?
     end
 
     # Constructs Appium capabilities for running on a local Android or iOS device.

--- a/lib/features/support/capabilities/capabilities.rb
+++ b/lib/features/support/capabilities/capabilities.rb
@@ -16,6 +16,7 @@ class Capabilities
       }
       capabilities.merge! Devices::DEVICE_HASH[device_type]
       capabilities['browserstack.appium_version'] = appium_version unless appium_version.nil?
+      capabilities
     end
 
     # Constructs Appium capabilities for running on a local Android or iOS device.

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -2,14 +2,32 @@
 
 # MazeRunner configuration
 class Configuration
+
+  #
+  # Common configuration
+  #
+
   # Whether each scenario should have its own Appium session
   attr_accessor :appium_session_isolation
+
+  # Element locator strategy, :id or :accessibility_id
+  attr_accessor :locator
+
+  # Appium capabilities
+  attr_accessor :capabilities
+
+  # File path or URL of the app (IPA or APK) that tests will be run against
+  attr_accessor :app_location
 
   # Device farm to be used, one of:
   # :bs (BrowserStack)
   # :local (Using Appium Server with a local device)
   # :none (Cucumber-driven testing with no devices)
   attr_accessor :farm
+
+  #
+  # BrowserStack specific configuration
+  #
 
   # Location of the BrowserStackLocal binary (if used)
   attr_accessor :bs_local
@@ -20,11 +38,18 @@ class Configuration
   # Farm access key
   attr_accessor :access_key
 
-  # Apple Team Id
-  attr_accessor :apple_team_id
-
   # BrowserStack device type
   attr_accessor :bs_device
+
+  # Appium version to use on BrowserStack
+  attr_accessor :appium_version
+
+  #
+  # Local testing specific configuration
+  #
+
+  # Apple Team Id
+  attr_accessor :apple_team_id
 
   # OS
   attr_accessor :os
@@ -37,13 +62,4 @@ class Configuration
 
   # URL of the Appium server
   attr_accessor :appium_server_url
-
-  # Element locator strategy, :id or :accessibility_id
-  attr_accessor :locator
-
-  # Appium capabilities
-  attr_accessor :capabilities
-
-  # File path or URL of the app (IPA or APK) that tests will be run against
-  attr_accessor :app_location
 end


### PR DESCRIPTION
## Goal

Adds a new command line option for specifying the Appium version capability when using BrowserStack.

## Design

Design follows the usual pattern of adding the option and pushing into configuration for later use.  I've also taken the opportunity to group options into BrowserStack, local and common use (making the diff look a little messier, I'm afraid).

## Changeset

New CL option and config.  Update to the `Capabilities` class.

## Tests

I've specific Appium 1.17.0 on two of the CI pipeline steps and verified that the change takes effect by inspecting the Appium logs on BrowserStack:
```
[Appium] Appium v1.17.0 creating new AndroidUiautomator2Driver (v1.46.0) session
```
Earlier versions of Appium are not always as easy to identify, but the difference can be seen:
```
[Appium] Creating new AndroidUiautomator2Driver (v0.5.2) session
```
