### PR TITLE
Clear request arrays after each scenario

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -82,11 +82,6 @@ steps:
       --access-key=$BROWSER_STACK_ACCESS_KEY
     concurrency: 10
     concurrency_group: 'browserstack-app'
-    #
-    # TODO: Remove as soon as possible - working around BrowserStack network problem
-    #
-    soft_fail:
-      - exit_status: "*"
 
   - label: 'Browserstack app-automate test - Android 7.1 (separate Appium sessions)'
     depends_on: "test-images"
@@ -102,11 +97,6 @@ steps:
       --access-key=$BROWSER_STACK_ACCESS_KEY
     concurrency: 10
     concurrency_group: 'browserstack-app'
-    #
-    # TODO: Remove as soon as possible - working around BrowserStack network problem
-    #
-    soft_fail:
-      - exit_status: "*"
 
   - label: 'Browserstack app-automate test - Android 8.1'
     depends_on: "test-images"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.6.1 - 2020/12/16
+
+## Fixes
+
+- Clear request arrays after each scenario instead of beforehand
+  [#190](https://github.com/bugsnag/maze-runner/pull/190)
+
 # 3.6.0 - 2020/12/09
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (3.6.0)
+    bugsnag-maze-runner (3.6.1)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -128,7 +128,7 @@ After do |scenario|
   else
     MazeRunner.driver.reset_with_timeout 2
   end
-
+ensure
   # Request arrays in particular are cleared here, rather than in the Before hook, to allow requests to be registered
   # when a test fixture starts (which can be before the first Before scenario hook fires).
   Server.stored_requests.clear

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -71,9 +71,9 @@ Before do |scenario|
   STDOUT.puts "--- Scenario: #{scenario.name}"
 
   Runner.environment.clear
-  Server.stored_requests.clear
-  Server.invalid_requests.clear
   Store.values.clear
+  # Request arrays are cleared after the scenario as some test fixtures
+  # will send requests on startup - before this hook takes place.
 
   MazeRunner.driver.start_driver if MazeRunner.config.farm != :none && MazeRunner.config.appium_session_isolation
 
@@ -148,6 +148,11 @@ After do |scenario|
     msg = "#{Server.invalid_requests.length} invalid request(s) received during scenario"
     scenario.fail msg
   end
+
+  # Request arrays are cleared after the scenario to allow requests to be registered
+  # when a test fixture starts (which can be before the first Before scenario hook fires).
+  Server.stored_requests.clear
+  Server.invalid_requests.clear
 end
 
 # After all tests

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -21,6 +21,30 @@ Then("the request is valid for the session reporting API version {string} for th
   }
 end
 
+
+# Verifies that generic elements of a session payload are present for the React Native notifier
+# APIKey fields and headers are tested against the '$api_key' global variable.
+#
+# @step_input payload_version [String] The payload version expected
+# @step_input notifier_name [String] The expected name of the notifier
+# TODO: I'm reluctant to risk changing the previous step implementation right now, but we should consider
+#   refactoring the two at some point to avoid duplication.
+Then('the request is valid for the session reporting API version {string} for the React Native notifier') do |payload_version|
+  steps %Q{
+    Then the "bugsnag-api-key" header equals "#{$api_key}"
+    And the "bugsnag-payload-version" header equals "#{payload_version}"
+    And the "Content-Type" header equals "application/json"
+    And the "Bugsnag-Sent-At" header is a timestamp
+
+    And the payload field "notifier.name" matches the regex "(Android|iOS) Bugsnag Notifier"
+    And the payload field "notifier.url" is not null
+    And the payload field "notifier.version" is not null
+
+    And the payload field "app" is not null
+    And the payload field "device" is not null
+  }
+end
+
 # Tests whether a value in the first session entry matches a literal.
 #
 # @step_input field [String] The relative location of the value to test

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '3.6.0'.freeze
+  VERSION = '3.6.1'.freeze
 end


### PR DESCRIPTION
## Goal

Clear the request arrays that we assert against after each scenario completes, rather than beforehand.

## Design

Until now our device-based test fixtures have not started Bugsnag until a button is actively pressed.  That has changed with the birth of the RN CLI, such that session requests are sent as soon as the app is first opened - which occurs before the scenario itself actually starts.  

## Changeset

Clearing of arrays moved to the `After`hook and clearly comments as to why.

I've also taken the opportunity to add a new Cucumber step for checking session requests for React Native, which could have come from either the Cocoa or Android notifier.

## Tests

Regression is mitigated by Maze Runner CI and I have tested the new step locally with a RN app on both Android and iOS.