### PR TITLE
Allow more than one valid ISO8601 timezone format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# TBD
+
+## Enhancements
+
+- Allow timezone offsets in timestamps
+  [#174](https://github.com/bugsnag/maze-runner/pull/174)
+
 # 3.5.0 - 2020/11/13
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# TBD
+# 3.5.1 - 2020/11/17
 
-## Enhancements
+## Fixes
 
 - Allow timezone offsets in timestamps
   [#174](https://github.com/bugsnag/maze-runner/pull/174)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (3.5.0)
+    bugsnag-maze-runner (3.5.1)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -134,7 +134,6 @@ Then("the event {string} matches {string}") do |field, pattern|
 end
 
 # Tests whether a value in the first event entry is a timestamp.
-#   Uses the regex /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
 #
 # @step_input field [String] The relative location of the value to test
 Then("the event {string} is a timestamp") do |field|

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -30,7 +30,7 @@ Then('I wait to receive {int} request(s)') do |request_count|
       'This could indicate that Bugsnag crashed with a fatal error, or that it hasn’t made the requests that it ' \
       'should have done. Please check the device logs to confirm.'
   end
-  
+
   assert_equal(request_count, Server.stored_requests.size, "#{Server.stored_requests.size} requests received")
 end
 
@@ -81,7 +81,6 @@ Then('the {string} header equals one of:') do |header_name, header_values|
 end
 
 # Tests that a header is a timestamp.
-#   Uses the regex /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
 #
 # @step_input header_name [String] The header to test
 Then('the {string} header is a timestamp') do |header_name|
@@ -105,7 +104,6 @@ Then('the {string} query parameter is not null') do |parameter_name|
 end
 
 # Tests that a query parameter is a timestamp.
-#   Uses the regex /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
 #
 # @step_input parameter_name [String] The parameter to test
 Then('the {string} query parameter is a timestamp') do |parameter_name|

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -38,7 +38,6 @@ Then("the session {string} equals {string}") do |field, string_value|
 end
 
 # Tests whether a value in the first session entry is a timestamp.
-#   Uses the regex /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
 #
 # @step_input field [String] The relative location of the value to test
 Then("the session {string} is a timestamp") do |field|
@@ -70,7 +69,6 @@ Then("the sessionCount {string} equals {int}") do |field, int_value|
 end
 
 # Tests whether a value in the first sessionCount entry is a timestamp.
-#   Uses the regex /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
 #
 # @step_input field [String] The relative location of the value to test
 Then("the sessionCount {string} is a timestamp") do |field|

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -4,4 +4,4 @@ require 'securerandom'
 $api_key = SecureRandom.hex(16).tr('+/=', 'xyz')
 
 # A regex providing the pattern expected from timestamps
-TIMESTAMP_REGEX = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z?$/
+TIMESTAMP_REGEX = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+(Z|[+-]\d{2}:\d{2})?$/

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '3.5.0'.freeze
+  VERSION = '3.5.1'.freeze
 end

--- a/test/fixtures/payload-helpers/features/scripts/send_request.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_request.sh
@@ -2,6 +2,7 @@
 
 require 'net/http'
 require 'json'
+require 'time'
 
 http = Net::HTTP.new('localhost', ENV['MOCK_API_PORT'])
 request = Net::HTTP::Post.new('/')
@@ -12,7 +13,7 @@ templates = {
     'headers' => {
       'Bugsnag-Api-Key' => ENV['BUGSNAG_API_KEY'],
       'Bugsnag-Payload-Version' => '4.0',
-      'Bugsnag-Sent-At' => Time.now().utc().strftime('%Y-%m-%dT%H:%M:%S')
+      'Bugsnag-Sent-At' => Time.now().iso8601(3)
     },
     'body' => {
       'apiKey' => ENV['BUGSNAG_API_KEY'],
@@ -38,7 +39,7 @@ templates = {
     'headers' => {
       'Bugsnag-Api-Key' => ENV['BUGSNAG_API_KEY'],
       'Bugsnag-Payload-Version' => '1.0',
-      'Bugsnag-Sent-At' => Time.now().utc().strftime('%Y-%m-%dT%H:%M:%S')
+      'Bugsnag-Sent-At' => Time.now().iso8601(3)
     },
     'body' => {
       'notifier' => {


### PR DESCRIPTION
## Goal

ISO8601 timezones can either be 'Z' for UTC or a timezone offset, e.g. '+01:00' or '-12:34'

The PHP notifier uses timezone offsets rather than forcing everything to UTC, so the current assertions fail — only the Laravel notifier has MR tests so this wasn't noticed at the time

## Tests

One of the tests now uses Ruby's `iso8601` method, which returns '+00:00' for UTC