### PR TITLE
Reword request count assertion error message

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -25,7 +25,11 @@ Then('I wait to receive {int} request(s)') do |request_count|
     received = (Server.stored_requests.size >= request_count)
     sleep 0.1
   end
-  raise "Expected #{request_count} requests but received #{Server.stored_requests.size} within the 30s timeout. This could indicate that Bugsnag crashed with a fatal error, or that it hasn’t made the requests that it should have done. Please check the device logs to confirm." unless received
+  unless received
+    raise "Expected #{request_count} requests but received #{Server.stored_requests.size} within the 30s timeout. " \
+      'This could indicate that Bugsnag crashed with a fatal error, or that it hasn’t made the requests that it ' \
+      'should have done. Please check the device logs to confirm.'
+  end
   
   assert_equal(request_count, Server.stored_requests.size, "#{Server.stored_requests.size} requests received")
 end

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -25,7 +25,8 @@ Then('I wait to receive {int} request(s)') do |request_count|
     received = (Server.stored_requests.size >= request_count)
     sleep 0.1
   end
-  raise "Requests not received in 30s (received #{Server.stored_requests.size})" unless received
+  raise "Expected #{request_count} requests but received #{Server.stored_requests.size} within the 30s timeout. This could indicate that Bugsnag crashed with a fatal error, or that it hasn’t made the requests that it should have done. Please check the device logs to confirm." unless received
+  
   assert_equal(request_count, Server.stored_requests.size, "#{Server.stored_requests.size} requests received")
 end
 


### PR DESCRIPTION
## Goal

Rewords the error message when the number of requests does not match what is expected, as this has caused confusion in the past.

An example of what this looks like:

```
When I run "CXXAutoContextScenario"                                 # features/steps/android_steps.rb:1
And I wait to receive a request                                     # /maze-runner/lib/features/steps/request_assertion_steps.rb:12
Expected 1 requests but received 0 within the 30s timeout. This could indicate that Bugsnag crashed with a fatal error, or that it hasn’t made the requests that it should have done. Please check the device logs to confirm. (RuntimeError)
```
