### PR TITLE
Text entry and clearing tests added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ doc/
 .rakeTasks
 .yardoc/
 **/src/main/gen/
+.DS_Store

--- a/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
 import android.widget.Button
+import android.widget.EditText
 import com.bugsnag.android.*
 import java.lang.Exception
 
@@ -15,8 +16,9 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         val button = findViewById<Button>(R.id.trigger_error)
         button.setOnClickListener {
-
-            Bugsnag.notify(Exception("HandledException!"))
+            val metadata = findViewById<EditText>(R.id.metadata).text.toString()
+            val text = if (metadata == "") "HandledException!" else metadata
+            Bugsnag.notify(Exception(text))
         }
     }
 

--- a/test/fixtures/browserstack-app/app/src/main/res/layout/activity_main.xml
+++ b/test/fixtures/browserstack-app/app/src/main/res/layout/activity_main.xml
@@ -1,19 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="com.bugsnag.android.mazerunner.MainActivity">
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical"
+              android:paddingBottom="32dp"
+              android:paddingLeft="16dp"
+              android:paddingRight="16dp"
+              android:paddingTop="32dp"
+              tools:context="com.bugsnag.android.mazerunner.MainActivity">
+
+    <EditText
+            android:id="@+id/metadata"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text" />
 
     <Button
         android:id="@+id/trigger_error"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/error_button"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+/>
 
-</android.support.constraint.ConstraintLayout>
+</LinearLayout>

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -12,6 +12,17 @@ Scenario: Test Handled Android Exception
   # Verifies the environment variable change works
   And the payload field "apiKey" equals the environment variable "BUGSNAG_API_KEY"
 
+Scenario: Verify text entry and clearing steps
+  Given the element "trigger_error" is present
+  And I send the keys "IGNORE ME" to the element "metadata"
+  And I clear the element "metadata"
+  And I clear and send the keys "Listen to me!" to the element "metadata"
+  And I click the element "trigger_error"
+  Then I wait to receive a request
+  And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+  And the exception "errorClass" equals "java.lang.Exception"
+  And the exception "message" equals "Listen to me!"
+
 Scenario: Verify "equals the correct platform value" step
   Given the element "trigger_error" is present within 30 seconds
   When I click the element "trigger_error"


### PR DESCRIPTION
## Goal

Updates the BrowserStack test fixture and adds tests for text entry/clearing.

I found myself adding these as part of investigating a _possible_ bug in one of the steps.  I haven't found it necessary to make any changes to Maze as yet, but we may as well keep the tests.

## Changeset

BrowserStack test fixture updated and new scenario added.

## Tests

Covered by standard CI, no change to the MazeRunner tool itself..