### PR TITLE
Fix Appium version for iOS devices to 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
-# 3.3.0 - TBD
+# 3.3.0 - 2020/11/05
 
 ## Enhancements
 
 - Make use of ResilientAppiumDriver optional
   [#159](https://github.com/bugsnag/maze-runner/pull/159)
+
+## Fixes
+
+- Fix Appium version for iOS devices to 1.15.0.
+  [#161](https://github.com/bugsnag/maze-runner/pull/161)
 
 # 3.2.0 - 2020/11/04
 

--- a/lib/features/support/capabilities/devices.rb
+++ b/lib/features/support/capabilities/devices.rb
@@ -6,9 +6,9 @@ class Devices
   APPIUM_1_6_5 ||= '1.6.5'
   APPIUM_1_7_2 ||= '1.7.2'
   APPIUM_1_8_0 ||= '1.8.0'
+  APPIUM_1_15_0 ||= '1.15.0'
 
   class << self
-
     def make_android_hash(device, version, appium_version)
       {
         'device' => device,
@@ -35,7 +35,8 @@ class Devices
         'device' => device,
         'os_version' => version,
         'platformName' => 'iOS',
-        'os' => 'ios'
+        'os' => 'ios',
+        'browserstack.appium_version' => APPIUM_1_15_0
       }.freeze
     end
 


### PR DESCRIPTION
## Goal

Default the Appium version for iOS devices to 1.15.0.

## Design

Our Cocoa tests currently set the Appium version to 1.15.0 when they instantiate the ResilientAppiumDriver in `env.rb`, but the creation of the driver is now performed by Maze in v3.

This change simply sets the default Appium version in accordance with that.  Notifiers can still override this should they wish by using the `--appium-version=` command line option.

Note: The React Native CI pipeline still uses Maze Runner v2 currently, so there is no impact.

## Changeset

Appium version set for BrowserStack iOS devices only.

## Tests

Tested locally before raising the PR.  We do need to add iOS based tests to the Maze Runner CI, but that is outside of the scope of this PR.