### PR TITLE
Provide an option to use the resilient driver

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -97,6 +97,7 @@ steps:
         run: browserstack-app-automate
     command: >-
       bundle exec bugsnag-maze-runner
+      --resilient
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
       --device=ANDROID_8_1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.3.0 - TBD
+
+## Enhancements
+
+- Make use of ResilientAppiumDriver optional
+  [#159](https://github.com/bugsnag/maze-runner/pull/159)
+
 # 3.2.0 - 2020/11/04
 
 ## Enhancements

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -17,6 +17,7 @@ class MazeRunnerEntry
   OPTION_FARM = 'farm'
   OPTION_APP = 'app'
   OPTION_A11Y_LOCATOR = 'a11y-locator'
+  OPTION_RESILIENT = 'resilient'
 
   # BrowserStack-only options
   OPTION_BS_LOCAL = 'bs-local'
@@ -57,6 +58,10 @@ class MazeRunnerEntry
           'Locate elements by accessibility id rather than id',
           short: :none,
           type: :boolean,
+          default: false
+      opt OPTION_RESILIENT,
+          'Use the resilient Appium driver',
+          short: :none,
           default: false
 
       # BrowserStack-only options
@@ -125,7 +130,8 @@ class MazeRunnerEntry
       OPTION_A11Y_LOCATOR,
       OPTION_UDID,
       OPTION_APPLE_TEAM_ID,
-      OPTION_BS_APPIUM_VERSION
+      OPTION_BS_APPIUM_VERSION,
+      OPTION_RESILIENT
     ]
     remove.each do |opt|
       @args.reject! { |arg| arg == "--#{opt}" || (arg.start_with? "--#{opt}=") }
@@ -166,6 +172,7 @@ class MazeRunnerEntry
     config = MazeRunner.config
     config.appium_session_isolation = options[OPTION_SEPARATE_SESSIONS]
     config.app_location = options[OPTION_APP]
+    config.resilient = options[OPTION_RESILIENT]
     farm = options[OPTION_FARM]
     config.farm = case farm
                   when nil then :none

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -35,10 +35,18 @@ AfterConfiguration do |config|
   # Set app location (file or url) in capabilities
   config.capabilities['app'] = config.app_location
 
-  # Create and start the driver
-  MazeRunner.driver = ResilientAppiumDriver.new config.appium_server_url,
-                                                config.capabilities,
-                                                config.locator
+  # Create and start the relevant driver
+  MazeRunner.driver = if MazeRunner.config.resilient
+                        $logger.info 'Creating ResilientAppiumDriver instance'
+                        ResilientAppiumDriver.new config.appium_server_url,
+                                                  config.capabilities,
+                                                  config.locator
+                      else
+                        $logger.info 'Creating AppiumDriver instance'
+                        AppiumDriver.new config.appium_server_url,
+                                         config.capabilities,
+                                         config.locator
+                      end
   if config.farm == :bs
     # Log a link to the BrowserStack session search dashboard
     build = MazeRunner.driver.caps[:build]

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -19,6 +19,9 @@ class Configuration
   # File path or URL of the app (IPA or APK) that tests will be run against
   attr_accessor :app_location
 
+  # Whether the ResilientAppiumDriver should be used (only applicable when using Appium in the first place)
+  attr_accessor :resilient
+
   # Device farm to be used, one of:
   # :bs (BrowserStack)
   # :local (Using Appium Server with a local device)


### PR DESCRIPTION
## Goal

Make the use of the ResilientAppiumDriver optional.

## Tests

`--resilient` option added to one of the CI test steps and logs inspected to check the expected branch was taken.
