### PR TITLE
[PLAT-5475] Allow environment variables be used to configure specific options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.6.0 - TBD
+# 3.6.0 - 2020/12/09
 
 ## Enhancements
 
@@ -11,6 +11,9 @@
   [#180](https://github.com/bugsnag/maze-runner/pull/180)
 - Add steps for running interaction shells
   [#185](https://github.com/bugsnag/maze-runner/pull/185)
+- Enabled specific configuration options to be set using environment variables.
+  [#188](https://github.com/bugsnag/maze-runner/pull/188)
+
 
 ## Fixes
 

--- a/lib/options/option_parser.rb
+++ b/lib/options/option_parser.rb
@@ -54,21 +54,21 @@ module Maze
 
           # BrowserStack-only options
           opt Option::BS_LOCAL,
-              '(BS only) Path to the BrowserStackLocal binary',
+              '(BS only) Path to the BrowserStackLocal binary. MAZE_BS_LOCAL env var or "/BrowserStackLocal" by default',
               short: :none,
               type: :string,
-              default: '/BrowserStackLocal'
+              default: ENV['MAZE_BS_LOCAL'] || '/BrowserStackLocal'
           opt Option::BS_DEVICE,
               'BrowserStack device to use (a key of Devices.DEVICE_HASH)',
               short: :none,
               type: :string
           opt Option::USERNAME,
-              'Device farm username',
+              'Device farm username. MAZE_DEVICE_FARM_USERNAME env var by default',
               short: '-u',
               type: :string,
               default: ENV['MAZE_DEVICE_FARM_USERNAME']
           opt Option::ACCESS_KEY,
-              'Device farm access key',
+              'Device farm access key. MAZE_DEVICE_FARM_ACCESS_KEY env var by default',
               short: '-p',
               type: :string,
               default: ENV['MAZE_DEVICE_FARM_ACCESS_KEY']
@@ -87,17 +87,17 @@ module Maze
               short: :none,
               type: :string
           opt Option::APPIUM_SERVER,
-              'Appium server URL, only used for --farm=local',
+              'Appium server URL, only used for --farm=local. MAZE_APPIUM_SERVER env var by default',
               short: :none,
               type: :string,
-              default: 'http://localhost:4723/wd/hub'
+              default: ENV['MAZE_APPIUM_SERVER'] || 'http://localhost:4723/wd/hub'
           opt Option::APPLE_TEAM_ID,
-              'Apple Team Id, required for local iOS testing',
+              'Apple Team Id, required for local iOS testing. MAZE_APPLE_TEAM_ID env var by default',
               short: :none,
               type: :string,
               default: ENV['MAZE_APPLE_TEAM_ID']
           opt Option::UDID,
-              'Apple UDID, required for local iOS testing',
+              'Apple UDID, required for local iOS testing. MAZE_UDID env var by default',
               short: :none,
               type: :string,
               default: ENV['MAZE_UDID']

--- a/lib/options/option_parser.rb
+++ b/lib/options/option_parser.rb
@@ -17,10 +17,12 @@ module Maze
           text 'Usage [OPTIONS] <filenames>'
           text ''
           text 'Overridden Cucumber options:'
-          opt :help, 'Print this help.'
-          opt :init, 'Initialises a new Maze Runner project'
-
-          opt :version, 'Display Maze Runner and Cucumber versions'
+          opt :help,
+              'Print this help.'
+          opt :init,
+              'Initialises a new Maze Runner project'
+          opt :version,
+              'Display Maze Runner and Cucumber versions'
 
           # Common options
           opt Option::SEPARATE_SESSIONS,
@@ -28,8 +30,14 @@ module Maze
               short: :none,
               type: :boolean,
               default: false
-          opt Option::FARM, 'Device farm to use: "bs" (BrowserStack) or "local"', short: '-f', type: :string
-          opt Option::APP, 'The app to be installed and run against', short: '-a', type: :string
+          opt Option::FARM,
+              'Device farm to use: "bs" (BrowserStack) or "local"',
+              short: '-f',
+              type: :string
+          opt Option::APP,
+              'The app to be installed and run against',
+              short: '-a',
+              type: :string
           opt Option::A11Y_LOCATOR,
               'Locate elements by accessibility id rather than id',
               short: :none,
@@ -54,8 +62,16 @@ module Maze
               'BrowserStack device to use (a key of Devices.DEVICE_HASH)',
               short: :none,
               type: :string
-          opt Option::USERNAME, 'Device farm username', short: '-u', type: :string
-          opt Option::ACCESS_KEY, 'Device farm access key', short: '-p', type: :string
+          opt Option::USERNAME,
+              'Device farm username',
+              short: '-u',
+              type: :string,
+              default: ENV['MAZE_DEVICE_FARM_USERNAME']
+          opt Option::ACCESS_KEY,
+              'Device farm access key',
+              short: '-p',
+              type: :string,
+              default: ENV['MAZE_DEVICE_FARM_ACCESS_KEY']
           opt Option::BS_APPIUM_VERSION,
               'The Appium version to use with BrowserStack',
               short: :none,
@@ -75,8 +91,16 @@ module Maze
               short: :none,
               type: :string,
               default: 'http://localhost:4723/wd/hub'
-          opt Option::APPLE_TEAM_ID, 'Apple Team Id, required for local iOS testing', short: :none, type: :string
-          opt Option::UDID, 'Apple UDID, required for local iOS testing', short: :none, type: :string
+          opt Option::APPLE_TEAM_ID,
+              'Apple Team Id, required for local iOS testing',
+              short: :none,
+              type: :string,
+              default: ENV['MAZE_APPLE_TEAM_ID']
+          opt Option::UDID,
+              'Apple UDID, required for local iOS testing',
+              short: :none,
+              type: :string,
+              default: ENV['MAZE_UDID']
 
           version "Maze Runner v#{BugsnagMazeRunner::VERSION} " \
                   "(Cucumber v#{Cucumber::VERSION.strip})"

--- a/test/options/options_parser_test.rb
+++ b/test/options/options_parser_test.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../../lib/options/option'
+require_relative '../../lib/options/option_parser'
+
+# Tests the options parser and processor together (using only valid options and with no validator).
+class OptionsParserTest < Test::Unit::TestCase
+  def setup
+    ENV.delete('MAZE_DEVICE_FARM_USERNAME')
+    ENV.delete('MAZE_DEVICE_FARM_ACCESS_KEY')
+    ENV.delete('MAZE_APPLE_TEAM_ID')
+    ENV.delete('MAZE_UDID')
+  end
+
+  def test_default_values
+    args = %w[]
+    options = Maze::OptionParser.parse args
+
+    # Common options
+    assert_false(options[Maze::Option::SEPARATE_SESSIONS])
+    assert_nil(options[Maze::Option::FARM])
+    assert_nil(options[Maze::Option::APP])
+    assert_false(options[Maze::Option::A11Y_LOCATOR])
+    assert_false(options[Maze::Option::RESILIENT])
+    assert_equal('{}', options[Maze::Option::CAPABILITIES])
+
+    # BrowserStack-only options
+    assert_equal('/BrowserStackLocal', options[Maze::Option::BS_LOCAL])
+    assert_nil(options[Maze::Option::BS_DEVICE])
+    assert_nil(options[Maze::Option::USERNAME])
+    assert_nil(options[Maze::Option::ACCESS_KEY])
+    assert_nil(options[Maze::Option::BS_APPIUM_VERSION])
+
+    # Local-only options
+    assert_nil(options[Maze::Option::OS])
+    assert_nil(options[Maze::Option::OS_VERSION])
+    assert_equal('http://localhost:4723/wd/hub', options[Maze::Option::APPIUM_SERVER])
+    assert_nil(options[Maze::Option::APPLE_TEAM_ID])
+    assert_nil(options[Maze::Option::UDID])
+  end
+
+  def test_overwritten_values
+    args = %w[
+      --separate-sessions=true
+      --farm=ARG_FARM
+      --app=ARG_APP
+      --a11y-locator=true
+      --resilient=true
+      --capabilities=ARG_CAPABILITIES
+      --bs-local=ARG_BS_LOCAL
+      --device=ARG_DEVICE
+      --username=ARG_USERNAME
+      --access-key=ARG_ACCESS_KEY
+      --appium-version=ARG_APPIUM_VERSION
+      --os=ARG_OS
+      --os-version=ARG_OS_VERSION
+      --appium-server=ARG_APPIUM_SERVER
+      --apple-team-id=ARG_APPLE_TEAM_ID
+      --udid=ARG_UDID
+    ]
+    options = Maze::OptionParser.parse args
+
+    # Common options
+    assert_true(options[Maze::Option::SEPARATE_SESSIONS])
+    assert_equal('ARG_FARM', options[Maze::Option::FARM])
+    assert_equal('ARG_APP', options[Maze::Option::APP])
+    assert_true(options[Maze::Option::A11Y_LOCATOR])
+    assert_true(options[Maze::Option::RESILIENT])
+    assert_equal('ARG_CAPABILITIES', options[Maze::Option::CAPABILITIES])
+
+    # BrowserStack-only options
+    assert_equal('ARG_BS_LOCAL', options[Maze::Option::BS_LOCAL])
+    assert_equal('ARG_DEVICE', options[Maze::Option::BS_DEVICE])
+    assert_equal('ARG_USERNAME', options[Maze::Option::USERNAME])
+    assert_equal('ARG_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])
+    assert_equal('ARG_APPIUM_VERSION', options[Maze::Option::BS_APPIUM_VERSION])
+
+    # Local-only options
+    assert_equal('ARG_OS', options[Maze::Option::OS])
+    assert_equal('ARG_OS_VERSION', options[Maze::Option::OS_VERSION])
+    assert_equal('ARG_APPIUM_SERVER', options[Maze::Option::APPIUM_SERVER])
+    assert_equal('ARG_APPLE_TEAM_ID', options[Maze::Option::APPLE_TEAM_ID])
+    assert_equal('ARG_UDID', options[Maze::Option::UDID])
+  end
+
+  def test_short_flags
+    args = %w[
+      -f SHORT_FARM
+      -a SHORT_APP
+      -r true
+      -c SHORT_CAPABILITIES
+      -u SHORT_USERNAME
+      -p SHORT_ACCESS_KEY
+    ]
+    options = Maze::OptionParser.parse args
+
+    # Common options
+    assert_equal('SHORT_FARM', options[Maze::Option::FARM])
+    assert_equal('SHORT_APP', options[Maze::Option::APP])
+    assert_true(options[Maze::Option::RESILIENT])
+    assert_equal('SHORT_CAPABILITIES', options[Maze::Option::CAPABILITIES])
+
+    # BrowserStack-only options
+    assert_equal('SHORT_USERNAME', options[Maze::Option::USERNAME])
+    assert_equal('SHORT_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])
+  end
+
+  def test_environment_values
+    ENV['MAZE_DEVICE_FARM_USERNAME'] = 'ENV_USERNAME'
+    ENV['MAZE_DEVICE_FARM_ACCESS_KEY'] = 'ENV_ACCESS_KEY'
+    ENV['MAZE_APPLE_TEAM_ID'] = 'ENV_TEAM_ID'
+    ENV['MAZE_UDID'] = 'ENV_UDID'
+
+    args = %w[]
+    options = Maze::OptionParser.parse args
+
+    # BrowserStack-only options
+    assert_equal('ENV_USERNAME', options[Maze::Option::USERNAME])
+    assert_equal('ENV_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])
+
+    # Local-only options
+    assert_equal('ENV_TEAM_ID', options[Maze::Option::APPLE_TEAM_ID])
+    assert_equal('ENV_UDID', options[Maze::Option::UDID])
+  end
+
+  def test_override_priority
+    ENV['MAZE_DEVICE_FARM_USERNAME'] = 'ENV_USERNAME'
+    ENV['MAZE_DEVICE_FARM_ACCESS_KEY'] = 'ENV_ACCESS_KEY'
+    ENV['MAZE_APPLE_TEAM_ID'] = 'ENV_TEAM_ID'
+    ENV['MAZE_UDID'] = 'ENV_UDID'
+
+    args = %w[
+      --username=ARG_USERNAME
+      --access-key=ARG_ACCESS_KEY
+      --apple-team-id=ARG_TEAM_ID
+      --udid=ARG_UDID
+    ]
+    options = Maze::OptionParser.parse args
+
+    # BrowserStack-only options
+    assert_equal('ARG_USERNAME', options[Maze::Option::USERNAME])
+    assert_equal('ARG_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])
+
+    # Local-only options
+    assert_equal('ARG_TEAM_ID', options[Maze::Option::APPLE_TEAM_ID])
+    assert_equal('ARG_UDID', options[Maze::Option::UDID])
+  end
+end

--- a/test/options/options_parser_test.rb
+++ b/test/options/options_parser_test.rb
@@ -42,11 +42,11 @@ class OptionsParserTest < Test::Unit::TestCase
 
   def test_overwritten_values
     args = %w[
-      --separate-sessions=true
+      --separate-sessions
       --farm=ARG_FARM
       --app=ARG_APP
-      --a11y-locator=true
-      --resilient=true
+      --a11y-locator
+      --resilient
       --capabilities=ARG_CAPABILITIES
       --bs-local=ARG_BS_LOCAL
       --device=ARG_DEVICE
@@ -88,7 +88,7 @@ class OptionsParserTest < Test::Unit::TestCase
     args = %w[
       -f SHORT_FARM
       -a SHORT_APP
-      -r true
+      -r
       -c SHORT_CAPABILITIES
       -u SHORT_USERNAME
       -p SHORT_ACCESS_KEY

--- a/test/options/options_parser_test.rb
+++ b/test/options/options_parser_test.rb
@@ -9,6 +9,8 @@ class OptionsParserTest < Test::Unit::TestCase
   def setup
     ENV.delete('MAZE_DEVICE_FARM_USERNAME')
     ENV.delete('MAZE_DEVICE_FARM_ACCESS_KEY')
+    ENV.delete('MAZE_BS_LOCAL')
+    ENV.delete('MAZE_APPIUM_SERVER')
     ENV.delete('MAZE_APPLE_TEAM_ID')
     ENV.delete('MAZE_UDID')
   end
@@ -109,6 +111,8 @@ class OptionsParserTest < Test::Unit::TestCase
   def test_environment_values
     ENV['MAZE_DEVICE_FARM_USERNAME'] = 'ENV_USERNAME'
     ENV['MAZE_DEVICE_FARM_ACCESS_KEY'] = 'ENV_ACCESS_KEY'
+    ENV['MAZE_BS_LOCAL'] = 'ENV_BS_LOCAL'
+    ENV['MAZE_APPIUM_SERVER'] = 'ENV_APPIUM_SERVER'
     ENV['MAZE_APPLE_TEAM_ID'] = 'ENV_TEAM_ID'
     ENV['MAZE_UDID'] = 'ENV_UDID'
 
@@ -118,8 +122,10 @@ class OptionsParserTest < Test::Unit::TestCase
     # BrowserStack-only options
     assert_equal('ENV_USERNAME', options[Maze::Option::USERNAME])
     assert_equal('ENV_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])
+    assert_equal('ENV_BS_LOCAL', options[Maze::Option::BS_LOCAL])
 
     # Local-only options
+    assert_equal('ENV_APPIUM_SERVER', options[Maze::Option::APPIUM_SERVER])
     assert_equal('ENV_TEAM_ID', options[Maze::Option::APPLE_TEAM_ID])
     assert_equal('ENV_UDID', options[Maze::Option::UDID])
   end
@@ -127,12 +133,16 @@ class OptionsParserTest < Test::Unit::TestCase
   def test_override_priority
     ENV['MAZE_DEVICE_FARM_USERNAME'] = 'ENV_USERNAME'
     ENV['MAZE_DEVICE_FARM_ACCESS_KEY'] = 'ENV_ACCESS_KEY'
+    ENV['MAZE_BS_LOCAL'] = 'ENV_BS_LOCAL'
+    ENV['MAZE_APPIUM_SERVER'] = 'ENV_APPIUM_SERVER'
     ENV['MAZE_APPLE_TEAM_ID'] = 'ENV_TEAM_ID'
     ENV['MAZE_UDID'] = 'ENV_UDID'
 
     args = %w[
       --username=ARG_USERNAME
       --access-key=ARG_ACCESS_KEY
+      --bs-local=ARG_BS_LOCAL
+      --appium-server=ARG_APPIUM_SERVER
       --apple-team-id=ARG_TEAM_ID
       --udid=ARG_UDID
     ]
@@ -141,8 +151,10 @@ class OptionsParserTest < Test::Unit::TestCase
     # BrowserStack-only options
     assert_equal('ARG_USERNAME', options[Maze::Option::USERNAME])
     assert_equal('ARG_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])
+    assert_equal('ARG_BS_LOCAL', options[Maze::Option::BS_LOCAL])
 
     # Local-only options
+    assert_equal('ARG_APPIUM_SERVER', options[Maze::Option::APPIUM_SERVER])
     assert_equal('ARG_TEAM_ID', options[Maze::Option::APPLE_TEAM_ID])
     assert_equal('ARG_UDID', options[Maze::Option::UDID])
   end


### PR DESCRIPTION
## Goal

Enables environment variables to be used when configuring:
- Device farm username -> `MAZE_DEVICE_FARM_USERNAME`
- Device farm access key -> `MAZE_DEVICE_FARM_ACCESS_KEY`
- BrowserStack local path -> `MAZE_BS_LOCAL`
- Appium server URL -> `MAZE_APPIUM_SERVER`
- Apple team ID -> `MAZE_APPLE_TEAM_ID`
- Apple UDID -> `MAZE_UDID`

These variables will be lower priority than actual configuration flags, which will take precedence.

In addition minor formatting changes have been made for readability.

## Tests

Unit tests for the option parser in general have been added, verifying:
- Defaults
- Flag configuration
- Short-flag configuration
- Environment variable configuration
- Configuration priority
