### PR TITLE
Add assertions for and auto-checking of Bugsnag-Integrity header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Add assertions to verify Bugsnag-Integrity header is correct
+- Add assertions for and automatic verification of Bugsnag-Integrity headers
   [#159](https://github.com/bugsnag/maze-runner/pull/159)
 
 # 3.3.0 - 2020/11/05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# TBD
+
+## Enhancements
+
+- Add assertions to verify Bugsnag-Integrity header is correct
+  [#159](https://github.com/bugsnag/maze-runner/pull/159)
+
 # 3.3.0 - 2020/11/05
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Enhancements
 
-- Add assertions for and automatic verification of Bugsnag-Integrity headers
+- Add Cucumber steps for checking Bugsnag-Integrity headers, in addition to automatically 
+  verifying digests on all received requests when the header is present.
   [#159](https://github.com/bugsnag/maze-runner/pull/159)
 
 # 3.3.0 - 2020/11/05

--- a/lib/features/steps/header_steps.rb
+++ b/lib/features/steps/header_steps.rb
@@ -2,6 +2,6 @@
 
 # Checks that the Bugsnag-Integrity header is a SHA1 or simple digest
 #
-When("the Bugsnag-Integrity header is valid") do
-  valid_bugsnag_integrity_header(Server.current_request)
+When('the Bugsnag-Integrity header is valid') do
+  assert_true(valid_bugsnag_integrity_header(Server.current_request), 'Invalid Bugsnag-Integrity header detected')
 end

--- a/lib/features/steps/header_steps.rb
+++ b/lib/features/steps/header_steps.rb
@@ -1,0 +1,7 @@
+# @!group Header steps
+
+# Checks that the Bugsnag-Integrity header is a SHA1 or simple digest
+#
+When("the Bugsnag-Integrity header is valid") do
+  valid_bugsnag_integrity_header(Server.current_request)
+end

--- a/lib/features/support/header.rb
+++ b/lib/features/support/header.rb
@@ -26,7 +26,7 @@ def valid_simple_digest_header(request)
   header = request[:request]['Bugsnag-Integrity']
   assert_not_nil(request[:body], 'No request body present')
   body = JSON.generate(request[:body])
-  computed_digest = "simple #{body.to_s.size}"
+  computed_digest = "simple #{body.to_s.bytesize}"
   assert_equal(header, computed_digest, "SHA1 digest does not match request payload. Computed #{computed_digest}.")
   header == computed_digest
 end

--- a/lib/features/support/header.rb
+++ b/lib/features/support/header.rb
@@ -3,30 +3,13 @@ require 'json'
 
 def valid_bugsnag_integrity_header(request)
   header = request[:request]['Bugsnag-Integrity']
-
+  digests = request[:digests]
   if header.start_with?('sha1')
-    assert_true(valid_sha_digest_header(request), 'Bugsnag-Integrity header does not match SHA1 digest.')
+    computed_digest = "sha1 #{digests[:sha1]}"
   elsif header.start_with?('simple')
-    assert_true(valid_simple_digest_header(request), 'Bugsnag-Integrity header does not match simple digest.')
+    computed_digest = "simple #{digests[:simple]}"
   else
-    assert_true(false, 'Bugsnag-Integrity header does not match SHA1 or Request Length digest.')
+    return false
   end
-end
-
-def valid_sha_digest_header(request)
-  header = request[:request]['Bugsnag-Integrity']
-  assert_not_nil(request[:body], 'No request body present')
-  body = JSON.generate(request[:body])
-  computed_digest = 'sha1 ' + Digest::SHA1.hexdigest(body.to_s)
-  assert_equal(header, computed_digest, "SHA1 digest does not match request payload. Computed #{computed_digest}.")
-  header == computed_digest
-end
-
-def valid_simple_digest_header(request)
-  header = request[:request]['Bugsnag-Integrity']
-  assert_not_nil(request[:body], 'No request body present')
-  body = JSON.generate(request[:body])
-  computed_digest = "simple #{body.to_s.bytesize}"
-  assert_equal(header, computed_digest, "SHA1 digest does not match request payload. Computed #{computed_digest}.")
   header == computed_digest
 end

--- a/lib/features/support/header.rb
+++ b/lib/features/support/header.rb
@@ -2,31 +2,31 @@ require 'digest/sha1'
 require 'json'
 
 def valid_bugsnag_integrity_header(request)
-  header = request[:request]["Bugsnag-Integrity"]
+  header = request[:request]['Bugsnag-Integrity']
 
-  if header.start_with?("sha1")
-    assert_true(valid_sha_digest_header(request) , "Bugsnag-Integrity header does not match SHA1 digest.")
-  elsif header.start_with?("simple")
-    assert_true(valid_simple_digest_header(request) , "Bugsnag-Integrity header does not match simple digest.")
+  if header.start_with?('sha1')
+    assert_true(valid_sha_digest_header(request), 'Bugsnag-Integrity header does not match SHA1 digest.')
+  elsif header.start_with?('simple')
+    assert_true(valid_simple_digest_header(request), 'Bugsnag-Integrity header does not match simple digest.')
   else
-    assert_true(false, "Bugsnag-Integrity header does not match SHA1 or Request Length digest.")
+    assert_true(false, 'Bugsnag-Integrity header does not match SHA1 or Request Length digest.')
   end
 end
 
 def valid_sha_digest_header(request)
-  header = request[:request]["Bugsnag-Integrity"]
-  assert_not_nil(request[:body], "No request body present")
+  header = request[:request]['Bugsnag-Integrity']
+  assert_not_nil(request[:body], 'No request body present')
   body = JSON.generate(request[:body])
-  computed_digest = "sha1 " + Digest::SHA1.hexdigest(body.to_s)
+  computed_digest = 'sha1 ' + Digest::SHA1.hexdigest(body.to_s)
   assert_equal(header, computed_digest, "SHA1 digest does not match request payload. Computed #{computed_digest}.")
-  return header == computed_digest
+  header == computed_digest
 end
 
 def valid_simple_digest_header(request)
-  header = request[:request]["Bugsnag-Integrity"]
-  assert_not_nil(request[:body], "No request body present")
+  header = request[:request]['Bugsnag-Integrity']
+  assert_not_nil(request[:body], 'No request body present')
   body = JSON.generate(request[:body])
   computed_digest = "simple #{body.to_s.size}"
   assert_equal(header, computed_digest, "SHA1 digest does not match request payload. Computed #{computed_digest}.")
-  return header == computed_digest
+  header == computed_digest
 end

--- a/lib/features/support/header.rb
+++ b/lib/features/support/header.rb
@@ -2,8 +2,15 @@ require 'digest/sha1'
 require 'json'
 
 def valid_bugsnag_integrity_header(request)
-  valid = valid_sha_digest_header(request) || valid_simple_digest_header(request)
-  assert_true(valid, "Bugsnag-Integrity header does not match SHA1 or Request Length digest.")
+  header = request[:request]["Bugsnag-Integrity"]
+
+  if header.start_with?("sha1")
+    assert_true(valid_sha_digest_header(request) , "Bugsnag-Integrity header does not match SHA1 digest.")
+  elsif header.start_with?("simple")
+    assert_true(valid_simple_digest_header(request) , "Bugsnag-Integrity header does not match simple digest.")
+  else
+    assert_true(false, "Bugsnag-Integrity header does not match SHA1 or Request Length digest.")
+  end
 end
 
 def valid_sha_digest_header(request)
@@ -11,7 +18,7 @@ def valid_sha_digest_header(request)
   assert_not_nil(request[:body], "No request body present")
   body = JSON.generate(request[:body])
   computed_digest = "sha1 " + Digest::SHA1.hexdigest(body.to_s)
-  assert_equal(header, computed_digest, "SHA1 digest does not match request payload. Computed #{computed_digest} from #{body}.")
+  assert_equal(header, computed_digest, "SHA1 digest does not match request payload. Computed #{computed_digest}.")
   return header == computed_digest
 end
 
@@ -20,6 +27,6 @@ def valid_simple_digest_header(request)
   assert_not_nil(request[:body], "No request body present")
   body = JSON.generate(request[:body])
   computed_digest = "simple #{body.to_s.size}"
-  assert_equal(header, computed_digest, "SHA1 digest does not match request payload. Computed #{computed_digest} from #{body}.")
+  assert_equal(header, computed_digest, "SHA1 digest does not match request payload. Computed #{computed_digest}.")
   return header == computed_digest
 end

--- a/lib/features/support/header.rb
+++ b/lib/features/support/header.rb
@@ -1,0 +1,25 @@
+require 'digest/sha1'
+require 'json'
+
+def valid_bugsnag_integrity_header(request)
+  valid = valid_sha_digest_header(request) || valid_simple_digest_header(request)
+  assert_true(valid, "Bugsnag-Integrity header does not match SHA1 or Request Length digest.")
+end
+
+def valid_sha_digest_header(request)
+  header = request[:request]["Bugsnag-Integrity"]
+  assert_not_nil(request[:body], "No request body present")
+  body = JSON.generate(request[:body])
+  computed_digest = "sha1 " + Digest::SHA1.hexdigest(body.to_s)
+  assert_equal(header, computed_digest, "SHA1 digest does not match request payload. Computed #{computed_digest} from #{body}.")
+  return header == computed_digest
+end
+
+def valid_simple_digest_header(request)
+  header = request[:request]["Bugsnag-Integrity"]
+  assert_not_nil(request[:body], "No request body present")
+  body = JSON.generate(request[:body])
+  computed_digest = "simple #{body.to_s.size}"
+  assert_equal(header, computed_digest, "SHA1 digest does not match request payload. Computed #{computed_digest} from #{body}.")
+  return header == computed_digest
+end

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -18,6 +18,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
   # @param response [HTTPResponse] The response to return
   def do_POST(request, response)
     log_request(request)
+    check_digest request
     case request['Content-Type']
     when %r{^multipart/form-data; boundary=([^;]+)}
       boundary = WEBrick::HTTPUtils::dequote($1)
@@ -66,6 +67,35 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
     else
       $logger.debug "BODY: #{JSON.pretty_generate(JSON.parse(request.body))}"
     end
+  end
+
+  def check_digest(request)
+    header = request['Bugsnag-Integrity']
+    return if header.nil?
+
+    # Header must have type and digest
+    parts = header.split ' '
+    raise "Invalid Bugsnag-Integrity header: #{header}" unless parts.size == 2
+
+    # Both digest types are stored whatever
+    sha1 = Digest::SHA1.hexdigest(request.body)
+    simple = request.body.length
+    $logger.debug "DIGESTS computed: sha1=#{sha1} simple=#{simple}"
+
+    # Check digests match
+    case parts[0]
+    when 'sha1'
+      raise "Given sha1 #{parts[1]} does not match the computed #{sha1}" unless parts[1] == sha1
+    when 'simple'
+      raise "Given simple digest #{parts[1]} does not match the computed #{simple}" unless parts[1] == simple
+    else
+      raise "Invalid Bugsnag-Integrity digest type: #{parts[0]}"
+    end
+
+    {
+      sha1: sha1,
+      simple: simple
+    }
   end
 end
 

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -79,7 +79,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
 
     # Both digest types are stored whatever
     sha1 = Digest::SHA1.hexdigest(request.body)
-    simple = request.body.length
+    simple = request.body.bytesize
     $logger.debug "DIGESTS computed: sha1=#{sha1} simple=#{simple}"
 
     # Check digests match

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -18,18 +18,25 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
   # @param response [HTTPResponse] The response to return
   def do_POST(request, response)
     log_request(request)
-    check_digest request
+    digests = check_digest request
     case request['Content-Type']
     when %r{^multipart/form-data; boundary=([^;]+)}
       boundary = WEBrick::HTTPUtils::dequote($1)
       body = WEBrick::HTTPUtils.parse_form_data(request.body, boundary)
-      Server.stored_requests << { body: body, request: request }
+      Server.stored_requests << {
+        body: body,
+        request: request,
+        digests: digests
+      }
     else
       # "content-type" is assumed to be JSON (which mimics the behaviour of
       # the actual API). This supports browsers that can't set this header for
       # cross-domain requests (IE8/9)
-      Server.stored_requests << { body: JSON.parse(request.body),
-                                  request: request }
+      Server.stored_requests << {
+        body: JSON.parse(request.body),
+        request: request,
+        digests: digests
+      }
     end
     response.header['Access-Control-Allow-Origin'] = '*'
     response.status = Server.status_code

--- a/test/fixtures/android-app/app/build.gradle
+++ b/test/fixtures/android-app/app/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {
     jcenter()

--- a/test/fixtures/browserstack-app/app/build.gradle
+++ b/test/fixtures/browserstack-app/app/build.gradle
@@ -30,14 +30,15 @@ android {
 }
 
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android:4.13.0'
+    implementation 'com.bugsnag:bugsnag-android:5.2.3'
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {
+    mavenLocal()
     jcenter()
 }

--- a/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -15,28 +15,30 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         val button = findViewById<Button>(R.id.trigger_error)
         button.setOnClickListener {
-            Bugsnag.notify(Exception("HandledException!"), {
-                val error = it.error!!
-                error.metaData.addToTab("test", "boolean_false", false)
-                error.metaData.addToTab("test", "boolean_true", true)
-                error.metaData.addToTab("test", "float", 1.55)
-                error.metaData.addToTab("test", "integer", 2)
-            })
+
+            Bugsnag.notify(Exception("HandledException!"))
         }
     }
 
     override fun onResume() {
         super.onResume()
-        initialiseBugsnag()
+        startBugsnag()
     }
 
-    private fun initialiseBugsnag() {
+    private fun startBugsnag() {
         val config = Configuration("12312312312312312312312312312312")
-        config.autoCaptureSessions = false
-        config.setEndpoints("http://localhost:9339", "http://localhost:9339")
+        config.autoTrackSessions = false
+        config.setEndpoints(EndpointConfiguration("http://localhost:9339", "http://localhost:9339"))
+        config.addOnError(OnErrorCallback { event ->
+            event.addMetadata("test", "boolean_false", false)
+            event.addMetadata("test", "boolean_true", true)
+            event.addMetadata("test", "float", 1.55)
+            event.addMetadata("test", "integer", 2)
 
-        Bugsnag.init(this, config)
-        Bugsnag.setLoggingEnabled(true)
+            true
+        })
+
+        Bugsnag.start(this, config)
     }
 
 }

--- a/test/fixtures/browserstack-app/build.gradle
+++ b/test/fixtures/browserstack-app/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.51'
+    ext.kotlin_version = '1.3.72'
 
     repositories {
         google()

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -4,6 +4,8 @@ Scenario: Test Handled Android Exception
   Given the element "trigger_error" is present
   When I click the element "trigger_error"
   Then I wait to receive a request
+  # TODO Uncomment this once Android is released with the Integrity header
+  # And the Bugsnag-Integrity header is valid
   And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
   And the exception "errorClass" equals "java.lang.Exception"
   And the exception "message" equals "HandledException!"
@@ -14,6 +16,8 @@ Scenario: Verify "equals the correct platform value" step
   Given the element "trigger_error" is present within 30 seconds
   When I click the element "trigger_error"
   Then I wait to receive a request
+  # TODO Uncomment this once Android is released with the Integrity header
+  # And the Bugsnag-Integrity header is valid
   And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
   # Verify string comparisons
   And the event "exceptions.0.errorClass" equals the platform-dependent string:

--- a/test/fixtures/browserstack-app/gradle/wrapper/gradle-wrapper.properties
+++ b/test/fixtures/browserstack-app/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/test/header_test.rb
+++ b/test/header_test.rb
@@ -4,27 +4,50 @@ require_relative '../lib/features/support/header'
 class HeaderTest < Test::Unit::TestCase
 
   def test_valid_sha_digest_header
-    request = {:request => { "Bugsnag-Integrity" => "sha1 3cac245198d9b6e6a91b7d46b5117311f20d9eba"}, :body => {"apiKey" => "your-api-key"}}
-    assert_true(valid_sha_digest_header(request))
-  end
-
-  def test_invalid_sha_digest_header
-    request = {:request => { "Bugsnag-Integrity" => "sha1 5522240098dcc6e6a91ab936b5192911f2aa9000"}, :body => {"apiKey" => "your-api-key"}}
-    assert_raise do
-      assert_false(valid_sha_digest_header(request))
-    end
+    request = {
+      request: {
+        'Bugsnag-Integrity' => 'sha1 3cac245198d9b6e6a91b7d46b5117311f20d9eba'
+      },
+      digests: {
+        sha1: '3cac245198d9b6e6a91b7d46b5117311f20d9eba'
+      }
+    }
+    assert_true(valid_bugsnag_integrity_header(request))
   end
 
   def test_valid_simple_digest_header
-    request = {:request => { "Bugsnag-Integrity" => "simple 25"}, :body => {"apiKey" => "your-api-key"}}
-    assert_true(valid_simple_digest_header(request))
+    request = {
+      request: {
+        'Bugsnag-Integrity' => 'simple 12'
+      },
+      digests: {
+        simple: 12
+      }
+    }
+    assert_true(valid_bugsnag_integrity_header(request))
+  end
+
+  def test_invalid_sha_digest_header
+    request = {
+      request: {
+        'Bugsnag-Integrity' => 'sha1 3cac245198d9b6e6a91b7d46b5117311f20d9eba'
+      },
+      digests: {
+        sha1: '111115198d9b6e6a91b7d46b5117311f20d9eba'
+      }
+    }
+    assert_false(valid_bugsnag_integrity_header(request))
   end
 
   def test_invalid_simple_digest_header
-    request = {:request => { "Bugsnag-Integrity" => "simple 509"}, :body => {"apiKey" => "your-api-key"}}
-    assert_raise do
-      assert_true(valid_simple_digest_header(request))
-    end
+    request = {
+      request: {
+        'Bugsnag-Integrity' => 'simple 12'
+      },
+      digests: {
+        simple: 13
+      }
+    }
+    assert_false(valid_bugsnag_integrity_header(request))
   end
-
 end

--- a/test/header_test.rb
+++ b/test/header_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+require_relative '../lib/features/support/header'
+
+class HeaderTest < Test::Unit::TestCase
+
+  def test_valid_sha_digest_header
+    request = {:request => { "Bugsnag-Integrity" => "sha1 3cac245198d9b6e6a91b7d46b5117311f20d9eba"}, :body => {"apiKey" => "your-api-key"}}
+    assert_true(valid_sha_digest_header(request))
+  end
+
+  def test_invalid_sha_digest_header
+    request = {:request => { "Bugsnag-Integrity" => "sha1 5522240098dcc6e6a91ab936b5192911f2aa9000"}, :body => {"apiKey" => "your-api-key"}}
+    assert_raise do
+      assert_false(valid_sha_digest_header(request))
+    end
+  end
+
+  def test_valid_simple_digest_header
+    request = {:request => { "Bugsnag-Integrity" => "simple 25"}, :body => {"apiKey" => "your-api-key"}}
+    assert_true(valid_simple_digest_header(request))
+  end
+
+  def test_invalid_simple_digest_header
+    request = {:request => { "Bugsnag-Integrity" => "simple 509"}, :body => {"apiKey" => "your-api-key"}}
+    assert_raise do
+      assert_true(valid_simple_digest_header(request))
+    end
+  end
+
+end


### PR DESCRIPTION
## Goal

Adds `the Bugsnag-Integrity header is valid` as a step to validate the `Bugsnag-Integrity` header. This should be a valid SHA-1 or simple digest.

The validation logic is covered by new unit tests. This has also been run against the Android CI here: https://github.com/bugsnag/bugsnag-android/pull/987