### PR TITLE
Resolve warning: already initialized constant INTERVAL

### DIFF
--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -20,15 +20,15 @@ end
 #
 # @step_input request_count [Integer] The amount of requests expected
 Then('I wait to receive {int} request(s)') do |request_count|
-  INTERVAL = 0.1
+  interval = 0.1
   timeout = MazeRunner.config.receive_requests_wait
-  max_attempts = timeout / INTERVAL
+  max_attempts = timeout / interval
   attempts = 0
   received = false
   until (attempts >= max_attempts) || received
     attempts += 1
     received = (Server.stored_requests.size >= request_count)
-    sleep INTERVAL
+    sleep interval
   end
   unless received
     raise <<-MESSAGE


### PR DESCRIPTION
## Goal

Resolve the following runtime warning `warning: already initialized constant INTERVAL`

Observable in the last CI run for master (in the No-device tests step):


Scenario: Testing payloads pass regardless of order | 1s
-- | --
  | Scenario: Testing payloads pass regardless of order # features/test_unordered_requests.feature:3
  | When I send a "ordered 1"-type request            # features/steps/scripting_steps.rb:1
  | And I send a "ordered 2"-type request             # features/steps/scripting_steps.rb:1
  | /app/lib/features/steps/request_assertion_steps.rb:23: warning: already initialized constant INTERVAL
  | /app/lib/features/steps/request_assertion_steps.rb:23: warning: previous definition of INTERVAL was here
  | And I wait to receive 2 requests                  # lib/features/steps/request_assertion_steps.rb:22
  | Then the tests match the following:               # features/steps/scripting_steps.rb:9
  | \| foo \| bar \|
  | \| a   \| b   \|
  | \| b   \| a   \|
  | And the tests match the following:                # features/steps/scripting_steps.rb:9
  | \| foo \| bar \|
  | \| b   \| a   \|
  | \| a   \| b   \|

