### PR TITLE
macOS automation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add `--capabilities` option
   [#176](https://github.com/bugsnag/maze-runner/pull/176)
+- Add support for MacOS devices using AppiumForMac
+  [#177](https://github.com/bugsnag/maze-runner/pull/177)
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add `--capabilities` option
   [#176](https://github.com/bugsnag/maze-runner/pull/176)
-- Add support for MacOS devices using AppiumForMac
+- Add support for macOS devices using AppiumForMac
   [#177](https://github.com/bugsnag/maze-runner/pull/177)
 
 ## Fixes

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y ruby-full apt-utils docker-compose wget
                                         libcurl4 libcurl4-openssl-dev
 RUN ruby -v
 
-RUN wget -q https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip \
+RUN wget -q https://storage.googleapis.com/bugsnag-public-test-dependencies/BrowserStackLocal-linux-x64.zip \
   && unzip BrowserStackLocal-linux-x64.zip \
   && rm BrowserStackLocal-linux-x64.zip
 

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -22,9 +22,9 @@ AfterConfiguration do |config|
                                                          config.appium_version,
                                                          config.capabilities_option
 
-    config.app_location = BrowserStackUtils.upload_app config.username,
-                                                       config.access_key,
-                                                       config.app_location
+    config.app = BrowserStackUtils.upload_app config.username,
+                                              config.access_key,
+                                              config.app
     BrowserStackUtils.start_local_tunnel config.bs_local,
                                          tunnel_id,
                                          config.access_key
@@ -36,7 +36,7 @@ AfterConfiguration do |config|
   end
 
   # Set app location (file or url) in capabilities
-  config.capabilities['app'] = config.app_location
+  config.capabilities['app'] = config.app
 
   # Create and start the relevant driver
   MazeRunner.driver = if MazeRunner.config.resilient
@@ -76,8 +76,8 @@ Before do |scenario|
 
   MazeRunner.driver.start_driver if MazeRunner.config.farm != :none && MazeRunner.config.appium_session_isolation
 
-  # Launch the app on MacOS
-  MazeRunner.driver.get(MazeRunner.config.app_location) if MazeRunner.config.os == 'macos'
+  # Launch the app on macOS
+  MazeRunner.driver.get(MazeRunner.config.app) if MazeRunner.config.os == 'macos'
 
   # Call any blocks registered by the client
   MazeRunner.hooks.call_before scenario
@@ -128,7 +128,7 @@ After do |scenario|
     MazeRunner.driver.driver_quit
   elsif MazeRunner.config.os == 'macos'
     # Close the app - without the sleep, launching the app for the next scenario intermittently fails
-    system("killall #{MazeRunner.config.app_location} && sleep 1")
+    system("killall #{MazeRunner.config.app} && sleep 1")
   else
     MazeRunner.driver.reset_with_timeout 2
   end

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -30,10 +30,11 @@ AfterConfiguration do |config|
                                          config.access_key
   elsif config.farm == :local
     config.capabilities = Capabilities.for_local config.os,
+                                                 config.capabilities_option,
                                                  config.apple_team_id,
-                                                 config.device_id,
-                                                 config.capabilities_option
+                                                 config.device_id
   end
+
   # Set app location (file or url) in capabilities
   config.capabilities['app'] = config.app_location
 
@@ -76,7 +77,7 @@ Before do |scenario|
   MazeRunner.driver.start_driver if MazeRunner.config.farm != :none && MazeRunner.config.appium_session_isolation
 
   # Launch the app on MacOS
-  MazeRunner.driver.get(MazeRunner.config.app_location) if MazeRunner.driver.os == 'macos'
+  MazeRunner.driver.get(MazeRunner.config.app_location) if MazeRunner.config.os == 'macos'
 
   # Call any blocks registered by the client
   MazeRunner.hooks.call_before scenario

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -75,6 +75,9 @@ Before do |scenario|
 
   MazeRunner.driver.start_driver if MazeRunner.config.farm != :none && MazeRunner.config.appium_session_isolation
 
+  # Launch the app on MacOS
+  MazeRunner.driver.get(MazeRunner.config.app_location) if MazeRunner.driver.os == 'macos'
+
   # Call any blocks registered by the client
   MazeRunner.hooks.call_before scenario
 end
@@ -122,6 +125,9 @@ After do |scenario|
 
   if MazeRunner.config.appium_session_isolation
     MazeRunner.driver.driver_quit
+  elsif MazeRunner.config.os == 'macos'
+    # Close the app - without the sleep, launching the app for the next scenario intermittently fails
+    system("killall #{MazeRunner.config.app_location} && sleep 1")
   else
     MazeRunner.driver.reset_with_timeout 2
   end

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -25,15 +25,12 @@ end
 # @step_input element_id [String] The locator id
 When('I click the element {string}') do |element_id|
   MazeRunner.driver.click_element(element_id)
-  begin
-    MazeRunner.driver.click_element(element_id)
-  rescue StandardError
-    # AppiumForMac raises an to run a scenario that crashes the app
-    raise unless MazeRunner.config.os == 'macos'
+rescue StandardError
+  # AppiumForMac raises an to run a scenario that crashes the app
+  raise unless MazeRunner.config.os == 'macos'
 
-    $logger.warn 'Ignoring exception raised on click_element - this is normal for AppiumForMac if the button click ' \
-      'causes the app to crash.'
-  end
+  $logger.warn 'Ignoring exception raised on click_element - this is normal for AppiumForMac if the button click ' \
+    'causes the app to crash.'
 end
 
 # Sends the app to the background for a number of seconds

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -25,6 +25,15 @@ end
 # @step_input element_id [String] The locator id
 When('I click the element {string}') do |element_id|
   MazeRunner.driver.click_element(element_id)
+  begin
+    MazeRunner.driver.click_element(element_id)
+  rescue StandardError
+    # AppiumForMac raises an to run a scenario that crashes the app
+    raise unless MazeRunner.config.os == 'macos'
+
+    $logger.warn 'Ignoring exception raised on click_element - this is normal for AppiumForMac if the button click ' \
+      'causes the app to crash.'
+  end
 end
 
 # Sends the app to the background for a number of seconds
@@ -122,6 +131,23 @@ end
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
 Then('the event {string} equals the platform-dependent boolean:') do |field_path, platform_values|
   test_boolean_platform_values("events.0.#{field_path}", platform_values)
+end
+
+# See `the payload field {string} equals the platform-dependent string:`
+#
+# @step_input field_path [String] The field to test, prepended with "events.0.exceptions.0."
+# @step_input platform_values [DataTable] A table of acceptable values for each platform
+Then('the exception {string} equals the platform-dependent string:') do |field_path, platform_values|
+  test_string_platform_values("events.0.exceptions.0.#{field_path}", platform_values)
+end
+
+# See `the payload field {string} equals the platform-dependent string:`
+#
+# @step_input field_path [String] The field to test, prepended with "events.0.exceptions.0.stacktrace.#{num}"
+# @step_input field_path [String] The index of the stack frame to test
+# @step_input platform_values [DataTable] A table of acceptable values for each platform
+Then('the {string} of stack frame {int} equals the platform-dependent string:') do |field_path, num, platform_values|
+  test_string_platform_values("events.0.exceptions.0.stacktrace.#{num}.#{field_path}", platform_values)
 end
 
 # Sends keys to a given element, clearing it first

--- a/lib/features/support/browser_stack_utils.rb
+++ b/lib/features/support/browser_stack_utils.rb
@@ -7,16 +7,16 @@ class BrowserStackUtils
     # Uploads an app to BrowserStack for later consumption
     # @param username [String] the BrowserStack username
     # @param access_key [String] the BrowserStack access key
-    def upload_app(username, access_key, app_location)
+    def upload_app(username, access_key, app)
       # TODO: Improve error handling:
       #   - res may not be JSON at all
-      #   - what if app_location doesn't exist locally
-      if app_location.start_with? 'bs://'
-        app_url = app_location
-        $logger.info "Using pre-uploaded app from #{app_location}"
+      #   - what if app doesn't exist locally
+      if app.start_with? 'bs://'
+        app_url = app
+        $logger.info "Using pre-uploaded app from #{app}"
       else
         url = 'https://api-cloud.browserstack.com/app-automate/upload'
-        res = `curl -u "#{username}:#{access_key}" -X POST "#{url}" -F "file=@#{app_location}"`
+        res = `curl -u "#{username}:#{access_key}" -X POST "#{url}" -F "file=@#{app}"`
         response = JSON.parse(res)
         raise "BrowserStack upload failed due to error: #{response['error']}" if response.include?('error')
 

--- a/lib/features/support/capabilities/capabilities.rb
+++ b/lib/features/support/capabilities/capabilities.rb
@@ -5,8 +5,8 @@ class Capabilities
   class << self
     # @param device_type [String] A key from @see Devices::DEVICE_HASH
     # @param local_id [String] unique key for the tunnel instance
-    # @param capabilties_option [String] extra capabilities provided on the command line
-    def for_browser_stack(device_type, local_id, appium_version, capabilties_option)
+    # @param capabilities_option [String] extra capabilities provided on the command line
+    def for_browser_stack(device_type, local_id, appium_version, capabilities_option)
       capabilities = {
         'browserstack.console' => 'errors',
         'browserstack.localIdentifier' => local_id,
@@ -14,18 +14,18 @@ class Capabilities
         'browserstack.networkLogs' => 'true'
       }
       capabilities.merge! Devices::DEVICE_HASH[device_type]
-      capabilities.merge! JSON.parse(capabilties_option)
+      capabilities.merge! JSON.parse(capabilities_option)
       capabilities['browserstack.appium_version'] = appium_version unless appium_version.nil?
       capabilities
     end
 
     # Constructs Appium capabilities for running on a local Android or iOS device.
     # @param platform [String] 'ios' or 'android'
-    # @param capabilties_option [String] extra capabilities provided on the command line
+    # @param capabilities_option [String] extra capabilities provided on the command line
     # @param team_id [String] Apple Team Id, for iOS only
     # @param udid [String] device UDID, for iOS only
     # noinspection RubyStringKeysInHashInspection
-    def for_local(platform, capabilties_option, team_id = nil, udid = nil)
+    def for_local(platform, capabilities_option, team_id = nil, udid = nil)
       capabilities = if platform.downcase == 'android'
                        {
                          'platformName' => 'Android',
@@ -41,13 +41,17 @@ class Capabilities
                          'xcodeSigningId' => 'iPhone Developer',
                          'udid' => udid
                        }
+                     elsif platform.downcase == 'macos'
+                       {
+                         'platformName' => 'Mac'
+                       }
                      end
       common = {
         'os' => platform,
         'autoAcceptAlerts': 'true'
       }
       capabilities.merge! common
-      capabilities.merge! JSON.parse(capabilties_option)
+      capabilities.merge! JSON.parse(capabilities_option)
     end
   end
 end

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -20,8 +20,11 @@ module Maze
     # Appium capabilities provided via the CL
     attr_accessor :capabilities_option
 
-    # File path or URL of the app (IPA or APK) that tests will be run against
-    attr_accessor :app_location
+    # The app that tests will be run against.  Could be one of:
+    # - a local file path
+    # - a BrowserStack url for a previously uploaded app (bs://...)
+    # - on macOS, the name of an installed or previously executed application
+    attr_accessor :app
 
     # Whether the ResilientAppiumDriver should be used (only applicable when using Appium in the first place)
     attr_accessor :resilient

--- a/lib/options/option_processor.rb
+++ b/lib/options/option_processor.rb
@@ -12,7 +12,7 @@ module Maze
       # @param options [Hash] Parsed command line options
       def populate(config, options)
         config.appium_session_isolation = options[Maze::Option::SEPARATE_SESSIONS]
-        config.app_location = options[Maze::Option::APP]
+        config.app = options[Maze::Option::APP]
         config.resilient = options[Maze::Option::RESILIENT]
         farm = options[Maze::Option::FARM]
         config.farm = case farm

--- a/lib/options/option_validator.rb
+++ b/lib/options/option_validator.rb
@@ -57,6 +57,7 @@ module Maze
       else
         os = options[Maze::Option::OS].downcase
         errors << 'os must be ios or android' unless %w[ios android].include? os
+        errors << 'os must be android, ios or macos' unless %w[android ios macos].include? os
         if os == 'ios'
           if options[Maze::Option::APPLE_TEAM_ID].nil?
             errors << "--#{Maze::Option::APPLE_TEAM_ID} must be specified for iOS"

--- a/lib/options/option_validator.rb
+++ b/lib/options/option_validator.rb
@@ -56,7 +56,6 @@ module Maze
         errors << "--#{Maze::Option::OS} must be specified"
       else
         os = options[Maze::Option::OS].downcase
-        errors << 'os must be ios or android' unless %w[ios android].include? os
         errors << 'os must be android, ios or macos' unless %w[android ios macos].include? os
         if os == 'ios'
           if options[Maze::Option::APPLE_TEAM_ID].nil?

--- a/test/browser_stack_utils_test.rb
+++ b/test/browser_stack_utils_test.rb
@@ -8,7 +8,7 @@ require_relative '../lib/features/support/browser_stack_utils'
 class BrowserStackUtilsTest < Test::Unit::TestCase
 
   ACCESS_KEY = 'access_key'
-  APP_LOCATION = '/app/location'
+  APP = '/app/location'
   BS_LOCAL = '/home/BrowserStackLocal'
   LOCAL_ID = 'abcde'
   TEST_APP_URL = 'bs://1234567890abcdef'
@@ -31,9 +31,9 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
     $logger.expects(:info).with('You can use this url to avoid uploading the same app more than once.').once
 
     json_response = JSON.dump(app_url: TEST_APP_URL)
-    expected_command = %(curl -u "#{USERNAME}:#{ACCESS_KEY}" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@#{APP_LOCATION}")
+    expected_command = %(curl -u "#{USERNAME}:#{ACCESS_KEY}" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@#{APP}")
     BrowserStackUtils.stubs(:`).with(expected_command).returns(json_response)
-    url = BrowserStackUtils.upload_app USERNAME, ACCESS_KEY, APP_LOCATION
+    url = BrowserStackUtils.upload_app USERNAME, ACCESS_KEY, APP
     assert_equal(TEST_APP_URL, url)
   end
 
@@ -41,10 +41,10 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
     json_response = JSON.dump(
       error: 'Error'
     )
-    expected_command = %(curl -u "#{USERNAME}:#{ACCESS_KEY}" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@#{APP_LOCATION}")
+    expected_command = %(curl -u "#{USERNAME}:#{ACCESS_KEY}" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@#{APP}")
     BrowserStackUtils.stubs(:`).with(expected_command).returns(json_response)
     assert_raise(RuntimeError, 'BrowserStack upload failed due to error: Error') do
-      BrowserStackUtils.upload_app USERNAME, ACCESS_KEY, APP_LOCATION
+      BrowserStackUtils.upload_app USERNAME, ACCESS_KEY, APP
     end
   end
 

--- a/test/options/options_processor_test.rb
+++ b/test/options/options_processor_test.rb
@@ -16,7 +16,7 @@ class OptionsProcessorTest < Test::Unit::TestCase
     assert_true config.appium_session_isolation
     assert_false config.resilient
     assert_equal :bs, config.farm
-    assert_equal 'my_app.apk', config.app_location
+    assert_equal 'my_app.apk', config.app
     assert_equal 'user', config.username
     assert_equal 'key', config.access_key
     assert_equal 'ANDROID_6_0', config.bs_device
@@ -43,7 +43,7 @@ class OptionsProcessorTest < Test::Unit::TestCase
     Maze::OptionProcessor.populate config, options
 
     assert_equal :local, config.farm
-    assert_equal 'my_app.ipa', config.app_location
+    assert_equal 'my_app.ipa', config.app
     assert_equal 'ios', config.os
     assert_equal 7.1, config.os_version
     assert_equal 'ABC', config.apple_team_id

--- a/test/options/options_validator_test.rb
+++ b/test/options/options_validator_test.rb
@@ -93,6 +93,15 @@ class OptionValidatorTest < Test::Unit::TestCase
     assert_empty errors
   end
 
+  def test_local_invalid_os
+    args = %w[--farm=local --app=my_app --os=invalid --os-version=8]
+    options = Maze::OptionParser.parse args
+    errors = @validator.validate options
+
+    assert_equal 1, errors.length
+    assert_equal 'os must be android, ios or macos', errors[0]
+  end
+
   def test_local_missing_os
     args = %w[--farm=local --app=my_app --os-version=8]
     options = Maze::OptionParser.parse args


### PR DESCRIPTION
## Goal

Provides the ability to run tests against macOS apps (using `--farm=local` and `--os=macos`) using Appium and [AppiumForMac](https://github.com/appium/appium-for-mac).

## Design

Follows the thrust of the recent prototype developed by @nickdowell, updated to align with the current codebase.

## Changeset

- Addition of `macos` as a valid `--os`
- Setting of Appium capabilities for MacOS
- Hooks to launch/kill MacOS apps
- New Cucumber steps to support MacOS testing

## Tests

Tested successfully locally with the macOS test fixture and scenarios currently in development in `bugsnag-cocoa`.