### PR TITLE
Allow checking the exit code of multiple commands

### DIFF
--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require_relative '../../wait'
 
 # @!group Runner steps
@@ -244,9 +245,11 @@ end
 Then('the last interactive command exited successfully') do
   assert(Runner.interactive_session?, 'No interactive session is running so the exit code cannot be checked')
 
+  uuid = SecureRandom.uuid
+
   steps %Q{
-    When I input "[ $? = 0 ] && echo 'exited with 0' || echo 'exited with error'" interactively
-    Then I wait for the shell to output "exited with 0" to stdout
+    When I input "[ $? = 0 ] && echo '#{uuid} exited with 0' || echo '#{uuid} exited with error'" interactively
+    Then I wait for the shell to output "#{uuid} exited with 0" to stdout
   }
 end
 
@@ -256,9 +259,11 @@ end
 Then('the last interactive command exit code is {int}') do |exit_code|
   assert(Runner.interactive_session?, 'No interactive session is running so the exit code cannot be checked')
 
+  uuid = SecureRandom.uuid
+
   steps %Q{
-    When I input "echo $?" interactively
-    Then I wait for the shell to output "#{exit_code}" to stdout
+    When I input "echo #{uuid} $?" interactively
+    Then I wait for the shell to output "#{uuid} #{exit_code}" to stdout
   }
 end
 
@@ -266,8 +271,10 @@ end
 Then('the last interactive command exited with an error code') do
   assert(Runner.interactive_session?, 'No interactive session is running so the exit code cannot be checked')
 
+  uuid = SecureRandom.uuid
+
   steps %Q{
-    When I input "[ $? = 0 ] && echo 'exited with 0' || echo 'exited with error'" interactively
-    Then I wait for the shell to output "exited with error" to stdout
+    When I input "[ $? = 0 ] && echo '#{uuid} exited with 0' || echo '#{uuid} exited with error'" interactively
+    Then I wait for the shell to output "#{uuid} exited with error" to stdout
   }
 end

--- a/test/fixtures/docker-app/features/run_docker_services.feature
+++ b/test/fixtures/docker-app/features/run_docker_services.feature
@@ -92,3 +92,15 @@ Feature: Running docker services and commands
         Then I wait for the shell to output "Hello" to stdout
 
         And the last interactive command exited successfully
+
+    Scenario: A service can be run multiple scripts with different exit codes
+        When I run the service "interactive" interactively
+        And I wait for the shell prompt "# "
+        And I input "(exit 0)" interactively
+        Then the last interactive command exited successfully
+        When I input "(exit 1)" interactively
+        Then the last interactive command exited with an error code
+        When I input "(exit 127)" interactively
+        Then the last interactive command exit code is 127
+        When I input "(exit 0)" interactively
+        Then the last interactive command exited successfully


### PR DESCRIPTION
## Goal

Currently our matching on stdout is done against any line — this is a good thing because otherwise there are race conditions and the potential for ordering changes to cause tests to flake

However, we also use the output of `echo $?` (and similar) to check the exit codes of commands. This means that any command that exits successfully will then allow all other commands to pass the "exited successfully" step, because the success output is already in the stdout logs

This PR is a fix specifically for that problem by adding a UUID to the exit code output, so each time the step runs it expects something different & unique

We also have an issue with output generally where any line of text in stdout will pass, even if another command is run afterwards. We may want to clear stdout before running a command, but maybe that could also cause issues? A manual "I clear stdout" command might be more robust, but a lot more error prone & annoying to use. This PR unblocks my immediate problem and I haven't had an issue with conflicting stdout otherwise, so I haven't attempted to fix that yet