### PR TITLE
InteractiveCLI fixes for RN CLI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,6 +59,8 @@ steps:
       - docker-compose#v3.7.0:
           run: proxy-tests
       - docker-compose#v3.7.0:
+          run: cli-tests
+      - docker-compose#v3.7.0:
           run: http-response-tests
       - docker-compose#v3.7.0:
           run: payload-helper-tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,12 @@ services:
       BUILDKITE_BUILD_NUMBER:
       BUILDKITE_STEP_KEY:
 
+  cli-tests:
+    build:
+      context: test/fixtures/cli
+      args:
+        BRANCH_NAME:
+
   comparison-tests:
     build:
       context: test/fixtures/comparison

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -5,6 +5,7 @@ require 'minitest'
 require 'open-uri'
 require 'json'
 require 'cgi'
+require_relative '../../wait'
 
 include Test::Unit::Assertions
 
@@ -20,16 +21,10 @@ end
 #
 # @step_input request_count [Integer] The amount of requests expected
 Then('I wait to receive {int} request(s)') do |request_count|
-  INTERVAL = 0.1
-  timeout = MazeRunner.config.receive_requests_wait
-  max_attempts = timeout / INTERVAL
-  attempts = 0
-  received = false
-  until (attempts >= max_attempts) || received
-    attempts += 1
-    received = (Server.stored_requests.size >= request_count)
-    sleep INTERVAL
-  end
+  wait = Maze::Wait.new(timeout: MazeRunner.config.receive_requests_wait)
+
+  received = wait.until { Server.stored_requests.size >= request_count }
+
   unless received
     raise <<-MESSAGE
     Expected #{request_count} requests but received #{Server.stored_requests.size} within the #{timeout}s timeout.

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -124,6 +124,17 @@ When('I stop the current shell') do
   Runner.stop_interactive_session
 end
 
+# Attempts to wait for the currently running interactive shell to exit
+When('I wait for the current shell to exit') do
+  shell = Runner.get_interactive_session
+  result = shell.wait_for_exit
+
+  # The result should be the Thread object if it successfully stopped; if it
+  # timed out then 'nil' is returned
+  assert_false(result.nil?, 'The shell is still running when it should have exited')
+  assert_false(shell.running?, 'The shell is still running when it should have exited')
+end
+
 # Run a command on the shell
 #
 # @step_input command [String] The command to run on the shell

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -163,7 +163,7 @@ Then('the shell has output {string} to stdout') do |expected_line|
   assert(match, "No output lines from #{current_shell.stdout_lines} matched #{expected_line}")
 end
 
-# Wait for a string to appear in the stdout logs
+# Wait for a string to appear in the stdout logs, timing out after MazeRunner.config.receive_requests_wait seconds.
 #
 # @step_input expected_line [String] The string present in stdout logs
 Then('I wait for the shell to output {string} to stdout') do |expected_line|

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -1,3 +1,5 @@
+require_relative '../../wait'
+
 # @!group Runner steps
 
 # Sets an environment variable for subsequent scripts or commands.
@@ -165,24 +167,14 @@ end
 #
 # @step_input expected_line [String] The string present in stdout logs
 Then('I wait for the shell to output {string} to stdout') do |expected_line|
+  wait = Maze::Wait.new(timeout: MazeRunner.config.receive_requests_wait)
   current_shell = Runner.get_interactive_session
 
-  interval = 0.1
-  timeout = MazeRunner.config.receive_requests_wait
-  max_attempts = timeout / interval
-
-  attempts = 0
-  matches = false
-
-  until matches do
-    break if attempts >= max_attempts
-
-    matches = current_shell.stdout_lines.any? { |line| line == expected_line }
-
-    sleep interval unless matches
+  success = wait.until do
+    current_shell.stdout_lines.any? { |line| line == expected_line }
   end
 
-  assert(matches, "No output lines from #{current_shell.stdout_lines} matched #{expected_line}")
+  assert(success, "No output lines from #{current_shell.stdout_lines} matched #{expected_line}")
 end
 
 # Verify a string appears in the stderr logs
@@ -198,21 +190,11 @@ end
 #
 # @step_input expected_line [String] The string present in stderr logs
 Then('I wait for the shell to output {string} to stderr') do |expected_line|
+  wait = Maze::Wait.new(timeout: MazeRunner.config.receive_requests_wait)
   current_shell = Runner.get_interactive_session
 
-  interval = 0.1
-  timeout = MazeRunner.config.receive_requests_wait
-  max_attempts = timeout / interval
-
-  attempts = 0
-  matches = false
-
-  until matches do
-    break if attempts >= max_attempts
-
-    matches = current_shell.stderr_lines.any? { |line| line == expected_line }
-
-    sleep interval unless matches
+  success = wait.until do
+    current_shell.stderr_lines.any? { |line| line == expected_line }
   end
 
   assert(matches, "No output lines from #{current_shell.stderr_lines} matched #{expected_line}")

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -161,6 +161,30 @@ Then('the shell has output {string} to stdout') do |expected_line|
   assert(match, "No output lines from #{current_shell.stdout_lines} matched #{expected_line}")
 end
 
+# Wait for a string to appear in the stdout logs
+#
+# @step_input expected_line [String] The string present in stdout logs
+Then('I wait for the shell to output {string} to stdout') do |expected_line|
+  current_shell = Runner.get_interactive_session
+
+  interval = 0.1
+  timeout = MazeRunner.config.receive_requests_wait
+  max_attempts = timeout / interval
+
+  attempts = 0
+  matches = false
+
+  until matches do
+    break if attempts >= max_attempts
+
+    matches = current_shell.stdout_lines.any? { |line| line == expected_line }
+
+    sleep interval unless matches
+  end
+
+  assert(matches, "No output lines from #{current_shell.stdout_lines} matched #{expected_line}")
+end
+
 # Verify a string appears in the stderr logs
 #
 # @step_input expected_err [String] The string present in stderr logs
@@ -168,6 +192,30 @@ Then('the shell has output {string} to stderr') do |expected_err|
   current_shell = Runner.get_interactive_session
   match = current_shell.stderr_lines.any? { |line| line == expected_err }
   assert(match, "No output lines from #{current_shell.stderr_lines} matched #{expected_err}")
+end
+
+# Wait for a string to appear in the stderr logs
+#
+# @step_input expected_line [String] The string present in stderr logs
+Then('I wait for the shell to output {string} to stderr') do |expected_line|
+  current_shell = Runner.get_interactive_session
+
+  interval = 0.1
+  timeout = MazeRunner.config.receive_requests_wait
+  max_attempts = timeout / interval
+
+  attempts = 0
+  matches = false
+
+  until matches do
+    break if attempts >= max_attempts
+
+    matches = current_shell.stderr_lines.any? { |line| line == expected_line }
+
+    sleep interval unless matches
+  end
+
+  assert(matches, "No output lines from #{current_shell.stderr_lines} matched #{expected_line}")
 end
 
 # Verify the shell exited successfully (assuming a 0 is a success)

--- a/lib/features/support/runner.rb
+++ b/lib/features/support/runner.rb
@@ -76,24 +76,30 @@ class Runner
     #
     # @return [InteractiveCLI] The interactiveCLI instance
     def get_interactive_session
-      @interactive_session ||= InteractiveCLI.new(environment)
+      return @interactive_session unless @interactive_session.nil?
+
+      interactive_session = InteractiveCLI.new(environment)
+
       attempts = 0
-      until @interactive_session.pid
+
+      until interactive_session.pid
         raise "Shell session would not start within 3 seconds" if attempts > 10 # allows 3 seconds of opening
 
         attempts += 1
         sleep(0.3)
       end
-      @interactive_session
+
+      @interactive_session = interactive_session
     end
 
     # Stops the interactive session, allowing a new one to be started
     def stop_interactive_session
-      return unless @interactive_session&.running
+      return if @interactive_session.nil?
 
       @interactive_session.stop
+
       # Make sure the process is properly ended
-      pids << @interactive_session.pid
+      pids << @interactive_session.pid if @interactive_session.pid
       @interactive_session = nil
     end
 

--- a/lib/wait.rb
+++ b/lib/wait.rb
@@ -7,8 +7,11 @@ module Maze
     # @param interval [Numeric] Optional. The time to sleep between attempts
     # @param timeout [Numeric] The amount of time to spend on attempts before giving up
     def initialize(interval: 0.1, timeout:)
+      raise "Interval must be greater than zero, got '#{interval}'" unless interval > 0
+      raise "Timeout (#{timeout}) must be greater than interval (#{interval})" unless timeout > interval
+
       @interval = interval
-      @max_attempts = interval / timeout
+      @max_attempts = timeout / interval
     end
 
     # Wait until the given block succeeds (returns a truthy value) or the
@@ -20,6 +23,7 @@ module Maze
       attempts = 0
 
       until success || attempts >= @max_attempts do
+        attempts += 1
         success = block.call
 
         sleep @interval unless success

--- a/lib/wait.rb
+++ b/lib/wait.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Maze
+  # Allows repeated attempts at something, until it is successful or the timeout
+  # is exceed
+  class Wait
+    # @param interval [Numeric] Optional. The time to sleep between attempts
+    # @param timeout [Numeric] The amount of time to spend on attempts before giving up
+    def initialize(interval: 0.1, timeout:)
+      @interval = interval
+      @max_attempts = interval / timeout
+    end
+
+    # Wait until the given block succeeds (returns a truthy value) or the
+    # timeout is exceeded
+    #
+    # @return [Object] The last value returned by the block
+    def until(&block)
+      success = false
+      attempts = 0
+
+      until success || attempts >= @max_attempts do
+        success = block.call
+
+        sleep @interval unless success
+      end
+
+      success
+    end
+  end
+end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -27,7 +27,7 @@ class InteractiveCLITest < Test::Unit::TestCase
     assert_nil(cli.last_exit_code)
     assert_nil(cli.pid)
     assert_equal(cli.current_buffer, '')
-    assert_false(cli.running)
+    assert_false(cli.running?)
     assert_false(cli.run_command('foo'))
 
     Open3.expects(:popen3).with({}, '/bin/sh')
@@ -54,7 +54,7 @@ class InteractiveCLITest < Test::Unit::TestCase
     assert_nil(cli.last_exit_code)
     assert_nil(cli.pid)
     assert_equal(cli.current_buffer, '')
-    assert_false(cli.running)
+    assert_false(cli.running?)
     assert_false(cli.run_command('foo'))
 
     Open3.expects(:popen3).with(environment, new_shell_cmd)

--- a/test/fixtures/cli/Dockerfile
+++ b/test/fixtures/cli/Dockerfile
@@ -1,5 +1,8 @@
 ARG BRANCH_NAME
 FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
+RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+RUN sudo apt-get install -y nodejs
+
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/cli/Dockerfile
+++ b/test/fixtures/cli/Dockerfile
@@ -1,0 +1,5 @@
+ARG BRANCH_NAME
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+
+COPY . /app
+WORKDIR /app

--- a/test/fixtures/cli/Gemfile
+++ b/test/fixtures/cli/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gem 'bugsnag-maze-runner', path: '../../..'
 gem 'pry'

--- a/test/fixtures/cli/Gemfile
+++ b/test/fixtures/cli/Gemfile
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'bugsnag-maze-runner', path: '../../..'
-gem 'pry'

--- a/test/fixtures/cli/features/CLI.feature
+++ b/test/fixtures/cli/features/CLI.feature
@@ -9,6 +9,8 @@ Feature: Interactive CLI support
     When I input "A" interactively
     And I wait for 1 seconds
     Then the shell has output "Repeat 5 times AAAAA" to stdout
+    And I wait for the current shell to exit
+    And the shell exited successfully
 
   Scenario: Allows reading of errors
     Given I start a new shell
@@ -17,6 +19,6 @@ Feature: Interactive CLI support
     Then the shell has output "Starting error script" to stdout
     And the current stdout line is "Input anything to error "
     When I input "A" interactively
-    And I wait for 1 seconds
+    And I wait for the current shell to exit
     Then the shell exited with an error code
     And the shell has output "Error: Oh no it's all gone wrong" to stderr

--- a/test/fixtures/cli/features/CLI.feature
+++ b/test/fixtures/cli/features/CLI.feature
@@ -3,21 +3,18 @@ Feature: Interactive CLI support
   Scenario: Supports a node script
     Given I start a new shell
     When I input "./features/fixtures/node_script" interactively
-    And I wait for 2 seconds
-    Then the shell has output "Starting node script" to stdout
-    And the current stdout line is "Repeat 5 times "
+    And I wait for the shell to output "Starting node script" to stdout
+    Then the current stdout line is "Repeat 5 times "
     When I input "A" interactively
-    And I wait for 1 seconds
-    Then the shell has output "Repeat 5 times AAAAA" to stdout
+    And I wait for the shell to output "Repeat 5 times AAAAA" to stdout
     And I wait for the current shell to exit
-    And the shell exited successfully
+    Then the shell exited successfully
 
   Scenario: Allows reading of errors
     Given I start a new shell
     When I input "./features/fixtures/error_script" interactively
-    And I wait for 2 seconds
-    Then the shell has output "Starting error script" to stdout
-    And the current stdout line is "Input anything to error "
+    And I wait for the shell to output "Starting error script" to stdout
+    Then the current stdout line is "Input anything to error "
     When I input "A" interactively
     And I wait for the current shell to exit
     Then the shell exited with an error code

--- a/test/wait_test.rb
+++ b/test/wait_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../lib/wait'
+
+# noinspection RubyNilAnalysis
+class WaitTest < Test::Unit::TestCase
+  def test_it_returns_block_result_on_success
+    wait = Maze::Wait.new(timeout: 1)
+
+    result = wait.until { true }
+
+    assert_true(result)
+  end
+
+  def test_it_retries_until_block_returns_truthy_value
+    wait = Maze::Wait.new(interval: 0.01, timeout: 0.1)
+
+    attempts = 0
+
+    result = wait.until(&lambda do
+      attempts += 1
+
+      return false if attempts < 5
+
+      true
+    end)
+
+    assert_true(result)
+    assert_equal(attempts, 5)
+  end
+
+  def test_it_retries_until_it_times_out
+    wait = Maze::Wait.new(interval: 0.01, timeout: 0.1)
+
+    attempts = 0
+
+    result = wait.until(&lambda do
+      attempts += 1
+
+      return false if attempts < 500
+
+      # this will never be reached as the timeout is shorter than the time it
+      # would take to reach 500 attempts
+      true
+    end)
+
+    assert_false(result)
+    assert_equal(attempts, 10)
+  end
+
+  def test_it_raises_when_timeout_is_zero
+    assert_raises(RuntimeError, "Timeout must be greater than zero, got '0'") do
+      Maze::Wait.new(timeout: 0)
+    end
+  end
+
+  def test_it_raises_when_interval_is_zero
+    assert_raises(RuntimeError, "Interval (0) must be greater than timeout (1)") do
+      Maze::Wait.new(interval: 0, timeout: 1)
+    end
+  end
+
+  def test_it_raises_when_timeout_is_negative
+    assert_raises(RuntimeError, "Timeout must be greater than zero, got '-1'") do
+      Maze::Wait.new(timeout: -1)
+    end
+  end
+
+  def test_it_raises_when_interval_is_negative
+    assert_raises(RuntimeError, "Interval (-5) must be greater than timeout (1)") do
+      Maze::Wait.new(interval: -5, timeout: 1)
+    end
+  end
+end


### PR DESCRIPTION
## Goal

Fixes some problems with the Interactive CLI / its tests, so that it's ready to use in anger

The tests were failing for two reasons:
- the docker image didn't have Node installed, so they couldn't run the scripts
- the command didn't exit until _after_ the stderr assertion, so stderr was never populated in time

If "the shell exited successfully" was added to the first step it would also fail due to the second reason above — the shell only exited _after_ the test finished. This has also been fixed, so tests can assert that they worked by waiting for the shell to exit

It's a bit unfortunate to have to explicitly let the shell exit, but I think this is unavoidable as the code doesn't know what the command should do, so it can't make assumptions about when it should be done

## Design

A new "I wait for the current shell to exit" step has been added, which closes STDIN and then waits for the command to stop, timing out after 15 seconds (if it times out then the step will fail)

I've also added "I wait for the shell to output {string} to stdout/stderr" steps, which wait for output rather than using "I wait X seconds". I did a bit of refactoring here to avoid having the same wait code in 3 places (the 2 new steps + "I wait to receive X requests")

## Tests

The current MR tests for this now pass