### PR TITLE
Do not detach when running Docker Compose services with a command

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,16 +6,9 @@ steps:
             - ci
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
           cache-from:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
-
-  - wait
-
-  - label: ':docker: Push CI'
-    plugins:
       - docker-compose#v3.7.0:
           push:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
   - wait
@@ -28,7 +21,10 @@ steps:
             - browserstack-app-automate
             - payload-helper-tests
             - http-response-tests
+            - unit-test
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+          cache-from:
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
           build-parallel: true
 
   - wait
@@ -53,7 +49,7 @@ steps:
 
   - label: 'HTTP response tests'
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: http-response-tests
     command: 'bundle exec bugsnag-maze-runner'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ':docker: Build CI image'
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           build:
             - ci
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
@@ -13,7 +13,7 @@ steps:
 
   - label: ':docker: Push CI'
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           push:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-ci
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
@@ -22,7 +22,7 @@ steps:
 
   - label: ':docker: Build test images'
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           build:
             - comparison-tests
             - browserstack-app-automate
@@ -35,19 +35,19 @@ steps:
 
   - label: 'Unit tests'
     plugins:
-      docker-compose#v3.3.0:
-        run: ci
+      docker-compose#v3.7.0:
+        run: unit-test
     command: 'bundle exec rake'
 
   - label: 'Comparison tests'
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: comparison-tests
     command: 'bundle exec bugsnag-maze-runner'
 
   - label: 'Proxy tests'
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: proxy-tests
     command: 'bundle exec bugsnag-maze-runner'
 
@@ -59,7 +59,7 @@ steps:
 
   - label: 'Browserstack app-automate test - Android 6'
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browserstack-app-automate
     command: >-
       bundle exec bugsnag-maze-runner
@@ -78,7 +78,7 @@ steps:
 
   - label: 'Browserstack app-automate test - Android 7.1 (separate Appium sessions)'
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browserstack-app-automate
     command: >-
       bundle exec bugsnag-maze-runner
@@ -97,7 +97,7 @@ steps:
 
   - label: 'Browserstack app-automate test - Android 8.1'
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browserstack-app-automate
     command: >-
       bundle exec bugsnag-maze-runner
@@ -111,7 +111,7 @@ steps:
 
   - label: 'Browserstack app-automate test - Android 9'
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browserstack-app-automate
     command: >-
       bundle exec bugsnag-maze-runner
@@ -125,7 +125,7 @@ steps:
 
   - label: 'Browserstack app-automate test - Android 10 (separate Appium sessions)'
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browserstack-app-automate
     command: >-
       bundle exec bugsnag-maze-runner
@@ -140,7 +140,7 @@ steps:
 
   - label: 'Browserstack app-automate test - Android 11 (separate Appium sessions)'
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browserstack-app-automate
     command: >-
       bundle exec bugsnag-maze-runner
@@ -155,7 +155,7 @@ steps:
 
   - label: 'Payload helper tests'
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: payload-helper-tests
     command: 'bundle exec bugsnag-maze-runner'
 
@@ -163,10 +163,10 @@ steps:
 
   - label: 'Push Docker image for branch'
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           build: cli
           cache-from: cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
 
@@ -196,7 +196,7 @@ steps:
   - label: 'Update docs'
     if: build.tag =~ /^v[2-9]\.[0-9]+\.[0-9]+\$/
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: docs
     command: 'bundle exec rake docs:build_and_publish'
 
@@ -204,7 +204,7 @@ steps:
   - label: 'Push Docker image for tag'
     if: build.tag =~ /^v[2-9]\.[0-9]+\.[0-9]+\$/
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:${BUILDKITE_TAG}-cli
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
-# TBD
+# 3.2.0 - 2020/11/04
 
 ## Enhancements
 
 - Add steps for setting the HTTP status code to be returned to incoming requests
   [#157](https://github.com/bugsnag/maze-runner/pull/157)
+
+## Fixes
+
+- Run docker-compose commands attached rather than detached.
+  [#158](https://github.com/bugsnag/maze-runner/pull/158)
 
 # 3.1.0 - 2020/11/02
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (3.1.1)
+    bugsnag-maze-runner (3.2.0)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (3.1.0)
+    bugsnag-maze-runner (3.1.1)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -50,7 +50,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    curb (0.9.10)
+    curb (0.9.11)
     diff-lcs (1.4.4)
     eventmachine (1.2.7)
     faye-websocket (0.11.0)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,3 +55,9 @@ services:
       context: test/fixtures/http-response
       args:
         BRANCH_NAME:
+
+  unit-test:
+    build:
+      dockerfile: dockerfiles/Dockerfile.ci
+      context: .
+      target: unit-test

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as ci
+FROM ubuntu:20.04 as base
 
 RUN apt-get update && apt-get install -y ruby-full apt-utils docker-compose wget unzip bash bundler \
                                         # Needed by nokogiri (a dependency of appium_lib)
@@ -18,5 +18,9 @@ COPY lib/ lib/
 COPY Gemfile* bugsnag-maze-runner.gemspec ./
 RUN bundle install
 
-FROM ci as cli
+FROM base as cli
 ENTRYPOINT ["bundle", "exec", "maze-runner"]
+
+FROM base as unit-test
+COPY test/ test/
+COPY Rakefile .

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as base
+FROM ubuntu:20.04 as ci
 
 RUN apt-get update && apt-get install -y ruby-full apt-utils docker-compose wget unzip bash bundler \
                                         # Needed by nokogiri (a dependency of appium_lib)
@@ -18,9 +18,9 @@ COPY lib/ lib/
 COPY Gemfile* bugsnag-maze-runner.gemspec ./
 RUN bundle install
 
-FROM base as cli
+FROM ci as cli
 ENTRYPOINT ["bundle", "exec", "maze-runner"]
 
-FROM base as unit-test
+FROM ci as unit-test
 COPY test/ test/
 COPY Rakefile .

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,12 +1,10 @@
 FROM ubuntu:20.04 as ci
 
-RUN apt-get update
-RUN apt-get install -y ruby-full apt-utils docker-compose wget unzip bash bundler
-# Needed by nokogiri (a dependency of appium_lib)
-RUN apt-get install -y zlib1g libpng-dev zlibc zlib1g zlib1g-dev curl
-# Needed by curb (a dependency of Cucumber)
-RUN apt-get install -y libcurl4 libcurl4-openssl-dev
-
+RUN apt-get update && apt-get install -y ruby-full apt-utils docker-compose wget unzip bash bundler \
+                                        # Needed by nokogiri (a dependency of appium_lib)
+                                        zlib1g libpng-dev zlibc zlib1g zlib1g-dev curl \
+                                        # Needed by curb (a dependency of Cucumber)
+                                        libcurl4 libcurl4-openssl-dev
 RUN ruby -v
 
 RUN wget -q https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip \
@@ -15,8 +13,9 @@ RUN wget -q https://www.browserstack.com/browserstack-local/BrowserStackLocal-li
 
 WORKDIR /app/
 
-# We dont copy the gemfile in because this builds a gem so it needs the source
-COPY . ./
+COPY bin/ bin/
+COPY lib/ lib/
+COPY Gemfile* bugsnag-maze-runner.gemspec ./
 RUN bundle install
 
 FROM ci as cli

--- a/lib/features/support/docker.rb
+++ b/lib/features/support/docker.rb
@@ -9,6 +9,8 @@ class Docker
     COMPOSE_FILENAME = 'features/fixtures/docker-compose.yml'
 
     # Builds and starts a service, using a command if given.
+    # If running a command, it will be executed as an attached process, otherwise it
+    # will run detached.
     #
     # @param service [String] The name of the service to start
     # @param command [String] Optional. The command to use when running the service
@@ -17,9 +19,10 @@ class Docker
         # We build the service before running it as there is no --build
         # option for run.
         run_docker_compose_command("build #{service}")
-        run_docker_compose_command("run -d --use-aliases #{service} #{command}")
+        run_docker_compose_command("run --use-aliases #{service} #{command}")
       else
         run_docker_compose_command("up -d --build #{service}")
+        # TODO: Consider adding a logs command here
       end
     end
 
@@ -38,16 +41,14 @@ class Docker
       # as it is still in use, that is ok to ignore so we pass success codes!
       # We set timeout to 0 so this kills the services rather than stopping them
       # as its quicker and they are stateless anyway.
-      run_docker_compose_command('down -t 0', success_codes: [0,256]) if compose_stack_exists?
+      run_docker_compose_command('down -t 0', success_codes: [0, 256]) if compose_stack_exists?
     end
 
     def compose_project_name
       @compose_project_name ||= nil
     end
 
-    def compose_project_name=(project_name)
-      @compose_project_name = project_name
-    end
+    attr_writer :compose_project_name
 
     private
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.1.1'.freeze
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '3.1.1'.freeze
+  VERSION = '3.2.0'.freeze
 end


### PR DESCRIPTION
## Goal

Provide easy access to the container logs when running a Docker Compose service with a command.

## Design

when running a Docker service with a command, do so in the foreground rather than the detaching.  This is appropriate for the existing uses of the functionality as the commands issued are short lived processes.  Long running process such as web servers use the start service functionality with no command.

## Changeset

- Docker class
- Bumped Buildkite plugin versions
- Refactored Dockerfile to reduce image size.

## Tests

Covered by standard CI.
