### PR TITLE
Display version at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.7.0 - TBD
+
+## Enhancements
+
+- Display version at startup [#191](https://github.com/bugsnag/maze-runner/pull/191)
+
 # 3.6.1 - 2020/12/16
 
 ## Fixes

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -4,7 +4,7 @@ require 'version'
 
 Gem::Specification.new do |spec|
   spec.name    = 'bugsnag-maze-runner'
-  spec.version = BugsnagMazeRunner::VERSION
+  spec.version = Maze::VERSION
   spec.authors = ['Steve Kirkland']
   spec.email   = ['steve@bugsnag.com']
   spec.required_ruby_version = '>= 2.5.0'

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -4,6 +4,7 @@ require 'webrick'
 require 'json'
 require_relative './servlet'
 require_relative './logger'
+require_relative '../../version'
 
 # This port number is semi-arbitrary. It doesn't matter for the sake of
 # the application what it is, but there are some constraints due to some
@@ -75,6 +76,7 @@ class Server
     # Starts the WEBrick server in a separate thread
     def start_server
       attempts = 0
+      $logger.info "Maze Runner v#{Maze::VERSION}"
       $logger.info 'Starting mock server'
       loop do
         @thread = Thread.new do

--- a/lib/options/option_parser.rb
+++ b/lib/options/option_parser.rb
@@ -102,7 +102,7 @@ module Maze
               type: :string,
               default: ENV['MAZE_UDID']
 
-          version "Maze Runner v#{BugsnagMazeRunner::VERSION} " \
+          version "Maze Runner v#{Maze::VERSION} " \
                   "(Cucumber v#{Cucumber::VERSION.strip})"
           text ''
           text 'The Cucumber help follows:'

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
-module BugsnagMazeRunner
+module Maze
   VERSION = '3.6.1'.freeze
 end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -15,6 +15,7 @@ class ServerTest < Test::Unit::TestCase
 
   def test_start_server_cleanily
     # Expected logging calls
+    @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
     @logger_mock.expects(:info).with('Starting mock server')
 
     # Force synchronous execution
@@ -41,6 +42,7 @@ class ServerTest < Test::Unit::TestCase
 
   def test_start_server_on_retry
     # Expected logging calls
+    @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
     @logger_mock.expects(:info).with('Starting mock server')
     @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
     @logger_mock.expects(:info).with('Retrying in 5 seconds')
@@ -73,6 +75,7 @@ class ServerTest < Test::Unit::TestCase
 
   def test_start_server_fails
     # Expected logging calls
+    @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
     @logger_mock.expects(:info).with('Starting mock server')
     @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
     @logger_mock.expects(:info).with('Retrying in 5 seconds')


### PR DESCRIPTION
## Goal

Display the Maze Runner version when the mock server starts.

## Design

Our CI instances include localized Docker registries, so that just after a release of Maze Runner we can often we left in doubt as to whether the old `latest` image is still being used or if something has gone horribly wrong.  This should avoid that doubt.

## Changeset

Additional log in server class.

## Tests

Covered by CI and basic local testing that options such as `--help` and `--version` are not adversely affected.