### PR TITLE
Separate endpoints - Cocoa ready

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,12 +17,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.4)
+    activesupport (6.1.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     appium_lib (10.6.0)
       appium_lib_core (~> 3.3)
       nokogiri (~> 1.8, >= 1.8.1)
@@ -82,7 +82,7 @@ GEM
     props (1.2.0)
       iniparser (>= 0.1.0)
     rake (12.3.3)
-    redcarpet (3.5.0)
+    redcarpet (3.5.1)
     rexml (3.2.4)
     rubyzip (2.3.0)
     selenium-webdriver (3.142.7)
@@ -95,10 +95,9 @@ GEM
       logutils (>= 0.6.1)
       props (>= 1.1.2)
       rubyzip (>= 1.0.0)
-    thread_safe (0.3.6)
     tomlrb (1.3.0)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -107,7 +106,7 @@ GEM
       cucumber (>= 2.0, < 4.0)
       gherkin (>= 4.0, < 6.0)
       yard (~> 0.8, >= 0.8.1)
-    zeitwerk (2.4.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,18 +19,22 @@ config.setEndpoints("http://localhost:9339/notify", "http://localhost:9339/sessi
 
 ### Cucumber steps changed
  
-Several Cucumber steps have changed their wording:
+Several Cucumber steps have changed their wording or been split into separate steps:
 
-Old step | New step
+Old step | New step(s)
 ----| -------- | 
-I wait to receive a request | I wait to receive an error
-I wait to receive {int} request(s) | I wait to receive {int} error(s)
-I discard the oldest request | I discard the oldest error
-I should receive no requests | I should receive no errors
-the {string} header is not null | the error {string} header is not null
+I wait to receive a request | I wait to receive an error <br> I wait to receive a session
+I wait to receive {int} request(s) | I wait to receive {int} error(s) <br> I wait to receive {int} session(s)
+I discard the oldest request | I discard the oldest error <br> I discard the oldest session
+the {string} header is not null | the error {string} header is not null <br> the session {string} header is not null
+the {string} header equals {string} | the error {string} header equals {string} <br> the session {string} header equals {string}
+the {string} header matches the regex {string} | the error {string} header matches the regex {string} <br> the session {string} header matches the regex {string}
+the {string} header equals one of: | the error {string} header equals one of: <br> the session {string} header equals one of:
+the {string} header is a timestamp | the error {string} header is a timestamp <br> the session {string} header is a timestamp
 the {string} query parameter equals {string} | the error {string} query parameter equals {string}
 the {string} query parameter is not null | the error {string} query parameter is not null
 the {string} query parameter is a timestamp | the error {string} query parameter is a timestamp
+
 
 ### Cucumber steps removed
 

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -108,6 +108,16 @@ After do |scenario|
   # TODO Revamp and log sessions
   if scenario.failed?
     STDOUT.puts '^^^ +++'
+    if Server.sessions.empty?
+      $logger.info 'No valid sessions received'
+    else
+      $logger.info "#{Server.sessions.size} sessions were received:"
+      Server.sessions.all.each.with_index(1) do |request, number|
+        $logger.info "Session #{number}:"
+        LogUtil.log_hash(Logger::Severity::INFO, request)
+      end
+    end
+
     if Server.errors.empty?
       $logger.info 'No valid errors received'
     else

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -9,12 +9,12 @@
 # @step_input name [String] The expected name of the notifier
 Then('the request is valid for the error reporting API version {string} for the {string} notifier') do |version, name|
   steps %(
-    Then the "Bugsnag-Api-Key" header equals "#{$api_key}"
+    Then the error "Bugsnag-Api-Key" header equals "#{$api_key}"
     And the payload field "apiKey" equals "#{$api_key}"
-    And the "Bugsnag-Payload-Version" header equals "#{version}"
+    And the error "Bugsnag-Payload-Version" header equals "#{version}"
     And the payload contains the payloadVersion "#{version}"
-    And the "Content-Type" header equals "application/json"
-    And the "Bugsnag-Sent-At" header is a timestamp
+    And the error "Content-Type" header equals "application/json"
+    And the error "Bugsnag-Sent-At" header is a timestamp
 
     And the payload field "notifier.name" equals "#{name}"
     And the payload field "notifier.url" is not null

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -11,7 +11,7 @@ include Test::Unit::Assertions
 
 # @!group Request assertion steps
 
-def check_for_requests(request_count, list, list_name)
+def assert_received_requests(request_count, list, list_name)
   timeout = MazeRunner.config.receive_requests_wait
   wait = Maze::Wait.new(timeout: timeout)
 
@@ -52,7 +52,7 @@ end
 #
 # @step_input request_count [Integer] The amount of requests expected
 Then('I wait to receive {int} error(s)') do |request_count|
-  check_for_requests request_count, Server.errors, 'errors'
+  assert_received_requests request_count, Server.errors, 'errors'
 end
 
 # Assert that the test Server hasn't received any errors.
@@ -102,7 +102,7 @@ end
 #
 # @step_input request_count [Integer] The amount of requests expected
 Then('I wait to receive {int} session(s)') do |request_count|
-  check_for_requests request_count, Server.sessions, 'sessions'
+  assert_received_requests request_count, Server.sessions, 'sessions'
 end
 
 # Assert that the test Server hasn't received any sessions.

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -11,11 +11,6 @@ include Test::Unit::Assertions
 
 # @!group Request assertion steps
 
-# Shortcut to waiting to receive a single request
-Then('I wait to receive an error') do
-  step 'I wait to receive 1 error'
-end
-
 def check_for_requests(request_count, list, list_name)
   timeout = MazeRunner.config.receive_requests_wait
   wait = Maze::Wait.new(timeout: timeout)
@@ -36,12 +31,41 @@ def check_for_requests(request_count, list, list_name)
   assert_equal(request_count, list.size, "#{list.size} #{list_name} received")
 end
 
+#
+# Error request assertions
+#
+Then('I wait to receive an error') do
+  step 'I wait to receive 1 error'
+end
+
 # Continually checks to see if the required amount of errors have been received.
 # Times out according to @see MazeRunner.config.receive_requests_wait.
 #
 # @step_input request_count [Integer] The amount of requests expected
 Then('I wait to receive {int} error(s)') do |request_count|
   check_for_requests request_count, Server.errors, 'errors'
+end
+
+# Assert that the test Server hasn't received any errors.
+Then('I should receive no errors') do
+  sleep MazeRunner.config.receive_no_requests_wait
+  assert_equal(0, Server.errors.size, "#{Server.errors.size} errors received")
+end
+
+#
+# Session request assertions
+#
+
+# Shortcut to waiting to receive a single request
+
+# Shortcut to waiting to receive a single session
+Then('I wait to receive a session') do
+  step 'I wait to receive 1 session'
+end
+
+# Moves to the next error
+Then('I discard the oldest error') do
+  Server.errors.next
 end
 
 # Continually checks to see if the required amount of sessions have been received.
@@ -52,21 +76,10 @@ Then('I wait to receive {int} session(s)') do |request_count|
   check_for_requests request_count, Server.sessions, 'sessions'
 end
 
-# Assert that the test Server hasn't received any errors.
-Then('I should receive no errors') do
-  sleep MazeRunner.config.receive_no_requests_wait
-  assert_equal(0, Server.errors.size, "#{Server.errors.size} errors received")
-end
-
 # Assert that the test Server hasn't received any sessions.
 Then('I should receive no sessions') do
   sleep MazeRunner.config.receive_no_requests_wait
   assert_equal(0, Server.sessions.size, "#{Server.sessions.size} sessions received")
-end
-
-# Moves to the next error
-Then('I discard the oldest error') do
-  Server.errors.next
 end
 
 # Moves to the next sessions
@@ -74,51 +87,105 @@ Then('I discard the oldest session') do
   Server.sessions.next
 end
 
+
 #
-# TODO Split this section into header_assertion_steps
+# TODO There's a lot of overlap between error and session header assertions and only implemented this
+# way for ease when separating from a single request endpoint.
 #
 
-# Tests that a header is not null
+#
+# Errors
+#
+
+# Tests that an error header is not null
 #
 # @step_input header_name [String] The header to test
 Then('the error {string} header is not null') do |header_name|
   assert_not_nil(Server.errors.current[:request][header_name],
-                 "The '#{header_name}' header should not be null")
+                 "The error '#{header_name}' header should not be null")
 end
 
-# Tests that a header equals a string
+# Tests that an error header equals a string
 #
 # @step_input header_name [String] The header to test
 # @step_input header_value [String] The string it should match
-Then('the {string} header equals {string}') do |header_name, header_value|
+Then('the error {string} header equals {string}') do |header_name, header_value|
   assert_not_nil(Server.errors.current[:request][header_name],
-                 "The '#{header_name}' header wasn't present in the request")
+                 "The error '#{header_name}' header wasn't present in the request")
   assert_equal(header_value, Server.errors.current[:request][header_name])
 end
 
-# Tests that a header matches a regex
+# Tests that an error header matches a regex
 #
 # @step_input header_name [String] The header to test
 # @step_input regex_string [String] The regex to match with
-Then('the {string} header matches the regex {string}') do |header_name, regex_string|
+Then('the error {string} header matches the regex {string}') do |header_name, regex_string|
   regex = Regexp.new(regex_string)
   value = Server.errors.current[:request][header_name]
   assert_match(regex, value)
 end
 
-# Tests that a header matches one of a list of strings
+# Tests that an error header matches one of a list of strings
 #
 # @step_input header_name [String] The header to test
 # @step_input header_values [DataTable] A parsed data table
-Then('the {string} header equals one of:') do |header_name, header_values|
+Then('the error {string} header equals one of:') do |header_name, header_values|
   assert_includes(header_values.raw.flatten, Server.errors.current[:request][header_name])
 end
 
-# Tests that a header is a timestamp.
+# Tests that am error header is a timestamp.
 #
 # @step_input header_name [String] The header to test
-Then('the {string} header is a timestamp') do |header_name|
+Then('the error {string} header is a timestamp') do |header_name|
   header = Server.errors.current[:request][header_name]
+  assert_match(TIMESTAMP_REGEX, header)
+end
+
+#
+# Sessions
+#
+
+# Tests that a session header is not null
+#
+# @step_input header_name [String] The header to test
+Then('the session {string} header is not null') do |header_name|
+  assert_not_nil(Server.sessions.current[:request][header_name],
+                 "The session '#{header_name}' header should not be null")
+end
+
+# Tests that a session header equals a string
+#
+# @step_input header_name [String] The header to test
+# @step_input header_value [String] The string it should match
+Then('the session {string} header equals {string}') do |header_name, header_value|
+  assert_not_nil(Server.errors.current[:request][header_name],
+                 "The session '#{header_name}' header wasn't present in the request")
+  assert_equal(header_value, Server.sessions.current[:request][header_name])
+end
+
+# Tests that a session header matches a regex
+#
+# @step_input header_name [String] The header to test
+# @step_input regex_string [String] The regex to match with
+Then('the session {string} header matches the regex {string}') do |header_name, regex_string|
+  regex = Regexp.new(regex_string)
+  value = Server.sessions.current[:request][header_name]
+  assert_match(regex, value)
+end
+
+# Tests that a session header matches one of a list of strings
+#
+# @step_input header_name [String] The header to test
+# @step_input header_values [DataTable] A parsed data table
+Then('the session {string} header equals one of:') do |header_name, header_values|
+  assert_includes(header_values.raw.flatten, Server.sessions.current[:request][header_name])
+end
+
+# Tests that a session header is a timestamp.
+#
+# @step_input header_name [String] The header to test
+Then('the session {string} header is a timestamp') do |header_name|
+  header = Server.sessions.current[:request][header_name]
   assert_match(TIMESTAMP_REGEX, header)
 end
 

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -20,7 +20,7 @@ end
 # Times out according to @see MazeRunner.config.receive_requests_wait.
 #
 # @step_input request_count [Integer] The amount of requests expected
-Then('I wait to receive {int} request(s)') do |request_count|
+Then('I wait to receive {int} error(s)') do |request_count|
   timeout = MazeRunner.config.receive_requests_wait
   wait = Maze::Wait.new(timeout: timeout)
 

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -42,6 +42,7 @@ end
 #
 # Error request assertions
 #
+# Shortcut to waiting to receive a single error
 Then('I wait to receive an error') do
   step 'I wait to receive 1 error'
 end
@@ -84,11 +85,9 @@ end
 # Session request assertions
 #
 
-# Shortcut to waiting to receive a single request
-
 # Shortcut to waiting to receive a single session
 Then('I wait to receive a session') do
-  step 'I wait to receive 1 session'
+  step '\I wait to receive 1 session'
 end
 
 # Moves to the next error

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -85,6 +85,8 @@ end
 
 # Moves to the next error
 Then('I discard the oldest error') do
+  raise 'No error to discard' if Server.errors.current.nil?
+
   Server.errors.next
 end
 
@@ -104,6 +106,8 @@ end
 
 # Moves to the next sessions
 Then('I discard the oldest session') do
+  raise 'No session to discard' if Server.sessions.current.nil?
+
   Server.sessions.next
 end
 

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -87,7 +87,7 @@ end
 
 # Shortcut to waiting to receive a single session
 Then('I wait to receive a session') do
-  step '\I wait to receive 1 session'
+  step 'I wait to receive 1 session'
 end
 
 # Moves to the next error

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -31,6 +31,14 @@ def check_for_requests(request_count, list, list_name)
   assert_equal(request_count, list.size, "#{list.size} #{list_name} received")
 end
 
+
+# Assert that the test Server hasn't received any requests at all.
+Then('I should receive no requests') do
+  sleep MazeRunner.config.receive_no_requests_wait
+  assert_equal(0, Server.errors.size, "#{Server.errors.size} errors received")
+  assert_equal(0, Server.sessions.size, "#{Server.sessions.size} sessions received")
+end
+
 #
 # Error request assertions
 #

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -158,7 +158,7 @@ end
 # @step_input header_name [String] The header to test
 # @step_input header_value [String] The string it should match
 Then('the session {string} header equals {string}') do |header_name, header_value|
-  assert_not_nil(Server.errors.current[:request][header_name],
+  assert_not_nil(Server.sessions.current[:request][header_name],
                  "The session '#{header_name}' header wasn't present in the request")
   assert_equal(header_value, Server.sessions.current[:request][header_name])
 end

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -52,6 +52,26 @@ Then('I should receive no errors') do
   assert_equal(0, Server.errors.size, "#{Server.errors.size} errors received")
 end
 
+Then('the received errors match:') do |table|
+  # Checks that each request matches one of the event fields
+  requests = Server.errors.remaining
+  match_count = 0
+
+  # iterate through each row in the table. exactly 1 request should match each row.
+  table.hashes.each do |row|
+    requests.each do |request|
+      if !request.key? :body or !request[:body].key? "events" then
+        # No body.events in this request - skip
+        return
+      end
+      events = request[:body]['events']
+      assert_equal(1, events.length, 'Expected exactly one event per request')
+      match_count += 1 if request_matches_row(events[0], row)
+    end
+  end
+  assert_equal(requests.size, match_count, 'Unexpected number of requests matched the received payloads')
+end
+
 #
 # Session request assertions
 #

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -5,19 +5,19 @@
 #
 # @step_input payload_version [String] The payload version expected
 # @step_input notifier_name [String] The expected name of the notifier
-Then("the request is valid for the session reporting API version {string} for the {string} notifier") do |payload_version, notifier_name|
+Then("the session is valid for the session reporting API version {string} for the {string} notifier") do |payload_version, notifier_name|
   steps %Q{
-    Then the "bugsnag-api-key" header equals "#{$api_key}"
-    And the "bugsnag-payload-version" header equals "#{payload_version}"
-    And the "Content-Type" header equals "application/json"
-    And the "Bugsnag-Sent-At" header is a timestamp
+    Then the session "bugsnag-api-key" header equals "#{$api_key}"
+    And the session "bugsnag-payload-version" header equals "#{payload_version}"
+    And the session "Content-Type" header equals "application/json"
+    And the session "Bugsnag-Sent-At" header is a timestamp
 
-    And the payload field "notifier.name" equals "#{notifier_name}"
-    And the payload field "notifier.url" is not null
-    And the payload field "notifier.version" is not null
+    And the session payload field "notifier.name" equals "#{notifier_name}"
+    And the session payload field "notifier.url" is not null
+    And the session payload field "notifier.version" is not null
 
-    And the payload field "app" is not null
-    And the payload field "device" is not null
+    And the session payload field "app" is not null
+    And the session payload field "device" is not null
   }
 end
 
@@ -29,19 +29,19 @@ end
 # @step_input notifier_name [String] The expected name of the notifier
 # TODO: I'm reluctant to risk changing the previous step implementation right now, but we should consider
 #   refactoring the two at some point to avoid duplication.
-Then('the request is valid for the session reporting API version {string} for the React Native notifier') do |payload_version|
+Then('the session is valid for the session reporting API version {string} for the React Native notifier') do |payload_version|
   steps %Q{
-    Then the "bugsnag-api-key" header equals "#{$api_key}"
-    And the "bugsnag-payload-version" header equals "#{payload_version}"
-    And the "Content-Type" header equals "application/json"
-    And the "Bugsnag-Sent-At" header is a timestamp
+    Then the session "bugsnag-api-key" header equals "#{$api_key}"
+    And the session "bugsnag-payload-version" header equals "#{payload_version}"
+    And the session "Content-Type" header equals "application/json"
+    And the session "Bugsnag-Sent-At" header is a timestamp
 
-    And the payload field "notifier.name" matches the regex "(Android|iOS) Bugsnag Notifier"
-    And the payload field "notifier.url" is not null
-    And the payload field "notifier.version" is not null
+    And the session payload field "notifier.name" matches the regex "(Android|iOS) Bugsnag Notifier"
+    And the session payload field "notifier.url" is not null
+    And the session payload field "notifier.version" is not null
 
-    And the payload field "app" is not null
-    And the payload field "device" is not null
+    And the session payload field "app" is not null
+    And the session payload field "device" is not null
   }
 end
 
@@ -50,7 +50,7 @@ end
 # @step_input field [String] The relative location of the value to test
 # @step_input literal [Enum] The literal to test against, one of: true, false, null, not null
 Then(/^the session "(.+)" is (true|false|null|not null)$/) do |field, literal|
-  step "the payload field \"sessions.0.#{field}\" is #{literal}"
+  step "the session payload field \"sessions.0.#{field}\" is #{literal}"
 end
 
 # Tests whether a value in the first session entry matches a string.
@@ -58,14 +58,14 @@ end
 # @step_input field [String] The relative location of the value to test
 # @step_input string_value [String] The string to match against
 Then("the session {string} equals {string}") do |field, string_value|
-  step "the payload field \"sessions.0.#{field}\" equals \"#{string_value}\""
+  step "the session payload field \"sessions.0.#{field}\" equals \"#{string_value}\""
 end
 
 # Tests whether a value in the first session entry is a timestamp.
 #
 # @step_input field [String] The relative location of the value to test
 Then("the session {string} is a timestamp") do |field|
-  step "the payload field \"sessions.0.#{field}\" matches the regex \"#{TIMESTAMP_REGEX}\""
+  step "the session payload field \"sessions.0.#{field}\" matches the regex \"#{TIMESTAMP_REGEX}\""
 end
 
 # Tests whether a value in the first sessionCount entry matches a literal.
@@ -73,7 +73,7 @@ end
 # @step_input field [String] The relative location of the value to test
 # @step_input literal [Enum] The literal to test against, one of: true, false, null, not null
 Then(/^the sessionCount "(.+)" is (true|false|null|not null)$/) do |field, literal|
-  step "the payload field \"sessionCounts.0.#{field}\" is #{literal}"
+  step "the session payload field \"sessionCounts.0.#{field}\" is #{literal}"
 end
 
 # Tests whether a value in the first sessionCount entry matches a string.
@@ -81,7 +81,7 @@ end
 # @step_input field [String] The relative location of the value to test
 # @step_input string_value [String] The string to match against
 Then("the sessionCount {string} equals {string}") do |field, string_value|
-  step "the payload field \"sessionCounts.0.#{field}\" equals \"#{string_value}\""
+  step "the session payload field \"sessionCounts.0.#{field}\" equals \"#{string_value}\""
 end
 
 # Tests whether a value in the first sessionCount entry equals an integer.
@@ -89,18 +89,18 @@ end
 # @step_input field [String] The relative location of the value to test
 # @step_input int_value [Integer] The integer to test against
 Then("the sessionCount {string} equals {int}") do |field, int_value|
-  step "the payload field \"sessionCounts.0.#{field}\" equals #{int_value}"
+  step "the session payload field \"sessionCounts.0.#{field}\" equals #{int_value}"
 end
 
 # Tests whether a value in the first sessionCount entry is a timestamp.
 #
 # @step_input field [String] The relative location of the value to test
 Then("the sessionCount {string} is a timestamp") do |field|
-  step "the payload field \"sessionCounts.0.#{field}\" matches the regex \"#{TIMESTAMP_REGEX}\""
+  step "the session payload field \"sessionCounts.0.#{field}\" matches the regex \"#{TIMESTAMP_REGEX}\""
 end
 
 # Tests that a payload has an appropriately structured session array
-Then("the payload has a valid sessions array") do
+Then("the session payload has a valid sessions array") do
   if sessions = Server.sessions.current[:body]["sessions"]
     steps %Q{
       Then the session "id" is not null
@@ -113,3 +113,60 @@ Then("the payload has a valid sessions array") do
     }
   end
 end
+
+# Tests that a session payload element is true.
+#
+# @step_input field_path [String] Path to the tested element
+Then('the session payload field {string} is true') do |field_path|
+  assert_equal(true, read_key_path(Server.sessions.current[:body], field_path))
+end
+
+# Tests that a session payload element is false.
+#
+# @step_input field_path [String] Path to the tested element
+Then('the session payload field {string} is false') do |field_path|
+  assert_equal(false, read_key_path(Server.sessions.current[:body], field_path))
+end
+
+# Tests that a payload element is null.
+#
+# @step_input field_path [String] Path to the tested element
+Then('the session payload field {string} is null') do |field_path|
+  value = read_key_path(Server.sessions.current[:body], field_path)
+  assert_nil(value, "The field '#{field_path}' should be null but is #{value}")
+end
+
+# Tests that a session payload element is not null.
+#
+# @step_input field_path [String] Path to the tested element
+Then('the session payload field {string} is not null') do |field_path|
+  assert_not_nil(read_key_path(Server.sessions.current[:body], field_path),
+                 "The field '#{field_path}' should not be null")
+end
+
+# Tests that a session payload element equals an integer.
+#
+# @step_input field_path [String] Path to the tested element
+# @step_input int_value [Integer] The value to test against
+Then('the session payload field {string} equals {int}') do |field_path, int_value|
+  assert_equal(int_value, read_key_path(Server.sessions.current[:body], field_path))
+end
+
+# Tests a session payload field equals a string.
+#
+# @step_input field_path [String] The payload element to test
+# @step_input string_value [String] The string to test against
+Then('the session payload field {string} equals {string}') do |field_path, string_value|
+  assert_equal(string_value, read_key_path(Server.sessions.current[:body], field_path))
+end
+
+# Tests a session payload field matches a regex.
+#
+# @step_input field [String] The payload element to test
+# @step_input regex [String] The regex to test against
+Then('the session payload field {string} matches the regex {string}') do |field, regex_string|
+  regex = Regexp.new(regex_string)
+  value = read_key_path(Server.sessions.current[:body], field)
+  assert_match(regex, value)
+end
+

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -170,3 +170,26 @@ Then('the session payload field {string} matches the regex {string}') do |field,
   assert_match(regex, value)
 end
 
+# Tests a session payload field is an array with a specific element count.
+#
+# @step_input field [String] The payload element to test
+# @step_input count [Integer] The value expected
+Then('the session payload field {string} is an array with {int} elements') do |field, count|
+  value = read_key_path(Server.sessions.current[:body], field)
+  assert_kind_of Array, value
+  assert_equal(count, value.length)
+end
+
+# Tests a session payload field is a numeric timestamp.
+#
+# @step_input field [String] The payload element to test
+Then('the session payload field {string} is a parsable timestamp in seconds') do |field|
+  value = read_key_path(Server.sessions.current[:body], field)
+  begin
+    int = value.to_i
+    parsed_time = Time.at(int)
+  rescue StandardError
+    parsed_time = nil
+  end
+  assert_not_nil(parsed_time)
+end

--- a/lib/features/steps/value_steps.rb
+++ b/lib/features/steps/value_steps.rb
@@ -94,7 +94,7 @@ end
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
 Then('the session payload field {string} equals the stored value {string}') do |field, key|
-  payload_value = read_key_path(Server.session.current[:body], field)
+  payload_value = read_key_path(Server.sessions.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)
   assert_true(result.equal?, "Payload value: #{payload_value} does not equal stored value: #{stored_value}")
@@ -105,7 +105,7 @@ end
 # @step_input field [String] The session payload field to test
 # @step_input key [String] The key indicating a previously stored value
 Then('the session payload field {string} does not equal the stored value {string}') do |field, key|
-  payload_value = read_key_path(Server.session.current[:body], field)
+  payload_value = read_key_path(Server.sessions.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)
   assert_false(result.equal?, "Payload value: #{payload_value} equals stored value: #{stored_value}")
@@ -115,7 +115,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the session payload field {string} is a number') do |field|
-  value = read_key_path(Server.session.current[:body], field)
+  value = read_key_path(Server.sessions.current[:body], field)
   assert_kind_of Numeric, value
 end
 
@@ -123,7 +123,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the session payload field {string} is an integer') do |field|
-  value = read_key_path(Server.session.current[:body], field)
+  value = read_key_path(Server.sessions.current[:body], field)
   assert_kind_of Integer, value
 end
 
@@ -131,7 +131,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the session payload field {string} is a date') do |field|
-  value = read_key_path(Server.session.current[:body], field)
+  value = read_key_path(Server.sessions.current[:body], field)
   date = begin
            Date.parse(value)
          rescue StandardError
@@ -144,7 +144,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the session payload field {string} is a UUID') do |field|
-  value = read_key_path(Server.session.current[:body], field)
+  value = read_key_path(Server.sessions.current[:body], field)
   assert_not_nil(value, "Expected UUID, got nil for #{field}")
   match = /[a-fA-F0-9-]{36}/.match(value).size > 0
   assert_true(match, "Field #{field} is not a UUID, received #{value}")

--- a/lib/features/steps/value_steps.rb
+++ b/lib/features/steps/value_steps.rb
@@ -2,6 +2,10 @@ require 'date'
 
 # @!group Value steps
 
+#
+# Error payload steps
+#
+
 # Stores a payload value against a key for cross-request comparisons.
 #
 # @step_input field [String] The payload field to store
@@ -67,6 +71,80 @@ end
 # @step_input field [String] The payload field to test
 Then('the payload field {string} is a UUID') do |field|
   value = read_key_path(Server.errors.current[:body], field)
+  assert_not_nil(value, "Expected UUID, got nil for #{field}")
+  match = /[a-fA-F0-9-]{36}/.match(value).size > 0
+  assert_true(match, "Field #{field} is not a UUID, received #{value}")
+end
+
+#
+# Session payload steps
+#
+
+# Stores a session payload value against a key for cross-request comparisons.
+#
+# @step_input field [String] The session payload field to store
+# @step_input key [String] The key to store the value against
+Then('the session payload field {string} is stored as the value {string}') do |field, key|
+  value = read_key_path(Server.sessions.current[:body], field)
+  Store.values[key] = value.dup
+end
+
+# Tests whether a session payload field matches a previously stored payload value
+#
+# @step_input field [String] The payload field to test
+# @step_input key [String] The key indicating a previously stored value
+Then('the session payload field {string} equals the stored value {string}') do |field, key|
+  payload_value = read_key_path(Server.session.current[:body], field)
+  stored_value = Store.values[key]
+  result = value_compare(payload_value, stored_value)
+  assert_true(result.equal?, "Payload value: #{payload_value} does not equal stored value: #{stored_value}")
+end
+
+# Tests whether a session payload field is distinct from a previously stored payload value
+#
+# @step_input field [String] The session payload field to test
+# @step_input key [String] The key indicating a previously stored value
+Then('the session payload field {string} does not equal the stored value {string}') do |field, key|
+  payload_value = read_key_path(Server.session.current[:body], field)
+  stored_value = Store.values[key]
+  result = value_compare(payload_value, stored_value)
+  assert_false(result.equal?, "Payload value: #{payload_value} equals stored value: #{stored_value}")
+end
+
+# Tests whether a payload field is a number (Numeric according to Ruby)
+#
+# @step_input field [String] The payload field to test
+Then('the session payload field {string} is a number') do |field|
+  value = read_key_path(Server.session.current[:body], field)
+  assert_kind_of Numeric, value
+end
+
+# Tests whether a payload field is an integer (Integer according to Ruby)
+#
+# @step_input field [String] The payload field to test
+Then('the session payload field {string} is an integer') do |field|
+  value = read_key_path(Server.session.current[:body], field)
+  assert_kind_of Integer, value
+end
+
+# Tests whether a payload field is a date (parseable as a Date, according to Ruby)
+#
+# @step_input field [String] The payload field to test
+Then('the session payload field {string} is a date') do |field|
+  value = read_key_path(Server.session.current[:body], field)
+  date = begin
+           Date.parse(value)
+         rescue StandardError
+           nil
+         end
+  assert_kind_of Date, date
+end
+
+# Tests whether a payload field (loosely) matches a UUID regex (/[a-fA-F0-9-]{36}/)
+#
+# @step_input field [String] The payload field to test
+Then('the session payload field {string} is a UUID') do |field|
+  value = read_key_path(Server.session.current[:body], field)
   assert_not_nil(value, "Expected UUID, got nil for #{field}")
   match = /[a-fA-F0-9-]{36}/.match(value).size > 0
   assert_true(match, "Field #{field} is not a UUID, received #{value}")

--- a/lib/features/support/browser_stack_utils.rb
+++ b/lib/features/support/browser_stack_utils.rb
@@ -10,7 +10,6 @@ class BrowserStackUtils
     def upload_app(username, access_key, app)
       # TODO: Improve error handling:
       #   - res may not be JSON at all
-      #   - what if app doesn't exist locally
       if app.start_with? 'bs://'
         app_url = app
         $logger.info "Using pre-uploaded app from #{app}"

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -45,7 +45,7 @@ module Maze
     # Time in seconds to wait in the `I should receive no requests` step
     attr_accessor :receive_no_requests_wait
 
-    # Maximum time in seconds to wait in the `I wait to receive {int} error(s)` step
+    # Maximum time in seconds to wait in the `I wait to receive {int} error(s)/session(s)` steps
     attr_accessor :receive_requests_wait
 
     # Whether presence of the Bugsnag-Integrity header should be enforced

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -45,7 +45,7 @@ module Maze
     # Time in seconds to wait in the `I should receive no requests` step
     attr_accessor :receive_no_requests_wait
 
-    # Maximum time in seconds to wait in the `I wait to receive {int} request(s)` step
+    # Maximum time in seconds to wait in the `I wait to receive {int} error(s)` step
     attr_accessor :receive_requests_wait
 
     # Whether presence of the Bugsnag-Integrity header should be enforced

--- a/lib/features/support/request_list.rb
+++ b/lib/features/support/request_list.rb
@@ -31,17 +31,13 @@ class RequestList
     @requests[@current] if @requests.size > @current
   end
 
-  # Requests yet to be processed - i.e. from current onwards
-  #  Return an empty array if there are no requests outstanding.
+  # Peek at requests yet to be processed - i.e. from current onwards.  All requests are left visible in the list.
+  # Returns an empty array if there are no requests outstanding.
   def remaining
     requests = []
-    to_add = current
-    until to_add.nil?
-      requests.append to_add
-      self.next
-      to_add = current
-    end
-    requests
+    return requests if current.nil?
+
+    @requests[@current..@requests.size]
   end
 
   # Moves to the next request, if there is one

--- a/lib/features/support/request_list.rb
+++ b/lib/features/support/request_list.rb
@@ -34,8 +34,7 @@ class RequestList
   # Peek at requests yet to be processed - i.e. from current onwards.  All requests are left visible in the list.
   # Returns an empty array if there are no requests outstanding.
   def remaining
-    requests = []
-    return requests if current.nil?
+    return [] if current.nil?
 
     @requests[@current..@requests.size]
   end

--- a/lib/features/support/request_list.rb
+++ b/lib/features/support/request_list.rb
@@ -6,14 +6,16 @@ class RequestList
   def initialize
     @requests = []
     @current = 0
+    @count = 0
   end
 
   def empty?
     @requests.empty?
   end
 
+  # The number of unprocessed/remaining reqests in the list (not the total number actually held)
   def size
-    @requests.size
+    @count
   end
 
   # Add a request to the list
@@ -21,6 +23,7 @@ class RequestList
   # @param request The new request, from which a clone is made
   def add(request)
     @requests.append request.clone
+    @count += 1
   end
 
   # The current request
@@ -43,7 +46,10 @@ class RequestList
 
   # Moves to the next request, if there is one
   def next
-    @current += 1 if @current < @requests.size
+    return if @current >= @requests.size
+
+    @current += 1
+    @count -= 1
   end
 
   # A frozen clone of all requests held, including those already orocessed
@@ -55,5 +61,6 @@ class RequestList
   def clear
     @requests.clear
     @current = 0
+    @count = 0
   end
 end

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -78,6 +78,7 @@ class Server
             Logger: $logger,
             AccessLog: []
           )
+          # When adding more endpoints, be sure to update the 'I should receive no requests' step
           server.mount '/notify', Servlet, errors
           server.mount '/sessions', Servlet, sessions
           server.start

--- a/lib/options/option_validator.rb
+++ b/lib/options/option_validator.rb
@@ -32,7 +32,18 @@ module Maze
 
     # Validates BrowserStack options
     def validate_bs(options, errors)
-      errors << "--#{Maze::Option::APP} must be specified" if options[Maze::Option::APP].nil?
+      # App
+      app = options[Maze::Option::APP]
+      errors << "--#{Maze::Option::APP} must be specified" if app.nil?
+      unless app.start_with? 'bs://'
+        errors << "app file '#{app}' not found" unless File.exist? app
+      end
+
+      # BS local binary
+      bs_local = options[Maze::Option::BS_LOCAL]
+      errors << "BrowserStack local binary '#{bs_local}' not found" unless File.exist? bs_local
+
+      # Device
       bs_device = options[Maze::Option::BS_DEVICE]
       if bs_device.nil?
         errors << "--#{Maze::Option::BS_DEVICE} must be specified"
@@ -41,10 +52,10 @@ module Maze
           errors << "Device type '#{bs_device}' unknown on BrowserStack.  Must be one of #{Devices::DEVICE_HASH.keys}"
         end
       end
+
+      # Credentials
       errors << "--#{Maze::Option::USERNAME} must be specified" if options[Maze::Option::USERNAME].nil?
       errors << "--#{Maze::Option::ACCESS_KEY} must be specified" if options[Maze::Option::ACCESS_KEY].nil?
-      # TODO: Check that the --bs-local option is valid (file exists)
-      # TODO: Check that the --app option is valid (file exists)
     end
 
     # Validates Local device options

--- a/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
@@ -7,8 +7,8 @@ Feature: Testing helper methods respond correctly
 
     Scenario: The request body matches an expected session payload
         When I send a "session"-type request
-        Then I wait to receive an error
-        And the request is valid for the session reporting API version "1.0" for the "Maze-runner" notifier
+        Then I wait to receive a session
+        And the session is valid for the session reporting API version "1.0" for the "Maze-runner" notifier
 
     Scenario: The request body is correct for an unhandled payload
         When I send a "unhandled"-type request

--- a/test/fixtures/payload-helpers/features/scripts/send_request.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_request.sh
@@ -5,7 +5,12 @@ require 'json'
 require 'time'
 
 http = Net::HTTP.new('localhost', ENV['MOCK_API_PORT'])
-request = Net::HTTP::Post.new('/notify')
+endpoint = if ENV['request_type'] == 'session'
+             '/sessions'
+           else
+             '/notify'
+           end
+request = Net::HTTP::Post.new(endpoint)
 request['Content-Type'] = 'application/json'
 
 templates = {

--- a/test/request_list_test.rb
+++ b/test/request_list_test.rb
@@ -120,7 +120,10 @@ class RequestListTest < Test::Unit::TestCase
 
     list.next
     remaining = list.remaining
+    assert_equal [item2, item3], remaining
 
+    # Check that remaining does not change when inspected
+    remaining = list.remaining
     assert_equal [item2, item3], remaining
   end
 end


### PR DESCRIPTION
## Goal

Furthers development of the endpoint separation epic to the point that the Cocoa notifier tests now successfully run against it.

This change takes the integration branch to a candidate for release as v4 in its own right.  However, I've already taken the changes forward another step (for JS browsers), so another PR into the integration branch should be expected before moving on to PR the integration branch for a v4 release.

## Design 

The changes here were made in conjunction with the updating of the bugsnag-cocoa notifier tests to run against it.  These changes are on that repository's `tms/maze-v4` branch and will be PRed in due course (once the changes here are actually released).

## Changeset

The main source of changes here are the addition of Cucumber steps geared towards the verification of session payloads.  There are also some additions having taken the opportunity to absorb common steps currently present in the bugsnag-cocoa repository, as well as a few corrections to errors that came to light from having updated the Cocoa tests.

## Tests

Covered by passing CI and from having successfully updated the bugsnag-cocoa notifier tests on their own development branch.