### PR TITLE
Refactor parsing and processing of command line options

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,7 @@ steps:
     command: 'bundle exec maze-runner'
 
   - label: 'Browserstack app-automate test - Android 6'
-    depends_on: "ci-image"
+    depends_on: "test-images"
     plugins:
       docker-compose#v3.7.0:
         run: browserstack-app-automate
@@ -79,7 +79,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'Browserstack app-automate test - Android 7.1 (separate Appium sessions)'
-    depends_on: "ci-image"
+    depends_on: "test-images"
     plugins:
       docker-compose#v3.7.0:
         run: browserstack-app-automate
@@ -94,7 +94,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'Browserstack app-automate test - Android 8.1'
-    depends_on: "ci-image"
+    depends_on: "test-images"
     plugins:
       docker-compose#v3.7.0:
         run: browserstack-app-automate
@@ -110,7 +110,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'Browserstack app-automate test - Android 9'
-    depends_on: "ci-image"
+    depends_on: "test-images"
     plugins:
       docker-compose#v3.7.0:
         run: browserstack-app-automate
@@ -125,7 +125,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'Browserstack app-automate test - Android 10 (separate Appium sessions)'
-    depends_on: "ci-image"
+    depends_on: "test-images"
     plugins:
       docker-compose#v3.7.0:
         run: browserstack-app-automate
@@ -141,7 +141,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'Browserstack app-automate test - Android 11 (separate Appium sessions)'
-    depends_on: "ci-image"
+    depends_on: "test-images"
     plugins:
       docker-compose#v3.7.0:
         run: browserstack-app-automate

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -5,6 +5,7 @@ require 'cucumber/cli/main'
 require_relative '../lib/features/support/maze_runner'
 require_relative '../lib/features/support/option'
 require_relative '../lib/features/support/option_parser'
+require_relative '../lib/features/support/option_processor'
 require_relative '../lib/features/support/capabilities/capabilities'
 require_relative '../lib/features/support/capabilities/devices'
 
@@ -72,61 +73,7 @@ class MazeRunnerEntry
 
     # Process CL options
     init if options[:init]
-    config = MazeRunner.config
-    config.appium_session_isolation = options[Option::SEPARATE_SESSIONS]
-    config.app_location = options[Option::APP]
-    config.resilient = options[Option::RESILIENT]
-    farm = options[Option::FARM]
-    config.farm = case farm
-                  when nil then :none
-                  when 'bs' then :bs
-                  when 'local' then :local
-                  else
-                    raise "Unknown farm '#{farm}'"
-                  end
-    config.locator = options[Option::A11Y_LOCATOR] ? :accessibility_id : :id
-
-    # Farm specific options
-    case config.farm
-    when :bs then
-      raise "option --#{Option::USERNAME} must be specified" if options[Option::USERNAME].nil?
-      raise "option --#{Option::ACCESS_KEY} must be specified" if options[Option::ACCESS_KEY].nil?
-
-      bs_device = options[Option::BS_DEVICE]
-      raise "option --#{Option::BS_DEVICE} must be specified" if bs_device.nil?
-      unless Devices::DEVICE_HASH.key? bs_device
-        raise "Device type '#{bs_device}' not known on BrowserStack.  Must be one of #{Devices::DEVICE_HASH.keys}"
-      end
-
-      config.bs_device = bs_device
-      config.os_version = Devices::DEVICE_HASH[config.bs_device]['os_version'].to_f
-      config.bs_local = options[Option::BS_LOCAL]
-      config.appium_version = options[Option::BS_APPIUM_VERSION]
-      username = config.username = options[Option::USERNAME]
-      access_key = config.access_key = options[Option::ACCESS_KEY]
-      config.appium_server_url = "http://#{username}:#{access_key}@hub-cloud.browserstack.com/wd/hub"
-    when :local then
-      raise "option --#{Option::OS} must be specified" if options[Option::OS].nil?
-      raise "option --#{Option::OS_VERSION} must be specified" if options[Option::OS_VERSION].nil?
-      # Ensure OS version is a valid float so that notifier tests can perform numeric checks, e.g:
-      # 'MazeRunner.config.os_version > 7'
-      unless /^[1-9][0-9]*(\.[0-9])?/.match? options[Option::OS_VERSION]
-        raise "option --#{Option::OS_VERSION} must be a valid OS version matching '/^[1-9][0-9]*(\\.[0-9])?/'"
-      end
-
-      os = MazeRunner.config.os = options[Option::OS].downcase
-      MazeRunner.config.os_version = options[Option::OS_VERSION].to_f
-      raise 'os must be ios or android' unless %w[ios android].include? os
-
-      config.appium_server_url = options[Option::APPIUM_SERVER]
-      if os == 'ios'
-        raise 'option --apple-team-id must be specified for iOS' if options[Option::APPLE_TEAM_ID].nil?
-        raise 'option --udid must be specified for iOS' if options[Option::UDID].nil?
-
-        config.apple_team_id = options[Option::APPLE_TEAM_ID]
-        config.device_id = options[Option::UDID]
-      end
-    end
+    Maze::OptionProcessor.populate MazeRunner.config, options
 
     # Adjust CL options before calling down to Cucumber
     remove_maze_runner_args

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -69,7 +69,7 @@ class MazeRunnerEntry
     # Parse args, processing any Maze Runner specific options
     @args = args.dup
     options = Maze::OptionParser.parse args
-    return unless options
+    exit unless options
 
     # Process CL options
     init if options[:init]

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -69,7 +69,6 @@ class MazeRunnerEntry
     # Parse args, processing any Maze Runner specific options
     @args = args.dup
     options = Maze::OptionParser.parse args
-    exit unless options
 
     # Process CL options
     init if options[:init]

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -2,91 +2,14 @@
 # frozen_string_literal: true
 
 require 'cucumber/cli/main'
-require 'optimist'
 require_relative '../lib/features/support/maze_runner'
 require_relative '../lib/features/support/option'
+require_relative '../lib/features/support/option_parser'
 require_relative '../lib/features/support/capabilities/capabilities'
 require_relative '../lib/features/support/capabilities/devices'
-require_relative '../lib/version'
 
 # Encapsulates the MazeRunner entry point
 class MazeRunnerEntry
-
-  def initialize
-    @parser = Optimist::Parser.new do
-      text 'Maze Runner extends the functionality of Cucumber, ' \
-        'providing all of the command line arguments that it provides.'
-      text ''
-      text 'Usage [OPTIONS] <filenames>'
-      text ''
-      text 'Overridden Cucumber options:'
-      opt :help, 'Print this help.'
-      opt :init, 'Initialises a new Maze Runner project'
-
-      opt :version, 'Display Maze Runner and Cucumber versions'
-
-      # Common options
-      opt Option::SEPARATE_SESSIONS,
-          'Start a new Appium session for each scenario',
-          short: :none,
-          type: :boolean,
-          default: false
-      opt Option::FARM, 'Device farm to use: "bs" (BrowserStack) or "local"', short: :none, type: :string
-      opt Option::APP, 'The app to be installed and run against', short: :none, type: :string
-      opt Option::A11Y_LOCATOR,
-          'Locate elements by accessibility id rather than id',
-          short: :none,
-          type: :boolean,
-          default: false
-      opt Option::RESILIENT,
-          'Use the resilient Appium driver',
-          short: :none,
-          default: false
-
-      # BrowserStack-only options
-      opt Option::BS_LOCAL,
-          '(BS only) Path to the BrowserStackLocal binary',
-          short: :none,
-          type: :string,
-          default: '/BrowserStackLocal'
-      opt Option::BS_DEVICE,
-          'BrowserStack device to use (a key of Devices.DEVICE_HASH)',
-          short: :none,
-          type: :string
-      opt Option::USERNAME, 'Device farm username', short: :none, type: :string
-      opt Option::ACCESS_KEY, 'Device farm access key', short: :none, type: :string
-      opt Option::BS_APPIUM_VERSION,
-          'The Appium version to use with BrowserStack',
-          short: :none,
-          type: :string
-
-      # Local-only options
-      opt Option::OS,
-          'OS type to use ("ios", "android")',
-          short: :none,
-          type: :string
-      opt Option::OS_VERSION,
-          'The intended OS version when running on a local device',
-          short: :none,
-          type: :string
-      opt Option::APPIUM_SERVER,
-          'Appium server URL, only used for --farm=local',
-          short: :none,
-          type: :string,
-          default: 'http://localhost:4723/wd/hub'
-      opt Option::APPLE_TEAM_ID, 'Apple Team Id, required for local iOS testing', short: :none, type: :string
-      opt Option::UDID, 'Apple UDID, required for local iOS testing', short: :none, type: :string
-
-      version "Maze Runner v#{BugsnagMazeRunner::VERSION} " \
-              "(Cucumber v#{Cucumber::VERSION.strip})"
-      text ''
-      text 'The Cucumber help follows:'
-      text ''
-    end
-
-    # Allow for options destined for Cucumber
-    @parser.ignore_invalid_options = true
-  end
 
   def init
     require_relative 'commands/init'
@@ -144,7 +67,8 @@ class MazeRunnerEntry
   def start(args)
     # Parse args, processing any Maze Runner specific options
     @args = args.dup
-    options = @parser.parse args
+    options = Maze::OptionParser.parse args
+    return unless options
 
     # Process CL options
     init if options[:init]
@@ -209,14 +133,6 @@ class MazeRunnerEntry
     add_cucumber_args
 
     Cucumber::Cli::Main.new(@args).execute!
-
-  rescue Optimist::HelpNeeded
-    # Display
-    @parser.educate
-    Cucumber::Cli::Main.new(['--help']).execute!
-
-  rescue Optimist::VersionNeeded
-    puts @parser.version
   end
 end
 

--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -4,34 +4,13 @@
 require 'cucumber/cli/main'
 require 'optimist'
 require_relative '../lib/features/support/maze_runner'
+require_relative '../lib/features/support/option'
 require_relative '../lib/features/support/capabilities/capabilities'
 require_relative '../lib/features/support/capabilities/devices'
 require_relative '../lib/version'
 
 # Encapsulates the MazeRunner entry point
-#
-# TODO: Factor out CL options/processing to reduce overall size
 class MazeRunnerEntry
-  # Common options
-  OPTION_SEPARATE_SESSIONS = 'separate-sessions'
-  OPTION_FARM = 'farm'
-  OPTION_APP = 'app'
-  OPTION_A11Y_LOCATOR = 'a11y-locator'
-  OPTION_RESILIENT = 'resilient'
-
-  # BrowserStack-only options
-  OPTION_BS_LOCAL = 'bs-local'
-  OPTION_BS_DEVICE = 'device'
-  OPTION_USERNAME = 'username'
-  OPTION_ACCESS_KEY = 'access-key'
-  OPTION_BS_APPIUM_VERSION = 'appium-version'
-
-  # Local-only options
-  OPTION_OS = 'os'
-  OPTION_OS_VERSION = 'os-version'
-  OPTION_APPIUM_SERVER = 'appium-server'
-  OPTION_APPLE_TEAM_ID = 'apple-team-id'
-  OPTION_UDID = 'udid'
 
   def initialize
     @parser = Optimist::Parser.new do
@@ -47,56 +26,56 @@ class MazeRunnerEntry
       opt :version, 'Display Maze Runner and Cucumber versions'
 
       # Common options
-      opt OPTION_SEPARATE_SESSIONS,
+      opt Option::SEPARATE_SESSIONS,
           'Start a new Appium session for each scenario',
           short: :none,
           type: :boolean,
           default: false
-      opt OPTION_FARM, 'Device farm to use: "bs" (BrowserStack) or "local"', short: :none, type: :string
-      opt OPTION_APP, 'The app to be installed and run against', short: :none, type: :string
-      opt OPTION_A11Y_LOCATOR,
+      opt Option::FARM, 'Device farm to use: "bs" (BrowserStack) or "local"', short: :none, type: :string
+      opt Option::APP, 'The app to be installed and run against', short: :none, type: :string
+      opt Option::A11Y_LOCATOR,
           'Locate elements by accessibility id rather than id',
           short: :none,
           type: :boolean,
           default: false
-      opt OPTION_RESILIENT,
+      opt Option::RESILIENT,
           'Use the resilient Appium driver',
           short: :none,
           default: false
 
       # BrowserStack-only options
-      opt OPTION_BS_LOCAL,
+      opt Option::BS_LOCAL,
           '(BS only) Path to the BrowserStackLocal binary',
           short: :none,
           type: :string,
           default: '/BrowserStackLocal'
-      opt OPTION_BS_DEVICE,
+      opt Option::BS_DEVICE,
           'BrowserStack device to use (a key of Devices.DEVICE_HASH)',
           short: :none,
           type: :string
-      opt OPTION_USERNAME, 'Device farm username', short: :none, type: :string
-      opt OPTION_ACCESS_KEY, 'Device farm access key', short: :none, type: :string
-      opt OPTION_BS_APPIUM_VERSION,
+      opt Option::USERNAME, 'Device farm username', short: :none, type: :string
+      opt Option::ACCESS_KEY, 'Device farm access key', short: :none, type: :string
+      opt Option::BS_APPIUM_VERSION,
           'The Appium version to use with BrowserStack',
           short: :none,
           type: :string
 
       # Local-only options
-      opt OPTION_OS,
+      opt Option::OS,
           'OS type to use ("ios", "android")',
           short: :none,
           type: :string
-      opt OPTION_OS_VERSION,
+      opt Option::OS_VERSION,
           'The intended OS version when running on a local device',
           short: :none,
           type: :string
-      opt OPTION_APPIUM_SERVER,
+      opt Option::APPIUM_SERVER,
           'Appium server URL, only used for --farm=local',
           short: :none,
           type: :string,
           default: 'http://localhost:4723/wd/hub'
-      opt OPTION_APPLE_TEAM_ID, 'Apple Team Id, required for local iOS testing', short: :none, type: :string
-      opt OPTION_UDID, 'Apple UDID, required for local iOS testing', short: :none, type: :string
+      opt Option::APPLE_TEAM_ID, 'Apple Team Id, required for local iOS testing', short: :none, type: :string
+      opt Option::UDID, 'Apple UDID, required for local iOS testing', short: :none, type: :string
 
       version "Maze Runner v#{BugsnagMazeRunner::VERSION} " \
               "(Cucumber v#{Cucumber::VERSION.strip})"
@@ -117,21 +96,21 @@ class MazeRunnerEntry
   # Removes Maze Runner specific args from the array, as these will cause Cucumber to error.
   def remove_maze_runner_args
     remove = [
-      OPTION_SEPARATE_SESSIONS,
-      OPTION_APP,
-      OPTION_BS_LOCAL,
-      OPTION_BS_DEVICE,
-      OPTION_OS,
-      OPTION_OS_VERSION,
-      OPTION_FARM,
-      OPTION_USERNAME,
-      OPTION_ACCESS_KEY,
-      OPTION_APPIUM_SERVER,
-      OPTION_A11Y_LOCATOR,
-      OPTION_UDID,
-      OPTION_APPLE_TEAM_ID,
-      OPTION_BS_APPIUM_VERSION,
-      OPTION_RESILIENT
+      Option::SEPARATE_SESSIONS,
+      Option::APP,
+      Option::BS_LOCAL,
+      Option::BS_DEVICE,
+      Option::OS,
+      Option::OS_VERSION,
+      Option::FARM,
+      Option::USERNAME,
+      Option::ACCESS_KEY,
+      Option::APPIUM_SERVER,
+      Option::A11Y_LOCATOR,
+      Option::UDID,
+      Option::APPLE_TEAM_ID,
+      Option::BS_APPIUM_VERSION,
+      Option::RESILIENT
     ]
     remove.each do |opt|
       @args.reject! { |arg| arg == "--#{opt}" || (arg.start_with? "--#{opt}=") }
@@ -170,10 +149,10 @@ class MazeRunnerEntry
     # Process CL options
     init if options[:init]
     config = MazeRunner.config
-    config.appium_session_isolation = options[OPTION_SEPARATE_SESSIONS]
-    config.app_location = options[OPTION_APP]
-    config.resilient = options[OPTION_RESILIENT]
-    farm = options[OPTION_FARM]
+    config.appium_session_isolation = options[Option::SEPARATE_SESSIONS]
+    config.app_location = options[Option::APP]
+    config.resilient = options[Option::RESILIENT]
+    farm = options[Option::FARM]
     config.farm = case farm
                   when nil then :none
                   when 'bs' then :bs
@@ -181,47 +160,47 @@ class MazeRunnerEntry
                   else
                     raise "Unknown farm '#{farm}'"
                   end
-    config.locator = options[OPTION_A11Y_LOCATOR] ? :accessibility_id : :id
+    config.locator = options[Option::A11Y_LOCATOR] ? :accessibility_id : :id
 
     # Farm specific options
     case config.farm
     when :bs then
-      raise "option --#{OPTION_USERNAME} must be specified" if options[OPTION_USERNAME].nil?
-      raise "option --#{OPTION_ACCESS_KEY} must be specified" if options[OPTION_ACCESS_KEY].nil?
+      raise "option --#{Option::USERNAME} must be specified" if options[Option::USERNAME].nil?
+      raise "option --#{Option::ACCESS_KEY} must be specified" if options[Option::ACCESS_KEY].nil?
 
-      bs_device = options[OPTION_BS_DEVICE]
-      raise "option --#{OPTION_BS_DEVICE} must be specified" if bs_device.nil?
+      bs_device = options[Option::BS_DEVICE]
+      raise "option --#{Option::BS_DEVICE} must be specified" if bs_device.nil?
       unless Devices::DEVICE_HASH.key? bs_device
         raise "Device type '#{bs_device}' not known on BrowserStack.  Must be one of #{Devices::DEVICE_HASH.keys}"
       end
 
       config.bs_device = bs_device
       config.os_version = Devices::DEVICE_HASH[config.bs_device]['os_version'].to_f
-      config.bs_local = options[OPTION_BS_LOCAL]
-      config.appium_version = options[OPTION_BS_APPIUM_VERSION]
-      username = config.username = options[OPTION_USERNAME]
-      access_key = config.access_key = options[OPTION_ACCESS_KEY]
+      config.bs_local = options[Option::BS_LOCAL]
+      config.appium_version = options[Option::BS_APPIUM_VERSION]
+      username = config.username = options[Option::USERNAME]
+      access_key = config.access_key = options[Option::ACCESS_KEY]
       config.appium_server_url = "http://#{username}:#{access_key}@hub-cloud.browserstack.com/wd/hub"
     when :local then
-      raise "option --#{OPTION_OS} must be specified" if options[OPTION_OS].nil?
-      raise "option --#{OPTION_OS_VERSION} must be specified" if options[OPTION_OS_VERSION].nil?
+      raise "option --#{Option::OS} must be specified" if options[Option::OS].nil?
+      raise "option --#{Option::OS_VERSION} must be specified" if options[Option::OS_VERSION].nil?
       # Ensure OS version is a valid float so that notifier tests can perform numeric checks, e.g:
       # 'MazeRunner.config.os_version > 7'
-      unless /^[1-9][0-9]*(\.[0-9])?/.match? options[OPTION_OS_VERSION]
-        raise "option --#{OPTION_OS_VERSION} must be a valid OS version matching '/^[1-9][0-9]*(\\.[0-9])?/'"
+      unless /^[1-9][0-9]*(\.[0-9])?/.match? options[Option::OS_VERSION]
+        raise "option --#{Option::OS_VERSION} must be a valid OS version matching '/^[1-9][0-9]*(\\.[0-9])?/'"
       end
 
-      os = MazeRunner.config.os = options[OPTION_OS].downcase
-      MazeRunner.config.os_version = options[OPTION_OS_VERSION].to_f
+      os = MazeRunner.config.os = options[Option::OS].downcase
+      MazeRunner.config.os_version = options[Option::OS_VERSION].to_f
       raise 'os must be ios or android' unless %w[ios android].include? os
 
-      config.appium_server_url = options[OPTION_APPIUM_SERVER]
+      config.appium_server_url = options[Option::APPIUM_SERVER]
       if os == 'ios'
-        raise 'option --apple-team-id must be specified for iOS' if options[OPTION_APPLE_TEAM_ID].nil?
-        raise 'option --udid must be specified for iOS' if options[OPTION_UDID].nil?
+        raise 'option --apple-team-id must be specified for iOS' if options[Option::APPLE_TEAM_ID].nil?
+        raise 'option --udid must be specified for iOS' if options[Option::UDID].nil?
 
-        config.apple_team_id = options[OPTION_APPLE_TEAM_ID]
-        config.device_id = options[OPTION_UDID]
+        config.apple_team_id = options[Option::APPLE_TEAM_ID]
+        config.device_id = options[Option::UDID]
       end
     end
 

--- a/lib/features/support/option.rb
+++ b/lib/features/support/option.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Provides the set of Maze Runner command line options
+class Option
+  # Common options
+  SEPARATE_SESSIONS ||= 'separate-sessions'
+  FARM ||= 'farm'
+  APP ||= 'app'
+  A11Y_LOCATOR ||= 'a11y-locator'
+  RESILIENT ||= 'resilient'
+
+  # BrowserStack-only options
+  BS_LOCAL ||= 'bs-local'
+  BS_DEVICE ||= 'device'
+  USERNAME ||= 'username'
+  ACCESS_KEY ||= 'access-key'
+  BS_APPIUM_VERSION ||= 'appium-version'
+
+  # Local-only options
+  OS ||= 'os'
+  OS_VERSION ||= 'os-version'
+  APPIUM_SERVER ||= 'appium-server'
+  APPLE_TEAM_ID ||= 'apple-team-id'
+  UDID ||= 'udid'
+end

--- a/lib/features/support/option_parser.rb
+++ b/lib/features/support/option_parser.rb
@@ -85,12 +85,12 @@ module Maze
         parser.parse args
 
       rescue Optimist::HelpNeeded
-        # Display
         parser.educate
         Cucumber::Cli::Main.new(['--help']).execute!
-
+        exit
       rescue Optimist::VersionNeeded
         puts parser.version
+        exit
       end
     end
   end

--- a/lib/features/support/option_parser.rb
+++ b/lib/features/support/option_parser.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'cucumber/cli/main'
+require 'optimist'
+require_relative '../../version'
+
+module Maze
+  # Parses the command line options
+  class OptionParser
+    class << self
+      def parse(args)
+        parser = Optimist::Parser.new do
+          text 'Maze Runner extends the functionality of Cucumber, ' \
+            'providing all of the command line arguments that it provides.'
+          text ''
+          text 'Usage [OPTIONS] <filenames>'
+          text ''
+          text 'Overridden Cucumber options:'
+          opt :help, 'Print this help.'
+          opt :init, 'Initialises a new Maze Runner project'
+
+          opt :version, 'Display Maze Runner and Cucumber versions'
+
+          # Common options
+          opt Option::SEPARATE_SESSIONS,
+              'Start a new Appium session for each scenario',
+              short: :none,
+              type: :boolean,
+              default: false
+          opt Option::FARM, 'Device farm to use: "bs" (BrowserStack) or "local"', short: :none, type: :string
+          opt Option::APP, 'The app to be installed and run against', short: :none, type: :string
+          opt Option::A11Y_LOCATOR,
+              'Locate elements by accessibility id rather than id',
+              short: :none,
+              type: :boolean,
+              default: false
+          opt Option::RESILIENT,
+              'Use the resilient Appium driver',
+              short: :none,
+              default: false
+
+          # BrowserStack-only options
+          opt Option::BS_LOCAL,
+              '(BS only) Path to the BrowserStackLocal binary',
+              short: :none,
+              type: :string,
+              default: '/BrowserStackLocal'
+          opt Option::BS_DEVICE,
+              'BrowserStack device to use (a key of Devices.DEVICE_HASH)',
+              short: :none,
+              type: :string
+          opt Option::USERNAME, 'Device farm username', short: :none, type: :string
+          opt Option::ACCESS_KEY, 'Device farm access key', short: :none, type: :string
+          opt Option::BS_APPIUM_VERSION,
+              'The Appium version to use with BrowserStack',
+              short: :none,
+              type: :string
+
+          # Local-only options
+          opt Option::OS,
+              'OS type to use ("ios", "android")',
+              short: :none,
+              type: :string
+          opt Option::OS_VERSION,
+              'The intended OS version when running on a local device',
+              short: :none,
+              type: :string
+          opt Option::APPIUM_SERVER,
+              'Appium server URL, only used for --farm=local',
+              short: :none,
+              type: :string,
+              default: 'http://localhost:4723/wd/hub'
+          opt Option::APPLE_TEAM_ID, 'Apple Team Id, required for local iOS testing', short: :none, type: :string
+          opt Option::UDID, 'Apple UDID, required for local iOS testing', short: :none, type: :string
+
+          version "Maze Runner v#{BugsnagMazeRunner::VERSION} " \
+                  "(Cucumber v#{Cucumber::VERSION.strip})"
+          text ''
+          text 'The Cucumber help follows:'
+          text ''
+        end
+
+        # Allow for options destined for Cucumber
+        parser.ignore_invalid_options = true
+        parser.parse args
+
+      rescue Optimist::HelpNeeded
+        # Display
+        parser.educate
+        Cucumber::Cli::Main.new(['--help']).execute!
+
+      rescue Optimist::VersionNeeded
+        puts parser.version
+      end
+    end
+  end
+end

--- a/lib/features/support/option_processor.rb
+++ b/lib/features/support/option_processor.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Maze
+  # Processes the parsed command line options
+  class OptionProcessor
+    class << self
+      # Populates config from the parsed options given
+      # @param config [Configuration] MazeRunner configuration to populate
+      # @param options [Hash] Parsed command line options
+      def populate(config, options)
+        config.appium_session_isolation = options[Option::SEPARATE_SESSIONS]
+        config.app_location = options[Option::APP]
+        config.resilient = options[Option::RESILIENT]
+        farm = options[Option::FARM]
+        config.farm = case farm
+                      when nil then :none
+                      when 'bs' then :bs
+                      when 'local' then :local
+                      else
+                        raise "Unknown farm '#{farm}'"
+                      end
+        config.locator = options[Option::A11Y_LOCATOR] ? :accessibility_id : :id
+
+        # Farm specific options
+        case config.farm
+        when :bs then
+          raise "option --#{Option::USERNAME} must be specified" if options[Option::USERNAME].nil?
+          raise "option --#{Option::ACCESS_KEY} must be specified" if options[Option::ACCESS_KEY].nil?
+
+          bs_device = options[Option::BS_DEVICE]
+          raise "option --#{Option::BS_DEVICE} must be specified" if bs_device.nil?
+          unless Devices::DEVICE_HASH.key? bs_device
+            raise "Device type '#{bs_device}' not known on BrowserStack.  Must be one of #{Devices::DEVICE_HASH.keys}"
+          end
+
+          config.bs_device = bs_device
+          config.os_version = Devices::DEVICE_HASH[config.bs_device]['os_version'].to_f
+          config.bs_local = options[Option::BS_LOCAL]
+          config.appium_version = options[Option::BS_APPIUM_VERSION]
+          username = config.username = options[Option::USERNAME]
+          access_key = config.access_key = options[Option::ACCESS_KEY]
+          config.appium_server_url = "http://#{username}:#{access_key}@hub-cloud.browserstack.com/wd/hub"
+        when :local then
+          raise "option --#{Option::OS} must be specified" if options[Option::OS].nil?
+          raise "option --#{Option::OS_VERSION} must be specified" if options[Option::OS_VERSION].nil?
+          # Ensure OS version is a valid float so that notifier tests can perform numeric checks, e.g:
+          # 'MazeRunner.config.os_version > 7'
+          unless /^[1-9][0-9]*(\.[0-9])?/.match? options[Option::OS_VERSION]
+            raise "option --#{Option::OS_VERSION} must be a valid OS version matching '/^[1-9][0-9]*(\\.[0-9])?/'"
+          end
+
+          os = MazeRunner.config.os = options[Option::OS].downcase
+          MazeRunner.config.os_version = options[Option::OS_VERSION].to_f
+          raise 'os must be ios or android' unless %w[ios android].include? os
+
+          config.appium_server_url = options[Option::APPIUM_SERVER]
+          if os == 'ios'
+            raise 'option --apple-team-id must be specified for iOS' if options[Option::APPLE_TEAM_ID].nil?
+            raise 'option --udid must be specified for iOS' if options[Option::UDID].nil?
+
+            config.apple_team_id = options[Option::APPLE_TEAM_ID]
+            config.device_id = options[Option::UDID]
+          end
+        when :none
+          # Nothing to do
+        else
+          raise "Unexpected farm option #{config.farm}"
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/android-app/app/build.gradle
+++ b/test/fixtures/android-app/app/build.gradle
@@ -39,5 +39,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {
+    mavenCentral()
     jcenter()
 }

--- a/test/fixtures/android-app/build.gradle
+++ b/test/fixtures/android-app/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     ext.kotlin_version = '1.2.51'
 
     repositories {
+        mavenCentral()
         google()
         jcenter()
     }
@@ -18,6 +19,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         google()
         jcenter()
     }

--- a/test/fixtures/browserstack-app/build.gradle
+++ b/test/fixtures/browserstack-app/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     ext.kotlin_version = '1.3.72'
 
     repositories {
+        mavenCentral()
         google()
         jcenter()
     }
@@ -18,6 +19,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         google()
         jcenter()
     }


### PR DESCRIPTION
## Goal

Split the existing `bugsnag-maze-runner` entry point into separate files to reduce its size and make unit testing of each aspect easier.

## Design

I've been as friendly as I can be, by performing the refactoring in three distinct commits - each should be reviewable in its own right with no overlap.

## Changeset

This is a refactor only, there should be no change in functionality.

## Tests

Should be covered by passing CI, but I have also performed some light local testing including use of the `--help` and `--version` options.  Some further testing with notifier clients before release would also seem prudent on this occasion.
