### PR TITLE
Allow the Bugsnag-Integrity header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@
 - Add full range of iOS 11 devices on BrowserStack to test against
   [#166](https://github.com/bugsnag/maze-runner/pull/166)
 
+- Add the Bugsnag-Integrity header to Access-Control-Allow-Headers
+  [#167](https://github.com/bugsnag/maze-runner/pull/167)
+
 # 3.4.0 - 2020/11/10
 
 ## Enhancements
 
-- Add Cucumber steps for checking Bugsnag-Integrity headers, in addition to automatically 
+- Add Cucumber steps for checking Bugsnag-Integrity headers, in addition to automatically
   verifying digests on all received requests when the header is present.
   [#159](https://github.com/bugsnag/maze-runner/pull/159)
 - Reinstate environment clearing between scenarios
@@ -119,7 +122,7 @@
 
 ## Enhancements
 
-- Table-based assertions on requests, including option to specify 
+- Table-based assertions on requests, including option to specify
   expected values with Regexps.
   [#131](https://github.com/bugsnag/maze-runner/pull/131)
 
@@ -132,7 +135,7 @@
 
 ## Enhancements
 
-- Range of additional Android 6, 8.0 and 8.1 device options provided, 
+- Range of additional Android 6, 8.0 and 8.1 device options provided,
   together with Android 11 and iOS 14.
   [#127](https://github.com/bugsnag/maze-runner/pull/127)
 - Ability to run an HTTP/S proxy added
@@ -158,7 +161,7 @@
   [#122](https://github.com/bugsnag/maze-runner/pull/122)
 - Use BRANCH_NAME throughout instead of BUILDKITE_BRANCH
   [#123](https://github.com/bugsnag/maze-runner/pull/123)
-    
+
 # 2.3.2 - 2020/08/26
 
 ## Fixes
@@ -237,7 +240,7 @@ Addition of HTTP version steps.
 # 1.1.0
 
 Various changes have been made since the 1.0.0 release, but no specific versioning strategy
-was not employed.  This minor release encapsulates those changes and no further significant 
+was not employed.  This minor release encapsulates those changes and no further significant
 changes to the v1 series is expected (v2 already exists and should be used in preference).
 
 # 1.0.0

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -50,8 +50,16 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
     log_request(request)
     response.header['Access-Control-Allow-Origin'] = '*'
     response.header['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
-    response.header['Access-Control-Allow-Headers'] =
-      'Origin,Content-Type,Bugsnag-Sent-At,Bugsnag-Api-Key,Bugsnag-Payload-Version,Accept'
+    response.header['Access-Control-Allow-Headers'] = [
+      'Accept',
+      'Bugsnag-Api-Key',
+      'Bugsnag-Integrity',
+      'Bugsnag-Payload-Version',
+      'Bugsnag-Sent-At',
+      'Content-Type',
+      'Origin',
+    ].join(',')
+
     response.status = Server.status_code
   end
 


### PR DESCRIPTION
## Goal

The current `Access-Control-Allow-Headers` list doesn't include Bugsnag-Integrity, so requests using it fail in web browsers

> Request header field Bugsnag-Integrity is not allowed by Access-Control-Allow-Headers in preflight response.

## Tests

This is/will be tested by bugsnag-js; there aren't really any MR specific tests for this