### PR TITLE
Fix check for Bugsnag-Integrity header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# TBD
+# 3.6.0 - 2020/11/25
 
 ## Enhancements
 
@@ -8,6 +8,7 @@
   [#178](https://github.com/bugsnag/maze-runner/pull/178)
 - Enforce presence of `Bugsnag-Integrity` based on MazeRunner.config.enforce_bugsnag_integrity
   [#179](https://github.com/bugsnag/maze-runner/pull/179)
+  [#180](https://github.com/bugsnag/maze-runner/pull/180)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (3.5.1)
+    bugsnag-maze-runner (3.6.0)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -27,7 +27,7 @@ GEM
       appium_lib_core (~> 3.3)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (3.11.0)
+    appium_lib_core (3.11.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.18.2)
@@ -88,7 +88,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    test-unit (3.3.6)
+    test-unit (3.3.7)
       power_assert
     textutils (1.4.0)
       activesupport

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -97,7 +97,7 @@ class Servlet < WEBrick::HTTPServlet::AbstractServlet
   # if configuration says so.
   def check_digest(request)
     header = request['Bugsnag-Integrity']
-    if MazeRunner.config.enforce_bugsnag_integrity
+    if header.nil? && MazeRunner.config.enforce_bugsnag_integrity
       raise 'Bugsnag-Integrity header must be present according to MazeRunner.config.enforce_bugsnag_integrity'
     end
     return if header.nil?

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '3.5.1'.freeze
+  VERSION = '3.6.0'.freeze
 end


### PR DESCRIPTION
## Goal

Fixes the check on the `Bugsnag-Integrity` header and prepares for the release of v3.6.0.

## Tests

As before, further testing any updates to notifier repo will be made as part of shepherding the release out.