### PR TITLE
[PLAT-4982] Server response code steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,7 +53,7 @@ steps:
 
   - label: 'HTTP response tests'
     plugins:
-      docker-compose#v3.3.3:
+      docker-compose#v3.3.0:
         run: http-response-tests
     command: 'bundle exec bugsnag-maze-runner'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,6 +27,7 @@ steps:
             - comparison-tests
             - browserstack-app-automate
             - payload-helper-tests
+            - http-response-tests
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
           build-parallel: true
 
@@ -48,6 +49,12 @@ steps:
     plugins:
       docker-compose#v3.3.0:
         run: proxy-tests
+    command: 'bundle exec bugsnag-maze-runner'
+
+  - label: 'HTTP response tests'
+    plugins:
+      docker-compose#v3.3.3:
+        run: http-response-tests
     command: 'bundle exec bugsnag-maze-runner'
 
   - label: 'Browserstack app-automate test - Android 6'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# TBD
+
+## Enhancements
+
+- Add steps for setting the HTTP status code to be returned to incoming requests
+  []()
+
 # 3.1.0 - 2020/11/02
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Enhancements
 
 - Add steps for setting the HTTP status code to be returned to incoming requests
-  []()
+  [#157](https://github.com/bugsnag/maze-runner/pull/157)
 
 # 3.1.0 - 2020/11/02
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,3 +49,9 @@ services:
       context: test/fixtures/payload-helpers
       args:
         BRANCH_NAME:
+
+  http-response-tests:
+    build:
+      context: test/fixtures/http-response
+      args:
+        BRANCH_NAME:

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -65,6 +65,10 @@ end
 # After each scenario
 After do |scenario|
 
+  # Make sure we reset to HTTP 200 return status after each scenario
+  Server.status_code = 200
+  Server.reset_status_code = false
+
   # This is here to stop sessions from one test hitting another.
   # However this does mean that tests take longer.
   # TODO:SM We could try and fix this by generating unique endpoints

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -8,6 +8,15 @@ When("I wait for the host {string} to open port {string}") do |host, port|
   Network.wait_for_port(host, port)
 end
 
+When("I set the HTTP status code to {int}") do |status_code|
+  Server.status_code = status_code
+end
+
+When("I set the HTTP status code for the next request to {int}") do |status_code|
+  Server.reset_status_code = true
+  Server.status_code = status_code
+end
+
 # Attempts to open a URL.
 #
 # @step_input url [String] The URL to open.

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -8,10 +8,16 @@ When("I wait for the host {string} to open port {string}") do |host, port|
   Network.wait_for_port(host, port)
 end
 
+# Sets the HTTP status code to be used for all subsequent requests
+#
+# @step_input status_code [Integer] The status code to return
 When("I set the HTTP status code to {int}") do |status_code|
   Server.status_code = status_code
 end
 
+# Sets the HTTP status code to be used for the next request
+#
+# @step_input status_code [Integer] The status code to return
 When("I set the HTTP status code for the next request to {int}") do |status_code|
   Server.reset_status_code = true
   Server.status_code = status_code

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -19,6 +19,25 @@ MOCK_API_PORT = 9339
 # Receives and stores requests through a WEBrick HTTPServer
 class Server
   class << self
+    # Allows overwriting of the server status code
+    attr_writer :status_code
+
+    # Dictates if the status code should be reset after used
+    attr_writer :reset_status_code
+
+    # The intended HTTP status code on a successful request
+    #
+    # @return [Integer] The HTTP status code, defaults to 200
+    def status_code
+      code = @status_code ||= 200
+      @status_code = 200 if reset_status_code
+      code
+    end
+
+    def reset_status_code
+      @reset_status_code ||= false
+    end
+
     # Whether the server thread is running
     #
     # @return [Boolean] If the server is running

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -31,7 +31,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
                                   request: request }
     end
     response.header['Access-Control-Allow-Origin'] = '*'
-    response.status = 200
+    response.status = Server.status_code
   end
 
   # Logs and returns a set of valid headers for this servlet.
@@ -44,7 +44,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
     response.header['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
     response.header['Access-Control-Allow-Headers'] =
       'Origin,Content-Type,Bugsnag-Sent-At,Bugsnag-Api-Key,Bugsnag-Payload-Version,Accept'
-    response.status = 200
+    response.status = Server.status_code
   end
 
   private

--- a/test/fixtures/http-response/Dockerfile
+++ b/test/fixtures/http-response/Dockerfile
@@ -1,0 +1,5 @@
+ARG BRANCH_NAME
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+
+COPY . /app
+WORKDIR /app

--- a/test/fixtures/http-response/Gemfile
+++ b/test/fixtures/http-response/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'bugsnag-maze-runner', path: '../../..'

--- a/test/fixtures/http-response/features/fixtures/exact_match.json
+++ b/test/fixtures/http-response/features/fixtures/exact_match.json
@@ -1,0 +1,18 @@
+{
+    "animals": [
+        "bear",
+        "fox",
+        "goat",
+        "parrot"
+    ],
+    "fruits": {
+        "apple": {
+            "color": "red",
+            "types": 248
+        },
+        "cherry": {
+            "color": "black",
+            "types": 17
+        }
+    }
+}

--- a/test/fixtures/http-response/features/fixtures/fuzzy_match.json
+++ b/test/fixtures/http-response/features/fixtures/fuzzy_match.json
@@ -1,0 +1,18 @@
+{
+    "animals": [
+        "bear",
+        "fox",
+        "goat",
+        "parrot"
+    ],
+    "fruits": {
+        "apple": {
+            "color": "^\\w+$",
+            "types": 248
+        },
+        "cherry": {
+            "color": "^\\w+$",
+            "types": 17
+        }
+    }
+}

--- a/test/fixtures/http-response/features/fixtures/ignore_apple.json
+++ b/test/fixtures/http-response/features/fixtures/ignore_apple.json
@@ -1,0 +1,15 @@
+{
+    "animals": [
+        "bear",
+        "fox",
+        "goat",
+        "parrot"
+    ],
+    "fruits": {
+        "apple": "IGNORE",
+        "cherry": {
+            "color": "black",
+            "types": 17
+        }
+    }
+}

--- a/test/fixtures/http-response/features/fixtures/numerics.json
+++ b/test/fixtures/http-response/features/fixtures/numerics.json
@@ -1,0 +1,18 @@
+{
+    "animals": [
+        "bear",
+        "fox",
+        "goat",
+        "parrot"
+    ],
+    "fruits": {
+        "apple": {
+            "color": "red",
+            "types": "NUMBER"
+        },
+        "cherry": {
+            "color": "black",
+            "types": "NUMBER"
+        }
+    }
+}

--- a/test/fixtures/http-response/features/scripts/send_request.sh
+++ b/test/fixtures/http-response/features/scripts/send_request.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+require 'net/http'
+
+http = Net::HTTP.new('localhost', '9339')
+first_request = Net::HTTP::Post.new('/')
+first_request['Content-Type'] = 'application/json'
+first_request.body = '{"req": "first!"}'
+
+first_response = http.request(first_request)
+
+second_request = Net::HTTP::Post.new('/')
+second_request['Content-Type'] = 'application/json'
+
+second_request.body = "{\"first_code\": \"#{first_response.code}\"}"
+
+second_response = http.request(second_request)
+
+third_request = Net::HTTP::Post.new('/')
+third_request['Content-Type'] = 'application/json'
+
+third_request.body = "{\"second_code\": \"#{second_response.code}\"}"
+
+http.request(third_request)

--- a/test/fixtures/http-response/features/set_different_responses.feature
+++ b/test/fixtures/http-response/features/set_different_responses.feature
@@ -1,0 +1,30 @@
+Feature: Setting different response codes
+
+    Scenario: Default response codes (200) are present
+        When I run the script "features/scripts/send_request.sh" synchronously
+        And I wait to receive 3 requests
+        Then the payload field "req" equals "first!"
+        And I discard the oldest request
+        And the payload field "first_code" equals "200"
+        And I discard the oldest request
+        And the payload field "second_code" equals "200"
+
+    Scenario: Server response code can be set for all subsequent requests (400)
+        Given I set the HTTP status code to 400
+        When I run the script "features/scripts/send_request.sh" synchronously
+        And I wait to receive 3 requests
+        Then the payload field "req" equals "first!"
+        And I discard the oldest request
+        And the payload field "first_code" equals "400"
+        And I discard the oldest request
+        And the payload field "second_code" equals "400"
+
+    Scenario: Server response code can be set a single request (503)
+        Given I set the HTTP status code for the next request to 503
+        When I run the script "features/scripts/send_request.sh" synchronously
+        And I wait to receive 3 requests
+        Then the payload field "req" equals "first!"
+        And I discard the oldest request
+        And the payload field "first_code" equals "503"
+        And I discard the oldest request
+        And the payload field "second_code" equals "200"

--- a/test/integration/automation_test.rb
+++ b/test/integration/automation_test.rb
@@ -27,6 +27,10 @@ class SampleTest < Test::Unit::TestCase
     run_scenario("test/fixtures/comparison")
   end
 
+  def test_http_response_codes
+    run_scenario("test/fixtures/http-response")
+  end
+
   def test_init_command
     fixture_dir = "test/fixtures/init-test"
     FileUtils.rm_rf fixture_dir


### PR DESCRIPTION
## Goal

Adds steps to allow setting the HTTP status code response of the servlet to any given POST or OPTIONS request.

This will work in one of two ways:
- Setting an HTTP status code that will be used for all subsequent requests
- Setting an HTTP status code that will be used for the next received request, after which the code will return to `200`

## Tests

- Added maze test fixture exercising changes.
