### PR TITLE
Endpoint separation for JS-Browser and add Selenium web driver

### DIFF
--- a/bin/bugsnag-maze-runner
+++ b/bin/bugsnag-maze-runner
@@ -25,6 +25,7 @@ class MazeRunnerEntry
       Maze::Option::APP,
       Maze::Option::BS_LOCAL,
       Maze::Option::BS_DEVICE,
+      Maze::Option::BS_BROWSER,
       Maze::Option::OS,
       Maze::Option::OS_VERSION,
       Maze::Option::FARM,

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -144,7 +144,7 @@ After do |scenario|
     end
   end
 
-  next if MazeRunner.config.farm == :none
+  next if MazeRunner.config.farm == :none || !MazeRunner.config.bs_browser.nil?
 
   if MazeRunner.config.appium_session_isolation
     MazeRunner.driver.driver_quit

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -17,14 +17,20 @@ AfterConfiguration do |_cucumber_config|
   # BrowserStack specific setup
   if config.farm == :bs
     tunnel_id = SecureRandom.uuid
-    config.capabilities = Capabilities.for_browser_stack config.bs_device,
-                                                         tunnel_id,
-                                                         config.appium_version,
-                                                         config.capabilities_option
+    if config.bs_device
+      config.capabilities = Capabilities.for_browser_stack_device config.bs_device,
+                                                                  tunnel_id,
+                                                                  config.appium_version,
+                                                                  config.capabilities_option
 
-    config.app = BrowserStackUtils.upload_app config.username,
-                                              config.access_key,
-                                              config.app
+      config.app = BrowserStackUtils.upload_app config.username,
+                                                config.access_key,
+                                                config.app
+    else
+      config.capabilities = Capabilities.for_browser_stack_browser config.bs_browser,
+                                                                   tunnel_id,
+                                                                   config.capabilities_option
+    end
     BrowserStackUtils.start_local_tunnel config.bs_local,
                                          tunnel_id,
                                          config.access_key
@@ -50,6 +56,12 @@ AfterConfiguration do |_cucumber_config|
                                          config.capabilities,
                                          config.locator
                       end
+
+  # TODO: Weave this into the driver
+  # Selenium::WebDriver.for :remote,
+  #                         url: "http://#{ENV['BROWSER_STACK_USERNAME']}:#{ENV['BROWSER_STACK_ACCESS_KEY']}@hub.browserstack.com/wd/hub",
+  #                         desired_capabilities: caps
+
   if config.farm == :bs
     # Log a link to the BrowserStack session search dashboard
     build = MazeRunner.driver.caps[:build]

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -144,14 +144,12 @@ After do |scenario|
     end
   end
 
-  next if MazeRunner.config.farm == :none || !MazeRunner.config.bs_browser.nil?
-
   if MazeRunner.config.appium_session_isolation
     MazeRunner.driver.driver_quit
   elsif MazeRunner.config.os == 'macos'
     # Close the app - without the sleep, launching the app for the next scenario intermittently fails
     system("killall #{MazeRunner.config.app} && sleep 1")
-  else
+  elsif MazeRunner.config.bs_device
     MazeRunner.driver.reset_with_timeout 2
   end
 ensure

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -174,7 +174,7 @@ def test_string_platform_values(field_path, platform_values)
   expected_value = get_expected_platform_value(platform_values)
   return if should_skip_platform_check(expected_value)
 
-  payload_value = read_key_path(Server.errors.current[:body], field_path)
+  payload_value = read_key_path(Maze::Server.errors.current[:body], field_path)
   assert_equal(expected_value, payload_value)
 end
 
@@ -189,7 +189,7 @@ def test_boolean_platform_values(field_path, platform_values)
                   else
                     expected_value
                   end
-  payload_value = read_key_path(Server.errors.current[:body], field_path)
+  payload_value = read_key_path(Maze::Server.errors.current[:body], field_path)
   assert_equal(expected_bool, payload_value)
 end
 
@@ -197,6 +197,6 @@ def test_numeric_platform_values(field_path, platform_values)
   expected_value = get_expected_platform_value(platform_values)
   return if should_skip_platform_check(expected_value)
 
-  payload_value = read_key_path(Server.errors.current[:body], field_path)
+  payload_value = read_key_path(Maze::Server.errors.current[:body], field_path)
   assert_equal(expected_value.to_f, payload_value)
 end

--- a/lib/features/steps/breadcrumb_steps.rb
+++ b/lib/features/steps/breadcrumb_steps.rb
@@ -5,7 +5,7 @@
 # @step_input type [String] The expected breadcrumb's type
 # @step_input name [String] The expected breadcrumb's name
 Then("the event has a {string} breadcrumb named {string}") do |type, name|
-  value = Server.errors.current[:body]["events"].first["breadcrumbs"]
+  value = Maze::Server.errors.current[:body]["events"].first["breadcrumbs"]
   found = false
   value.each do |crumb|
     if crumb["type"] == type and crumb["name"] == name then
@@ -20,7 +20,7 @@ end
 # @step_input type [String] The expected breadcrumb's type
 # @step_input message [String] The expected breadcrumb's message
 Then("the event has a {string} breadcrumb with message {string}") do |type, message|
-  value = Server.errors.current[:body]["events"].first["breadcrumbs"]
+  value = Maze::Server.errors.current[:body]["events"].first["breadcrumbs"]
   found = false
   value.each do |crumb|
     if crumb["type"] == type and crumb["metaData"] and crumb["metaData"]["message"] == message then
@@ -35,7 +35,7 @@ end
 #
 # @step_input type [String] The type of breadcrumb expected to not be present
 Then("the event does not have a {string} breadcrumb") do |type|
-  value = Server.errors.current[:body]["events"].first["breadcrumbs"]
+  value = Maze::Server.errors.current[:body]["events"].first["breadcrumbs"]
   found = false
   value.each do |crumb|
     if crumb["type"] == type
@@ -49,7 +49,7 @@ end
 #
 # @step_input json_fixture [String] A path to the JSON fixture to compare against
 Then("the event contains a breadcrumb matching the JSON fixture in {string}") do |json_fixture|
-  breadcrumbs = read_key_path(Server.errors.current[:body], "events.0.breadcrumbs")
+  breadcrumbs = read_key_path(Maze::Server.errors.current[:body], "events.0.breadcrumbs")
   expected = JSON.parse(open(json_fixture, &:read))
   match = breadcrumbs.any? { |breadcrumb| value_compare(expected, breadcrumb).equal? }
   assert(match, "No breadcrumbs in the event matched the given breadcrumb")

--- a/lib/features/steps/browser_steps.rb
+++ b/lib/features/steps/browser_steps.rb
@@ -1,7 +1,7 @@
 # @!group Browser steps
 
 When('I navigate to the URL {string}') do |path|
-  MazeRunner.driver.navigate.to get_test_url path
+  MazeRunner.driver.navigate.to path
 end
 
 When('the test should run in this browser') do

--- a/lib/features/steps/browser_steps.rb
+++ b/lib/features/steps/browser_steps.rb
@@ -1,0 +1,121 @@
+# @!group Browser steps
+
+When('I navigate to the URL {string}') do |path|
+  $driver.navigate.to get_test_url path
+end
+
+When('the test should run in this browser') do
+  wait = Selenium::WebDriver::Wait.new(timeout: 10)
+  wait.until {
+    $driver.find_element(id: 'bugsnag-test-should-run') &&
+    $driver.find_element(id: 'bugsnag-test-should-run').text != 'PENDING'
+  }
+  skip_this_scenario if $driver.find_element(id: 'bugsnag-test-should-run').text == 'NO'
+end
+
+When('I let the test page run for up to {int} seconds') do |n|
+  wait = Selenium::WebDriver::Wait.new(timeout: n)
+  wait.until {
+    $driver.find_element(id: 'bugsnag-test-state') &&
+    (
+      $driver.find_element(id: 'bugsnag-test-state').text == 'DONE' ||
+      $driver.find_element(id: 'bugsnag-test-state').text == 'ERROR'
+    )
+  }
+  txt = $driver.find_element(id: 'bugsnag-test-state').text
+  assert_equal('DONE', txt, "Expected #bugsnag-test-state text to be 'DONE'. It was '#{txt}'.")
+end
+
+When('the exception matches the {string} values for the current browser') do |fixture|
+  err = get_error_message(fixture)
+  steps %(
+    And the exception "errorClass" equals "#{err['errorClass']}"
+    And the exception "message" equals "#{err['errorMessage']}"
+  )
+  if err['lineNumber']
+    step("the \"lineNumber\" of stack frame 0 equals #{err['lineNumber']}")
+  end
+  if err['columnNumber']
+    step("the \"columnNumber\" of stack frame 0 equals #{err['columnNumber']}")
+  end
+  if err['file']
+    step("the \"file\" of stack frame 0 ends with \"#{err['file']}\"")
+  end
+end
+
+Then(/^the request is a valid browser payload for the error reporting API$/) do
+  if !/^ie_(8|9|10)$/.match(ENV['BROWSER'])
+    steps %(
+      Then the "Bugsnag-API-Key" header is not null
+      And the "Content-Type" header equals one of:
+        | application/json |
+        | application/json; charset=UTF-8 |
+      And the "Bugsnag-Payload-Version" header equals "4"
+      And the "Bugsnag-Sent-At" header is a timestamp
+    )
+  else
+    steps %(
+      Then the "apiKey" query parameter is not null
+      And the "payloadVersion" query parameter equals "4"
+      And the "sentAt" query parameter is a timestamp
+    )
+  end
+  steps %(
+    And the payload field "notifier.name" is not null
+    And the payload field "notifier.url" is not null
+    And the payload field "notifier.version" is not null
+    And the payload field "events" is a non-empty array
+
+    And each element in payload field "events" has "severity"
+    And each element in payload field "events" has "severityReason.type"
+    And each element in payload field "events" has "unhandled"
+    And each element in payload field "events" has "exceptions"
+
+    And the exception "type" equals "browserjs"
+  )
+end
+
+Then('the request is a valid browser payload for the session tracking API') do
+  if !/^ie_(8|9|10)$/.match(ENV['BROWSER'])
+    steps %(
+      Then the "Bugsnag-API-Key" header is not null
+      And the "Content-Type" header equals one of:
+        | application/json |
+        | application/json; charset=UTF-8 |
+      And the "Bugsnag-Payload-Version" header equals "1"
+      And the "Bugsnag-Sent-At" header is a timestamp
+    )
+  else
+    steps %(
+      Then the "apiKey" query parameter is not null
+      And the "payloadVersion" query parameter equals "1"
+      And the "sentAt" query parameter is a timestamp
+    )
+  end
+  steps %(
+    And the payload field "app" is not null
+    And the payload field "device" is not null
+    And the payload field "notifier.name" is not null
+    And the payload field "notifier.url" is not null
+    And the payload field "notifier.version" is not null
+    And the payload has a valid sessions array
+  )
+end
+
+Then('the event device ID is valid') do
+  if has_local_storage
+    step('the event "device.id" matches "^c[a-z0-9]{20,32}$"')
+  else
+    $logger.info('Local storage is not supported in this browser, assuming device ID is null')
+    step('the event "device.id" is null')
+  end
+end
+
+Then('the event device ID is {string}') do |expected_id|
+  if has_local_storage
+    step("the event \"device.id\" equals \"#{expected_id}\"")
+  else
+    $logger.info('Local storage is not supported in this browser, assuming device ID is null')
+    step('the event "device.id" is null')
+  end
+end

--- a/lib/features/steps/browser_steps.rb
+++ b/lib/features/steps/browser_steps.rb
@@ -1,63 +1,47 @@
 # @!group Browser steps
 
 When('I navigate to the URL {string}') do |path|
+  $logger.debug "Navigating to: #{path}"
   MazeRunner.driver.navigate.to path
 end
 
 When('the test should run in this browser') do
   wait = Selenium::WebDriver::Wait.new(timeout: 10)
   wait.until {
-    $driver.find_element(id: 'bugsnag-test-should-run') &&
-    $driver.find_element(id: 'bugsnag-test-should-run').text != 'PENDING'
+    MazeRunner.driver.find_element(id: 'bugsnag-test-should-run') &&
+    MazeRunner.driver.find_element(id: 'bugsnag-test-should-run').text != 'PENDING'
   }
-  skip_this_scenario if $driver.find_element(id: 'bugsnag-test-should-run').text == 'NO'
+  skip_this_scenario if MazeRunner.driver.find_element(id: 'bugsnag-test-should-run').text == 'NO'
 end
 
 When('I let the test page run for up to {int} seconds') do |n|
   wait = Selenium::WebDriver::Wait.new(timeout: n)
   wait.until {
-    $driver.find_element(id: 'bugsnag-test-state') &&
+    MazeRunner.driver.find_element(id: 'bugsnag-test-state') &&
     (
-      $driver.find_element(id: 'bugsnag-test-state').text == 'DONE' ||
-      $driver.find_element(id: 'bugsnag-test-state').text == 'ERROR'
+      MazeRunner.driver.find_element(id: 'bugsnag-test-state').text == 'DONE' ||
+      MazeRunner.driver.find_element(id: 'bugsnag-test-state').text == 'ERROR'
     )
   }
-  txt = $driver.find_element(id: 'bugsnag-test-state').text
+  txt = MazeRunner.driver.find_element(id: 'bugsnag-test-state').text
   assert_equal('DONE', txt, "Expected #bugsnag-test-state text to be 'DONE'. It was '#{txt}'.")
-end
-
-When('the exception matches the {string} values for the current browser') do |fixture|
-  err = get_error_message(fixture)
-  steps %(
-    And the exception "errorClass" equals "#{err['errorClass']}"
-    And the exception "message" equals "#{err['errorMessage']}"
-  )
-  if err['lineNumber']
-    step("the \"lineNumber\" of stack frame 0 equals #{err['lineNumber']}")
-  end
-  if err['columnNumber']
-    step("the \"columnNumber\" of stack frame 0 equals #{err['columnNumber']}")
-  end
-  if err['file']
-    step("the \"file\" of stack frame 0 ends with \"#{err['file']}\"")
-  end
 end
 
 Then(/^the request is a valid browser payload for the error reporting API$/) do
   if !/^ie_(8|9|10)$/.match(ENV['BROWSER'])
     steps %(
-      Then the "Bugsnag-API-Key" header is not null
-      And the "Content-Type" header equals one of:
+      Then the error "Bugsnag-API-Key" header is not null
+      And the error "Content-Type" header equals one of:
         | application/json |
         | application/json; charset=UTF-8 |
-      And the "Bugsnag-Payload-Version" header equals "4"
-      And the "Bugsnag-Sent-At" header is a timestamp
+      And the error "Bugsnag-Payload-Version" header equals "4"
+      And the error "Bugsnag-Sent-At" header is a timestamp
     )
   else
     steps %(
-      Then the "apiKey" query parameter is not null
-      And the "payloadVersion" query parameter equals "4"
-      And the "sentAt" query parameter is a timestamp
+      Then the error "apiKey" query parameter is not null
+      And the error "payloadVersion" query parameter equals "4"
+      And the error "sentAt" query parameter is a timestamp
     )
   end
   steps %(
@@ -103,7 +87,7 @@ Then('the request is a valid browser payload for the session tracking API') do
 end
 
 Then('the event device ID is valid') do
-  if has_local_storage
+  if MazeRunner.driver.local_storage?
     step('the event "device.id" matches "^c[a-z0-9]{20,32}$"')
   else
     $logger.info('Local storage is not supported in this browser, assuming device ID is null')
@@ -112,7 +96,7 @@ Then('the event device ID is valid') do
 end
 
 Then('the event device ID is {string}') do |expected_id|
-  if has_local_storage
+  if MazeRunner.driver.local_storage?
     step("the event \"device.id\" equals \"#{expected_id}\"")
   else
     $logger.info('Local storage is not supported in this browser, assuming device ID is null')

--- a/lib/features/steps/browser_steps.rb
+++ b/lib/features/steps/browser_steps.rb
@@ -62,27 +62,27 @@ end
 Then('the request is a valid browser payload for the session tracking API') do
   if !/^ie_(8|9|10)$/.match(ENV['BROWSER'])
     steps %(
-      Then the "Bugsnag-API-Key" header is not null
-      And the "Content-Type" header equals one of:
+      Then the session "Bugsnag-API-Key" header is not null
+      And the session "Content-Type" header equals one of:
         | application/json |
         | application/json; charset=UTF-8 |
-      And the "Bugsnag-Payload-Version" header equals "1"
-      And the "Bugsnag-Sent-At" header is a timestamp
+      And the session "Bugsnag-Payload-Version" header equals "1"
+      And the session "Bugsnag-Sent-At" header is a timestamp
     )
   else
     steps %(
-      Then the "apiKey" query parameter is not null
-      And the "payloadVersion" query parameter equals "1"
-      And the "sentAt" query parameter is a timestamp
+      Then the session "apiKey" query parameter is not null
+      And the session "payloadVersion" query parameter equals "1"
+      And the session "sentAt" query parameter is a timestamp
     )
   end
   steps %(
-    And the payload field "app" is not null
-    And the payload field "device" is not null
-    And the payload field "notifier.name" is not null
-    And the payload field "notifier.url" is not null
-    And the payload field "notifier.version" is not null
-    And the payload has a valid sessions array
+    And the session payload field "app" is not null
+    And the session payload field "device" is not null
+    And the session payload field "notifier.name" is not null
+    And the session payload field "notifier.url" is not null
+    And the session payload field "notifier.version" is not null
+    And the session payload has a valid sessions array
   )
 end
 

--- a/lib/features/steps/browser_steps.rb
+++ b/lib/features/steps/browser_steps.rb
@@ -28,7 +28,7 @@ When('I let the test page run for up to {int} seconds') do |n|
 end
 
 Then(/^the request is a valid browser payload for the error reporting API$/) do
-  if !/^ie_(8|9|10)$/.match(ENV['BROWSER'])
+  if !/^ie_(8|9|10)$/.match(MazeRunner.config.bs_browser)
     steps %(
       Then the error "Bugsnag-API-Key" header is not null
       And the error "Content-Type" header equals one of:
@@ -60,7 +60,7 @@ Then(/^the request is a valid browser payload for the error reporting API$/) do
 end
 
 Then('the request is a valid browser payload for the session tracking API') do
-  if !/^ie_(8|9|10)$/.match(ENV['BROWSER'])
+  if !/^ie_(8|9|10)$/.match(MazeRunner.config.bs_browser)
     steps %(
       Then the session "Bugsnag-API-Key" header is not null
       And the session "Content-Type" header equals one of:

--- a/lib/features/steps/browser_steps.rb
+++ b/lib/features/steps/browser_steps.rb
@@ -1,7 +1,7 @@
 # @!group Browser steps
 
 When('I navigate to the URL {string}') do |path|
-  $driver.navigate.to get_test_url path
+  MazeRunner.driver.navigate.to get_test_url path
 end
 
 When('the test should run in this browser') do

--- a/lib/features/steps/browser_steps.rb
+++ b/lib/features/steps/browser_steps.rb
@@ -5,28 +5,6 @@ When('I navigate to the URL {string}') do |path|
   MazeRunner.driver.navigate.to path
 end
 
-When('the test should run in this browser') do
-  wait = Selenium::WebDriver::Wait.new(timeout: 10)
-  wait.until {
-    MazeRunner.driver.find_element(id: 'bugsnag-test-should-run') &&
-    MazeRunner.driver.find_element(id: 'bugsnag-test-should-run').text != 'PENDING'
-  }
-  skip_this_scenario if MazeRunner.driver.find_element(id: 'bugsnag-test-should-run').text == 'NO'
-end
-
-When('I let the test page run for up to {int} seconds') do |n|
-  wait = Selenium::WebDriver::Wait.new(timeout: n)
-  wait.until {
-    MazeRunner.driver.find_element(id: 'bugsnag-test-state') &&
-    (
-      MazeRunner.driver.find_element(id: 'bugsnag-test-state').text == 'DONE' ||
-      MazeRunner.driver.find_element(id: 'bugsnag-test-state').text == 'ERROR'
-    )
-  }
-  txt = MazeRunner.driver.find_element(id: 'bugsnag-test-state').text
-  assert_equal('DONE', txt, "Expected #bugsnag-test-state text to be 'DONE'. It was '#{txt}'.")
-end
-
 Then(/^the request is a valid browser payload for the error reporting API$/) do
   if !/^ie_(8|9|10)$/.match(MazeRunner.config.bs_browser)
     steps %(

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -80,9 +80,9 @@ end
 #
 # @step_input payload_version [String] The payload version expected
 Then('the payload contains the payloadVersion {string}') do |payload_version|
-  body_version = read_key_path(Server.errors.current[:body], 'payloadVersion')
+  body_version = read_key_path(Maze::Server.errors.current[:body], 'payloadVersion')
   body_set = payload_version == body_version
-  event_version = read_key_path(Server.errors.current[:body], 'events.0.payloadVersion')
+  event_version = read_key_path(Maze::Server.errors.current[:body], 'events.0.payloadVersion')
   event_set = payload_version == event_version
   assert_true(
     body_set || event_set,
@@ -280,7 +280,7 @@ end
 # @param payload_key [String] The thread identifier key
 # @param payload_value [Any] The thread identifier value
 def validate_error_reporting_thread(payload_key, payload_value)
-  threads = Server.errors.current[:body]['events'].first['threads']
+  threads = Maze::Server.errors.current[:body]['events'].first['threads']
   assert_kind_of Array, threads
   count = 0
 
@@ -309,7 +309,7 @@ def test_unhandled_state(event, unhandled, severity = nil)
     And the payload field "events.#{event}.severity" equals "#{expected_severity}"
   )
 
-  return if read_key_path(Server.errors.current[:body], "events.#{event}.session").nil?
+  return if read_key_path(Maze::Server.errors.current[:body], "events.#{event}.session").nil?
 
   session_field = unhandled ? 'unhandled' : 'handled'
   steps %(

--- a/lib/features/steps/header_steps.rb
+++ b/lib/features/steps/header_steps.rb
@@ -3,5 +3,5 @@
 # Checks that the Bugsnag-Integrity header is a SHA1 or simple digest
 #
 When('the Bugsnag-Integrity header is valid') do
-  assert_true(valid_bugsnag_integrity_header(Server.errors.current), 'Invalid Bugsnag-Integrity header detected')
+  assert_true(valid_bugsnag_integrity_header(Maze::Server.errors.current), 'Invalid Bugsnag-Integrity header detected')
 end

--- a/lib/features/steps/multipart_request_steps.rb
+++ b/lib/features/steps/multipart_request_steps.rb
@@ -20,25 +20,25 @@ end
 
 # Verifies that the request contains multipart form-data
 Then('the request is valid multipart form-data') do
-  valid_multipart_form_data?(Server.errors.current)
+  valid_multipart_form_data?(Maze::Server.errors.current)
 end
 
 # Verifies all received requests contain multipart form-data
 Then('all requests are valid multipart form-data') do
-  Server.errors.all.all? { |request| valid_multipart_form_data?(request) }
+  Maze::Server.errors.all.all? { |request| valid_multipart_form_data?(request) }
 end
 
 # Tests the number of fields a multipart request contains.
 #
 # @step_input part_count [Integer] The number of expected fields
 Then('the multipart request has {int} fields') do |part_count|
-  parts = Server.errors.current[:body]
+  parts = Maze::Server.errors.current[:body]
   assert_equal(part_count, parts.size)
 end
 
 # Tests the multipart request has at least one field.
 Then('the multipart request has a non-empty body') do
-  parts = Server.errors.current[:body]
+  parts = Maze::Server.errors.current[:body]
   assert(parts.size.positive?, "Multipart request payload contained #{parts.size} fields")
 end
 
@@ -49,7 +49,7 @@ end
 #
 # @step_input part_key [String] The key to the multipart element
 Then('the field {string} for multipart request is not null') do |part_key|
-  parts = Server.errors.current[:body]
+  parts = Maze::Server.errors.current[:body]
   assert_not_nil(parts[part_key], "The field '#{part_key}' should not be null")
 end
 
@@ -61,7 +61,7 @@ end
 # @step_input part_key [String] The key to the multipart element
 # @step_input expected_value [String] The string to match against
 Then('the field {string} for multipart request equals {string}') do |part_key, expected_value|
-  parts = Server.errors.current[:body]
+  parts = Maze::Server.errors.current[:body]
   assert_equal(parts[part_key], expected_value)
 end
 
@@ -72,7 +72,7 @@ end
 #
 # @step_input part_key [String] The key to the multipart element
 Then('the field {string} for multipart request is null') do |part_key|
-  parts = Server.errors.current[:body]
+  parts = Maze::Server.errors.current[:body]
   assert_nil(parts[part_key], "The field '#{part_key}' should be null")
 end
 
@@ -96,7 +96,7 @@ end
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart body does not match the JSON file in {string}') do |json_path|
   assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
-  raw_payload_value = Server.errors.current[:body]
+  raw_payload_value = Maze::Server.errors.current[:body]
   payload_value = parse_multipart_body(raw_payload_value)
   expected_value = JSON.parse(open(json_path, &:read))
   result = value_compare(expected_value, payload_value)
@@ -109,7 +109,7 @@ end
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart body matches the JSON file in {string}') do |json_path|
   assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
-  raw_payload_value = Server.errors.current[:body]
+  raw_payload_value = Maze::Server.errors.current[:body]
   payload_value = parse_multipart_body(raw_payload_value)
   expected_value = JSON.parse(open(json_path, &:read))
   result = value_compare(expected_value, payload_value)
@@ -123,7 +123,7 @@ end
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart field {string} matches the JSON file in {string}') do |field_path, json_path|
   assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
-  payload_value = JSON.parse(Server.errors.current[:body][field_path].to_s)
+  payload_value = JSON.parse(Maze::Server.errors.current[:body][field_path].to_s)
   expected_value = JSON.parse(open(json_path, &:read))
   result = value_compare(expected_value, payload_value)
   assert_true(result.equal?, "The multipart field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -12,15 +12,15 @@ end
 #
 # @step_input status_code [Integer] The status code to return
 When("I set the HTTP status code to {int}") do |status_code|
-  Server.status_code = status_code
+  Maze::Server.status_code = status_code
 end
 
 # Sets the HTTP status code to be used for the next request
 #
 # @step_input status_code [Integer] The status code to return
 When("I set the HTTP status code for the next request to {int}") do |status_code|
-  Server.reset_status_code = true
-  Server.status_code = status_code
+  Maze::Server.reset_status_code = true
+  Maze::Server.status_code = status_code
 end
 
 # Attempts to open a URL.

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -35,8 +35,8 @@ end
 # Assert that the test Server hasn't received any requests at all.
 Then('I should receive no requests') do
   sleep MazeRunner.config.receive_no_requests_wait
-  assert_equal(0, Maze::Maze::Server.errors.size, "#{Maze::Maze::Server.errors.size} errors received")
-  assert_equal(0, Maze::Maze::Server.sessions.size, "#{Maze::Maze::Server.sessions.size} sessions received")
+  assert_equal(0, Maze::Server.errors.size, "#{Maze::Server.errors.size} errors received")
+  assert_equal(0, Maze::Server.sessions.size, "#{Maze::Server.sessions.size} sessions received")
 end
 
 #
@@ -58,12 +58,12 @@ end
 # Assert that the test Server hasn't received any errors.
 Then('I should receive no errors') do
   sleep MazeRunner.config.receive_no_requests_wait
-  assert_equal(0, Maze::Maze::Server.errors.size, "#{Maze::Maze::Server.errors.size} errors received")
+  assert_equal(0, Maze::Server.errors.size, "#{Maze::Server.errors.size} errors received")
 end
 
 Then('the received errors match:') do |table|
   # Checks that each request matches one of the event fields
-  requests = Maze::Maze::Server.errors.remaining
+  requests = Maze::Server.errors.remaining
   match_count = 0
 
   # iterate through each row in the table. exactly 1 request should match each row.
@@ -92,9 +92,9 @@ end
 
 # Moves to the next error
 Then('I discard the oldest error') do
-  raise 'No error to discard' if Maze::Maze::Server.errors.current.nil?
+  raise 'No error to discard' if Maze::Server.errors.current.nil?
 
-  Maze::Maze::Server.errors.next
+  Maze::Server.errors.next
 end
 
 # Continually checks to see if the required amount of sessions have been received.
@@ -108,16 +108,15 @@ end
 # Assert that the test Server hasn't received any sessions.
 Then('I should receive no sessions') do
   sleep MazeRunner.config.receive_no_requests_wait
-  assert_equal(0, Maze::Maze::Server.sessions.size, "#{Maze::Maze::Server.sessions.size} sessions received")
+  assert_equal(0, Maze::Server.sessions.size, "#{Maze::Server.sessions.size} sessions received")
 end
 
 # Moves to the next sessions
 Then('I discard the oldest session') do
-  raise 'No session to discard' if Maze::Maze::Server.sessions.current.nil?
+  raise 'No session to discard' if Maze::Server.sessions.current.nil?
 
-  Maze::Maze::Server.sessions.next
+  Maze::Server.sessions.next
 end
-
 
 #
 # TODO There's a lot of overlap between error and session header assertions and only implemented this

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -35,8 +35,8 @@ end
 # Assert that the test Server hasn't received any requests at all.
 Then('I should receive no requests') do
   sleep MazeRunner.config.receive_no_requests_wait
-  assert_equal(0, Server.errors.size, "#{Server.errors.size} errors received")
-  assert_equal(0, Server.sessions.size, "#{Server.sessions.size} sessions received")
+  assert_equal(0, Maze::Maze::Server.errors.size, "#{Maze::Maze::Server.errors.size} errors received")
+  assert_equal(0, Maze::Maze::Server.sessions.size, "#{Maze::Maze::Server.sessions.size} sessions received")
 end
 
 #
@@ -52,18 +52,18 @@ end
 #
 # @step_input request_count [Integer] The amount of requests expected
 Then('I wait to receive {int} error(s)') do |request_count|
-  assert_received_requests request_count, Server.errors, 'errors'
+  assert_received_requests request_count, Maze::Server.errors, 'errors'
 end
 
 # Assert that the test Server hasn't received any errors.
 Then('I should receive no errors') do
   sleep MazeRunner.config.receive_no_requests_wait
-  assert_equal(0, Server.errors.size, "#{Server.errors.size} errors received")
+  assert_equal(0, Maze::Maze::Server.errors.size, "#{Maze::Maze::Server.errors.size} errors received")
 end
 
 Then('the received errors match:') do |table|
   # Checks that each request matches one of the event fields
-  requests = Server.errors.remaining
+  requests = Maze::Maze::Server.errors.remaining
   match_count = 0
 
   # iterate through each row in the table. exactly 1 request should match each row.
@@ -92,9 +92,9 @@ end
 
 # Moves to the next error
 Then('I discard the oldest error') do
-  raise 'No error to discard' if Server.errors.current.nil?
+  raise 'No error to discard' if Maze::Maze::Server.errors.current.nil?
 
-  Server.errors.next
+  Maze::Maze::Server.errors.next
 end
 
 # Continually checks to see if the required amount of sessions have been received.
@@ -102,20 +102,20 @@ end
 #
 # @step_input request_count [Integer] The amount of requests expected
 Then('I wait to receive {int} session(s)') do |request_count|
-  assert_received_requests request_count, Server.sessions, 'sessions'
+  assert_received_requests request_count, Maze::Server.sessions, 'sessions'
 end
 
 # Assert that the test Server hasn't received any sessions.
 Then('I should receive no sessions') do
   sleep MazeRunner.config.receive_no_requests_wait
-  assert_equal(0, Server.sessions.size, "#{Server.sessions.size} sessions received")
+  assert_equal(0, Maze::Maze::Server.sessions.size, "#{Maze::Maze::Server.sessions.size} sessions received")
 end
 
 # Moves to the next sessions
 Then('I discard the oldest session') do
-  raise 'No session to discard' if Server.sessions.current.nil?
+  raise 'No session to discard' if Maze::Maze::Server.sessions.current.nil?
 
-  Server.sessions.next
+  Maze::Maze::Server.sessions.next
 end
 
 
@@ -132,7 +132,7 @@ end
 #
 # @step_input header_name [String] The header to test
 Then('the error {string} header is not null') do |header_name|
-  assert_not_nil(Server.errors.current[:request][header_name],
+  assert_not_nil(Maze::Server.errors.current[:request][header_name],
                  "The error '#{header_name}' header should not be null")
 end
 
@@ -141,9 +141,9 @@ end
 # @step_input header_name [String] The header to test
 # @step_input header_value [String] The string it should match
 Then('the error {string} header equals {string}') do |header_name, header_value|
-  assert_not_nil(Server.errors.current[:request][header_name],
+  assert_not_nil(Maze::Server.errors.current[:request][header_name],
                  "The error '#{header_name}' header wasn't present in the request")
-  assert_equal(header_value, Server.errors.current[:request][header_name])
+  assert_equal(header_value, Maze::Server.errors.current[:request][header_name])
 end
 
 # Tests that an error header matches a regex
@@ -152,7 +152,7 @@ end
 # @step_input regex_string [String] The regex to match with
 Then('the error {string} header matches the regex {string}') do |header_name, regex_string|
   regex = Regexp.new(regex_string)
-  value = Server.errors.current[:request][header_name]
+  value = Maze::Server.errors.current[:request][header_name]
   assert_match(regex, value)
 end
 
@@ -161,14 +161,14 @@ end
 # @step_input header_name [String] The header to test
 # @step_input header_values [DataTable] A parsed data table
 Then('the error {string} header equals one of:') do |header_name, header_values|
-  assert_includes(header_values.raw.flatten, Server.errors.current[:request][header_name])
+  assert_includes(header_values.raw.flatten, Maze::Server.errors.current[:request][header_name])
 end
 
 # Tests that am error header is a timestamp.
 #
 # @step_input header_name [String] The header to test
 Then('the error {string} header is a timestamp') do |header_name|
-  header = Server.errors.current[:request][header_name]
+  header = Maze::Server.errors.current[:request][header_name]
   assert_match(TIMESTAMP_REGEX, header)
 end
 
@@ -180,7 +180,7 @@ end
 #
 # @step_input header_name [String] The header to test
 Then('the session {string} header is not null') do |header_name|
-  assert_not_nil(Server.sessions.current[:request][header_name],
+  assert_not_nil(Maze::Server.sessions.current[:request][header_name],
                  "The session '#{header_name}' header should not be null")
 end
 
@@ -189,9 +189,9 @@ end
 # @step_input header_name [String] The header to test
 # @step_input header_value [String] The string it should match
 Then('the session {string} header equals {string}') do |header_name, header_value|
-  assert_not_nil(Server.sessions.current[:request][header_name],
+  assert_not_nil(Maze::Server.sessions.current[:request][header_name],
                  "The session '#{header_name}' header wasn't present in the request")
-  assert_equal(header_value, Server.sessions.current[:request][header_name])
+  assert_equal(header_value, Maze::Server.sessions.current[:request][header_name])
 end
 
 # Tests that a session header matches a regex
@@ -200,7 +200,7 @@ end
 # @step_input regex_string [String] The regex to match with
 Then('the session {string} header matches the regex {string}') do |header_name, regex_string|
   regex = Regexp.new(regex_string)
-  value = Server.sessions.current[:request][header_name]
+  value = Maze::Server.sessions.current[:request][header_name]
   assert_match(regex, value)
 end
 
@@ -209,14 +209,14 @@ end
 # @step_input header_name [String] The header to test
 # @step_input header_values [DataTable] A parsed data table
 Then('the session {string} header equals one of:') do |header_name, header_values|
-  assert_includes(header_values.raw.flatten, Server.sessions.current[:request][header_name])
+  assert_includes(header_values.raw.flatten, Maze::Server.sessions.current[:request][header_name])
 end
 
 # Tests that a session header is a timestamp.
 #
 # @step_input header_name [String] The header to test
 Then('the session {string} header is a timestamp') do |header_name|
-  header = Server.sessions.current[:request][header_name]
+  header = Maze::Server.sessions.current[:request][header_name]
   assert_match(TIMESTAMP_REGEX, header)
 end
 
@@ -229,14 +229,14 @@ end
 # @step_input parameter_name [String] The parameter to test
 # @step_input parameter_value [String] The expected value
 Then('the error {string} query parameter equals {string}') do |parameter_name, parameter_value|
-  assert_equal(parameter_value, parse_querystring(Server.errors.current)[parameter_name][0])
+  assert_equal(parameter_value, parse_querystring(Maze::Server.errors.current)[parameter_name][0])
 end
 
 # Tests that a query parameter is present and not null.
 #
 # @step_input parameter_name [String] The parameter to test
 Then('the error {string} query parameter is not null') do |parameter_name|
-  assert_not_nil(parse_querystring(Server.errors.current)[parameter_name][0],
+  assert_not_nil(parse_querystring(Maze::Server.errors.current)[parameter_name][0],
                  "The '#{parameter_name}' query parameter should not be null")
 end
 
@@ -244,7 +244,7 @@ end
 #
 # @step_input parameter_name [String] The parameter to test
 Then('the error {string} query parameter is a timestamp') do |parameter_name|
-  param = parse_querystring(Server.errors.current)[parameter_name][0]
+  param = parse_querystring(Maze::Server.errors.current)[parameter_name][0]
   assert_match(TIMESTAMP_REGEX, param)
 end
 
@@ -252,7 +252,7 @@ end
 #
 # @step_input fixture_path [String] Path to a JSON fixture
 Then('the payload body does not match the JSON fixture in {string}') do |fixture_path|
-  payload_value = Server.errors.current[:body]
+  payload_value = Maze::Server.errors.current[:body]
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = value_compare(expected_value, payload_value)
   assert_false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
@@ -262,7 +262,7 @@ end
 #
 # @step_input fixture_path [String] Path to a JSON fixture
 Then('the payload body matches the JSON fixture in {string}') do |fixture_path|
-  payload_value = Server.errors.current[:body]
+  payload_value = Maze::Server.errors.current[:body]
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = value_compare(expected_value, payload_value)
   assert_true(result.equal?,
@@ -274,7 +274,7 @@ end
 # @step_input field_path [String] Path to the tested element
 # @step_input fixture_path [String] Path to a JSON fixture
 Then('the payload field {string} matches the JSON fixture in {string}') do |field_path, fixture_path|
-  payload_value = read_key_path(Server.errors.current[:body], field_path)
+  payload_value = read_key_path(Maze::Server.errors.current[:body], field_path)
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = value_compare(expected_value, payload_value)
   assert_true(result.equal?,
@@ -285,21 +285,21 @@ end
 #
 # @step_input field_path [String] Path to the tested element
 Then('the payload field {string} is true') do |field_path|
-  assert_equal(true, read_key_path(Server.errors.current[:body], field_path))
+  assert_equal(true, read_key_path(Maze::Server.errors.current[:body], field_path))
 end
 
 # Tests that a payload element is false.
 #
 # @step_input field_path [String] Path to the tested element
 Then('the payload field {string} is false') do |field_path|
-  assert_equal(false, read_key_path(Server.errors.current[:body], field_path))
+  assert_equal(false, read_key_path(Maze::Server.errors.current[:body], field_path))
 end
 
 # Tests that a payload element is null.
 #
 # @step_input field_path [String] Path to the tested element
 Then('the payload field {string} is null') do |field_path|
-  value = read_key_path(Server.errors.current[:body], field_path)
+  value = read_key_path(Maze::Server.errors.current[:body], field_path)
   assert_nil(value, "The field '#{field_path}' should be null but is #{value}")
 end
 
@@ -307,7 +307,7 @@ end
 #
 # @step_input field_path [String] Path to the tested element
 Then('the payload field {string} is not null') do |field_path|
-  assert_not_nil(read_key_path(Server.errors.current[:body], field_path),
+  assert_not_nil(read_key_path(Maze::Server.errors.current[:body], field_path),
                  "The field '#{field_path}' should not be null")
 end
 
@@ -316,7 +316,7 @@ end
 # @step_input field_path [String] Path to the tested element
 # @step_input int_value [Integer] The value to test against
 Then('the payload field {string} equals {int}') do |field_path, int_value|
-  assert_equal(int_value, read_key_path(Server.errors.current[:body], field_path))
+  assert_equal(int_value, read_key_path(Maze::Server.errors.current[:body], field_path))
 end
 
 # Tests the payload field value against an environment variable.
@@ -326,7 +326,7 @@ end
 Then('the payload field {string} equals the environment variable {string}') do |field_path, env_var|
   environment_value = ENV[env_var]
   assert_false(environment_value.nil?, "The environment variable #{env_var} must not be nil")
-  value = read_key_path(Server.errors.current[:body], field_path)
+  value = read_key_path(Maze::Server.errors.current[:body], field_path)
 
   assert_equal(environment_value, value)
 end
@@ -336,7 +336,7 @@ end
 # @step_input field_path [String] The payload element to test
 # @step_input int_value [Integer] The value to compare against
 Then('the payload field {string} is greater than {int}') do |field_path, int_value|
-  value = read_key_path(Server.errors.current[:body], field_path)
+  value = read_key_path(Maze::Server.errors.current[:body], field_path)
   assert_kind_of Integer, value
   assert(value > int_value, "The payload field '#{field_path}' is not greater than '#{int_value}'")
 end
@@ -346,7 +346,7 @@ end
 # @step_input field_path [String] The payload element to test
 # @step_input int_value [Integer] The value to compare against
 Then('the payload field {string} is less than {int}') do |field_path, int_value|
-  value = read_key_path(Server.errors.current[:body], field_path)
+  value = read_key_path(Maze::Server.errors.current[:body], field_path)
   assert_kind_of Integer, value
   assert(value < int_value, "The payload field '#{field_path}' is not less than '#{int_value}'")
 end
@@ -356,7 +356,7 @@ end
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
 Then('the payload field {string} equals {string}') do |field_path, string_value|
-  assert_equal(string_value, read_key_path(Server.errors.current[:body], field_path))
+  assert_equal(string_value, read_key_path(Maze::Server.errors.current[:body], field_path))
 end
 
 # Tests a payload field starts with a string.
@@ -364,7 +364,7 @@ end
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
 Then('the payload field {string} starts with {string}') do |field_path, string_value|
-  value = read_key_path(Server.errors.current[:body], field_path)
+  value = read_key_path(Maze::Server.errors.current[:body], field_path)
   assert_kind_of String, value
   assert(value.start_with?(string_value),
          "Field '#{field_path}' value ('#{value}') does not start with '#{string_value}'")
@@ -375,7 +375,7 @@ end
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
 Then('the payload field {string} ends with {string}') do |field_path, string_value|
-  value = read_key_path(Server.errors.current[:body], field_path)
+  value = read_key_path(Maze::Server.errors.current[:body], field_path)
   assert_kind_of String, value
   assert(value.end_with?(string_value),
          "Field '#{field_path}' does not end with '#{string_value}'")
@@ -386,7 +386,7 @@ end
 # @step_input field [String] The payload element to test
 # @step_input count [Integer] The value expected
 Then('the payload field {string} is an array with {int} elements') do |field, count|
-  value = read_key_path(Server.errors.current[:body], field)
+  value = read_key_path(Maze::Server.errors.current[:body], field)
   assert_kind_of Array, value
   assert_equal(count, value.length)
 end
@@ -395,7 +395,7 @@ end
 #
 # @step_input field [String] The payload element to test
 Then('the payload field {string} is a non-empty array') do |field|
-  value = read_key_path(Server.errors.current[:body], field)
+  value = read_key_path(Maze::Server.errors.current[:body], field)
   assert_kind_of Array, value
   assert(value.length > 0,
          "the field '#{field}' must be a non-empty array")
@@ -407,7 +407,7 @@ end
 # @step_input regex [String] The regex to test against
 Then('the payload field {string} matches the regex {string}') do |field, regex_string|
   regex = Regexp.new(regex_string)
-  value = read_key_path(Server.errors.current[:body], field)
+  value = read_key_path(Maze::Server.errors.current[:body], field)
   assert_match(regex, value)
 end
 
@@ -415,7 +415,7 @@ end
 #
 # @step_input field [String] The payload element to test
 Then('the payload field {string} is a parsable timestamp in seconds') do |field|
-  value = read_key_path(Server.errors.current[:body], field)
+  value = read_key_path(Maze::Server.errors.current[:body], field)
   begin
     int = value.to_i
     parsed_time = Time.at(int)
@@ -430,7 +430,7 @@ end
 # @step_input key_path [String] The path to the tested array
 # @step_input element_key_path [String] The key for the expected element inside the array
 Then('each element in payload field {string} has {string}') do |key_path, element_key_path|
-  value = read_key_path(Server.errors.current[:body], key_path)
+  value = read_key_path(Maze::Server.errors.current[:body], key_path)
   assert_kind_of Array, value
   value.each do |element|
     assert_not_nil(read_key_path(element, element_key_path),

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -199,14 +199,14 @@ end
 # @step_input parameter_name [String] The parameter to test
 # @step_input parameter_value [String] The expected value
 Then('the session {string} query parameter equals {string}') do |parameter_name, parameter_value|
-  assert_equal(parameter_value, parse_querystring(Maze::Server.sesisons.current)[parameter_name][0])
+  assert_equal(parameter_value, parse_querystring(Maze::Server.sessions.current)[parameter_name][0])
 end
 
 # Tests that a query parameter on a session request is present and not null.
 #
 # @step_input parameter_name [String] The parameter to test
 Then('the session {string} query parameter is not null') do |parameter_name|
-  assert_not_nil(parse_querystring(Maze::Server.errors.current)[parameter_name][0],
+  assert_not_nil(parse_querystring(Maze::Server.sessions.current)[parameter_name][0],
                  "The '#{parameter_name}' query parameter should not be null")
 end
 
@@ -214,6 +214,6 @@ end
 #
 # @step_input parameter_name [String] The parameter to test
 Then('the session {string} query parameter is a timestamp') do |parameter_name|
-  param = parse_querystring(Maze::Server.errors.current)[parameter_name][0]
+  param = parse_querystring(Maze::Server.sessions.current)[parameter_name][0]
   assert_match(TIMESTAMP_REGEX, param)
 end

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -101,7 +101,7 @@ end
 
 # Tests that a payload has an appropriately structured session array
 Then("the session payload has a valid sessions array") do
-  if sessions = Server.sessions.current[:body]["sessions"]
+  if sessions = Maze::Server.sessions.current[:body]["sessions"]
     steps %Q{
       Then the session "id" is not null
       And the session "startedAt" is a timestamp
@@ -118,21 +118,21 @@ end
 #
 # @step_input field_path [String] Path to the tested element
 Then('the session payload field {string} is true') do |field_path|
-  assert_equal(true, read_key_path(Server.sessions.current[:body], field_path))
+  assert_equal(true, read_key_path(Maze::Server.sessions.current[:body], field_path))
 end
 
 # Tests that a session payload element is false.
 #
 # @step_input field_path [String] Path to the tested element
 Then('the session payload field {string} is false') do |field_path|
-  assert_equal(false, read_key_path(Server.sessions.current[:body], field_path))
+  assert_equal(false, read_key_path(Maze::Server.sessions.current[:body], field_path))
 end
 
 # Tests that a payload element is null.
 #
 # @step_input field_path [String] Path to the tested element
 Then('the session payload field {string} is null') do |field_path|
-  value = read_key_path(Server.sessions.current[:body], field_path)
+  value = read_key_path(Maze::Server.sessions.current[:body], field_path)
   assert_nil(value, "The field '#{field_path}' should be null but is #{value}")
 end
 
@@ -140,7 +140,7 @@ end
 #
 # @step_input field_path [String] Path to the tested element
 Then('the session payload field {string} is not null') do |field_path|
-  assert_not_nil(read_key_path(Server.sessions.current[:body], field_path),
+  assert_not_nil(read_key_path(Maze::Server.sessions.current[:body], field_path),
                  "The field '#{field_path}' should not be null")
 end
 
@@ -149,7 +149,7 @@ end
 # @step_input field_path [String] Path to the tested element
 # @step_input int_value [Integer] The value to test against
 Then('the session payload field {string} equals {int}') do |field_path, int_value|
-  assert_equal(int_value, read_key_path(Server.sessions.current[:body], field_path))
+  assert_equal(int_value, read_key_path(Maze::Server.sessions.current[:body], field_path))
 end
 
 # Tests a session payload field equals a string.
@@ -157,7 +157,7 @@ end
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
 Then('the session payload field {string} equals {string}') do |field_path, string_value|
-  assert_equal(string_value, read_key_path(Server.sessions.current[:body], field_path))
+  assert_equal(string_value, read_key_path(Maze::Server.sessions.current[:body], field_path))
 end
 
 # Tests a session payload field matches a regex.
@@ -166,7 +166,7 @@ end
 # @step_input regex [String] The regex to test against
 Then('the session payload field {string} matches the regex {string}') do |field, regex_string|
   regex = Regexp.new(regex_string)
-  value = read_key_path(Server.sessions.current[:body], field)
+  value = read_key_path(Maze::Server.sessions.current[:body], field)
   assert_match(regex, value)
 end
 
@@ -175,7 +175,7 @@ end
 # @step_input field [String] The payload element to test
 # @step_input count [Integer] The value expected
 Then('the session payload field {string} is an array with {int} elements') do |field, count|
-  value = read_key_path(Server.sessions.current[:body], field)
+  value = read_key_path(Maze::Server.sessions.current[:body], field)
   assert_kind_of Array, value
   assert_equal(count, value.length)
 end
@@ -184,7 +184,7 @@ end
 #
 # @step_input field [String] The payload element to test
 Then('the session payload field {string} is a parsable timestamp in seconds') do |field|
-  value = read_key_path(Server.sessions.current[:body], field)
+  value = read_key_path(Maze::Server.sessions.current[:body], field)
   begin
     int = value.to_i
     parsed_time = Time.at(int)

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -193,3 +193,27 @@ Then('the session payload field {string} is a parsable timestamp in seconds') do
   end
   assert_not_nil(parsed_time)
 end
+
+# Tests that a query parameter on a session request matches a string.
+#
+# @step_input parameter_name [String] The parameter to test
+# @step_input parameter_value [String] The expected value
+Then('the session {string} query parameter equals {string}') do |parameter_name, parameter_value|
+  assert_equal(parameter_value, parse_querystring(Maze::Server.sesisons.current)[parameter_name][0])
+end
+
+# Tests that a query parameter on a session request is present and not null.
+#
+# @step_input parameter_name [String] The parameter to test
+Then('the session {string} query parameter is not null') do |parameter_name|
+  assert_not_nil(parse_querystring(Maze::Server.errors.current)[parameter_name][0],
+                 "The '#{parameter_name}' query parameter should not be null")
+end
+
+# Tests that a query parameter on a session request is a timestamp.
+#
+# @step_input parameter_name [String] The parameter to test
+Then('the session {string} query parameter is a timestamp') do |parameter_name|
+  param = parse_querystring(Maze::Server.errors.current)[parameter_name][0]
+  assert_match(TIMESTAMP_REGEX, param)
+end

--- a/lib/features/steps/value_steps.rb
+++ b/lib/features/steps/value_steps.rb
@@ -11,7 +11,7 @@ require 'date'
 # @step_input field [String] The payload field to store
 # @step_input key [String] The key to store the value against
 Then('the payload field {string} is stored as the value {string}') do |field, key|
-  value = read_key_path(Server.errors.current[:body], field)
+  value = read_key_path(Maze::Server.errors.current[:body], field)
   Store.values[key] = value.dup
 end
 
@@ -20,7 +20,7 @@ end
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
 Then('the payload field {string} equals the stored value {string}') do |field, key|
-  payload_value = read_key_path(Server.errors.current[:body], field)
+  payload_value = read_key_path(Maze::Server.errors.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)
   assert_true(result.equal?, "Payload value: #{payload_value} does not equal stored value: #{stored_value}")
@@ -31,7 +31,7 @@ end
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
 Then('the payload field {string} does not equal the stored value {string}') do |field, key|
-  payload_value = read_key_path(Server.errors.current[:body], field)
+  payload_value = read_key_path(Maze::Server.errors.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)
   assert_false(result.equal?, "Payload value: #{payload_value} equals stored value: #{stored_value}")
@@ -41,7 +41,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the payload field {string} is a number') do |field|
-  value = read_key_path(Server.errors.current[:body], field)
+  value = read_key_path(Maze::Server.errors.current[:body], field)
   assert_kind_of Numeric, value
 end
 
@@ -49,7 +49,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the payload field {string} is an integer') do |field|
-  value = read_key_path(Server.errors.current[:body], field)
+  value = read_key_path(Maze::Server.errors.current[:body], field)
   assert_kind_of Integer, value
 end
 
@@ -57,7 +57,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the payload field {string} is a date') do |field|
-  value = read_key_path(Server.errors.current[:body], field)
+  value = read_key_path(Maze::Server.errors.current[:body], field)
   date = begin
            Date.parse(value)
          rescue StandardError
@@ -70,7 +70,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the payload field {string} is a UUID') do |field|
-  value = read_key_path(Server.errors.current[:body], field)
+  value = read_key_path(Maze::Server.errors.current[:body], field)
   assert_not_nil(value, "Expected UUID, got nil for #{field}")
   match = /[a-fA-F0-9-]{36}/.match(value).size > 0
   assert_true(match, "Field #{field} is not a UUID, received #{value}")
@@ -85,7 +85,7 @@ end
 # @step_input field [String] The session payload field to store
 # @step_input key [String] The key to store the value against
 Then('the session payload field {string} is stored as the value {string}') do |field, key|
-  value = read_key_path(Server.sessions.current[:body], field)
+  value = read_key_path(Maze::Server.sessions.current[:body], field)
   Store.values[key] = value.dup
 end
 
@@ -94,7 +94,7 @@ end
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
 Then('the session payload field {string} equals the stored value {string}') do |field, key|
-  payload_value = read_key_path(Server.sessions.current[:body], field)
+  payload_value = read_key_path(Maze::Server.sessions.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)
   assert_true(result.equal?, "Payload value: #{payload_value} does not equal stored value: #{stored_value}")
@@ -105,7 +105,7 @@ end
 # @step_input field [String] The session payload field to test
 # @step_input key [String] The key indicating a previously stored value
 Then('the session payload field {string} does not equal the stored value {string}') do |field, key|
-  payload_value = read_key_path(Server.sessions.current[:body], field)
+  payload_value = read_key_path(Maze::Server.sessions.current[:body], field)
   stored_value = Store.values[key]
   result = value_compare(payload_value, stored_value)
   assert_false(result.equal?, "Payload value: #{payload_value} equals stored value: #{stored_value}")
@@ -115,7 +115,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the session payload field {string} is a number') do |field|
-  value = read_key_path(Server.sessions.current[:body], field)
+  value = read_key_path(Maze::Server.sessions.current[:body], field)
   assert_kind_of Numeric, value
 end
 
@@ -123,7 +123,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the session payload field {string} is an integer') do |field|
-  value = read_key_path(Server.sessions.current[:body], field)
+  value = read_key_path(Maze::Server.sessions.current[:body], field)
   assert_kind_of Integer, value
 end
 
@@ -131,7 +131,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the session payload field {string} is a date') do |field|
-  value = read_key_path(Server.sessions.current[:body], field)
+  value = read_key_path(Maze::Server.sessions.current[:body], field)
   date = begin
            Date.parse(value)
          rescue StandardError
@@ -144,7 +144,7 @@ end
 #
 # @step_input field [String] The payload field to test
 Then('the session payload field {string} is a UUID') do |field|
-  value = read_key_path(Server.sessions.current[:body], field)
+  value = read_key_path(Maze::Server.sessions.current[:body], field)
   assert_not_nil(value, "Expected UUID, got nil for #{field}")
   match = /[a-fA-F0-9-]{36}/.match(value).size > 0
   assert_true(match, "Field #{field} is not a UUID, received #{value}")

--- a/lib/features/support/appium_driver.rb
+++ b/lib/features/support/appium_driver.rb
@@ -42,7 +42,7 @@ class AppiumDriver < Appium::Driver
     $logger.info "    build   : #{name_capabilities[:build]}"
   end
 
-  # Starts the BrowserStackLocal tunnel and the Appium driver
+  # Starts the Appium driver
   def start_driver
     $logger.info 'Starting Appium driver...'
     time = Time.now

--- a/lib/features/support/capabilities/browsers.yml
+++ b/lib/features/support/capabilities/browsers.yml
@@ -1,0 +1,107 @@
+# Selenium capabilities for browsers available on BrowserStack
+---
+ie_8:
+  browser: "ie"
+  browser_version: "8"
+  os: "windows"
+  os_version: "7"
+
+ie_9:
+  browser: "ie"
+  browser_version: "9"
+  os: "windows"
+  os_version: "7"
+
+ie_10:
+  browser: "ie"
+  browser_version: "10"
+  os: "windows"
+  os_version: "8"
+
+ie_11:
+  browser: "ie"
+  browser_version: "11"
+  os: "windows"
+  os_version: "10"
+
+edge_14:
+  browser: "edge"
+  browser_version: "14"
+  os: "windows"
+  os_version: "10"
+
+edge_15:
+  browser: "edge"
+  browser_version: "15"
+  os: "windows"
+  os_version: "10"
+
+safari_6:
+  browser: "safari"
+  browser_version: "6"
+  os: "OS X"
+  os_version: "lion"
+
+safari_10:
+  browser: "safari"
+  browser_version: "10.0"
+  os: "OS X"
+  os_version: "sierra"
+
+safari_13:
+  browser: "Safari"
+  browser_version: "13.0"
+  os: "OS X"
+  os_version: "Catalina"
+
+iphone_7:
+  browser: "iphone"
+  device: "iPhone 7"
+  os: "ios"
+  os_version: "10.3"
+  realMobile: true
+
+android_s8:
+  browser: "Android Browser"
+  device: "Samsung Galaxy S8 Plus"
+  os: "android"
+  os_version: "7.0"
+  realMobile: true
+
+firefox_30:
+  browser: "firefox"
+  browser_version: "30"
+  os: "windows"
+  os_version: "7"
+
+firefox_56:
+  browser: "firefox"
+  browser_version: "56"
+  os: "windows"
+  os_version: "10"
+
+firefox_latest:
+  browser: "firefox"
+  browser_version: "latest"
+  os: "windows"
+  os_version: "10"
+  selenium_version: "3.10.0"
+
+chrome_43:
+  browser: "chrome"
+  browser_version: "43.0"
+  os: "windows"
+  os_version: "7"
+
+chrome_61:
+  browser: "chrome"
+  browser_version: "61.0"
+  os: "windows"
+  os_version: "10"
+
+chrome_latest:
+  browser: "chrome"
+  browser_version: "latest"
+  os: "windows"
+  os_version: "10"
+  selenium_version: "3.14.0"

--- a/lib/features/support/capabilities/capabilities.rb
+++ b/lib/features/support/capabilities/capabilities.rb
@@ -6,7 +6,7 @@ class Capabilities
     # @param device_type [String] A key from @see Devices::DEVICE_HASH
     # @param local_id [String] unique key for the tunnel instance
     # @param capabilities_option [String] extra capabilities provided on the command line
-    def for_browser_stack(device_type, local_id, appium_version, capabilities_option)
+    def for_browser_stack_device(device_type, local_id, appium_version, capabilities_option)
       capabilities = {
         'browserstack.console' => 'errors',
         'browserstack.localIdentifier' => local_id,
@@ -16,6 +16,19 @@ class Capabilities
       capabilities.merge! Devices::DEVICE_HASH[device_type]
       capabilities.merge! JSON.parse(capabilities_option)
       capabilities['browserstack.appium_version'] = appium_version unless appium_version.nil?
+      capabilities
+    end
+
+    # @param browser_type [String] A key from @see browsers.yml
+    # @param local_id [String] unique key for the tunnel instance
+    # @param capabilities_option [String] extra capabilities provided on the command line
+    def for_browser_stack_browser(browser_type, local_id, capabilities_option)
+      capabilities = Selenium::WebDriver::Remote::Capabilities.new
+      capabilities['browserstack.local'] = 'true'
+      capabilities['browserstack.localIdentifier'] = bs_local_id
+      capabilities['browserstack.console'] = 'errors'
+      browsers = YAML.safe_load(File.read("#{__dir__}browsers.yml"))
+      capabilities.merge! browsers[browser_type]
       capabilities
     end
 

--- a/lib/features/support/capabilities/capabilities.rb
+++ b/lib/features/support/capabilities/capabilities.rb
@@ -25,9 +25,9 @@ class Capabilities
     def for_browser_stack_browser(browser_type, local_id, capabilities_option)
       capabilities = Selenium::WebDriver::Remote::Capabilities.new
       capabilities['browserstack.local'] = 'true'
-      capabilities['browserstack.localIdentifier'] = bs_local_id
+      capabilities['browserstack.localIdentifier'] = local_id
       capabilities['browserstack.console'] = 'errors'
-      browsers = YAML.safe_load(File.read("#{__dir__}browsers.yml"))
+      browsers = YAML.safe_load(File.read("#{__dir__}/browsers.yml"))
       capabilities.merge! browsers[browser_type]
       capabilities
     end

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -67,6 +67,9 @@ module Maze
     # BrowserStack device type
     attr_accessor :bs_device
 
+    # BrowserStack browser type
+    attr_accessor :bs_browser
+
     # Appium version to use on BrowserStack
     attr_accessor :appium_version
 

--- a/lib/features/support/selenium_driver.rb
+++ b/lib/features/support/selenium_driver.rb
@@ -28,7 +28,7 @@ class SeleniumDriver
   # does not have working local storage
   def local_storage?
     # Assume we can use local storage if we aren't able to verify by running JavaScript
-    return true unless can_run_javascript
+    return true unless MazeRunner.driver.javascript?
 
     @driver.execute_script <<-JAVASCRIPT
   try {

--- a/lib/features/support/selenium_driver.rb
+++ b/lib/features/support/selenium_driver.rb
@@ -8,7 +8,7 @@ class SeleniumDriver
                                       desired_capabilities: capabilities
   end
 
-  def nevigate
+  def navigate
     @driver.navigate
   end
 

--- a/lib/features/support/selenium_driver.rb
+++ b/lib/features/support/selenium_driver.rb
@@ -8,6 +8,10 @@ class SeleniumDriver
                                       desired_capabilities: capabilities
   end
 
+  def find_element(*args)
+    @driver.find_element *args
+  end
+
   def navigate
     @driver.navigate
   end

--- a/lib/features/support/selenium_driver.rb
+++ b/lib/features/support/selenium_driver.rb
@@ -32,7 +32,7 @@ class SeleniumDriver
   # does not have working local storage
   def local_storage?
     # Assume we can use local storage if we aren't able to verify by running JavaScript
-    return true unless MazeRunner.driver.javascript?
+    return true unless javascript?
 
     @driver.execute_script <<-JAVASCRIPT
   try {

--- a/lib/features/support/selenium_driver.rb
+++ b/lib/features/support/selenium_driver.rb
@@ -1,0 +1,44 @@
+require 'selenium-webdriver'
+
+# Handles browser automation fundamentals
+class SeleniumDriver
+  def initialize(selenium_url, capabilities)
+    @driver = Selenium::WebDriver.for :remote,
+                                      url: selenium_url,
+                                      desired_capabilities: capabilities
+  end
+
+  def nevigate
+    @driver.navigate
+  end
+
+  # Quits the driver
+  def driver_quit
+    @driver.quit
+  end
+
+  # check if Selenium supports running javascript in the current browser
+  def javascript?
+    @driver.execute_script('return true')
+  rescue Selenium::WebDriver::Error::UnsupportedOperationError
+    false
+  end
+
+  # check if the browser supports local storage, e.g. safari 10 on browserstack
+  # does not have working local storage
+  def local_storage?
+    # Assume we can use local storage if we aren't able to verify by running JavaScript
+    return true unless can_run_javascript
+
+    @driver.execute_script <<-JAVASCRIPT
+  try {
+    window.localStorage.setItem('__localstorage_test__', 1234)
+    window.localStorage.removeItem('__localstorage_test__')
+
+    return true
+  } catch (err) {
+    return false
+  }
+    JAVASCRIPT
+  end
+end

--- a/lib/features/support/server.rb
+++ b/lib/features/support/server.rb
@@ -8,104 +8,106 @@ require_relative './request_list'
 require_relative '../../version'
 
 # Receives and stores requests through a WEBrick HTTPServer
-class Server
+module Maze
+  class Server
 
-  # There are some constraints on the port from driving remote browsers on BrowserStack.
-  # E.g. the ports/ranges that Safari will access on "localhost" urls are restricted to the following:
-  #   80, 3000, 4000, 5000, 8000, 8080 or 9000-9999 [ from https://stackoverflow.com/a/28678652 ]
-  PORT = 9339
+    # There are some constraints on the port from driving remote browsers on BrowserStack.
+    # E.g. the ports/ranges that Safari will access on "localhost" urls are restricted to the following:
+    #   80, 3000, 4000, 5000, 8000, 8080 or 9000-9999 [ from https://stackoverflow.com/a/28678652 ]
+    PORT = 9339
 
-  class << self
-    # Allows overwriting of the server status code
-    attr_writer :status_code
+    class << self
+      # Allows overwriting of the server status code
+      attr_writer :status_code
 
-    # Dictates if the status code should be reset after used
-    attr_writer :reset_status_code
+      # Dictates if the status code should be reset after used
+      attr_writer :reset_status_code
 
-    # The intended HTTP status code on a successful request
-    #
-    # @return [Integer] The HTTP status code, defaults to 200
-    def status_code
-      code = @status_code ||= 200
-      @status_code = 200 if reset_status_code
-      code
-    end
-
-    def reset_status_code
-      @reset_status_code ||= false
-    end
-
-    # A list of error requests received
-    #
-    # @return [RequestList] Received error requests
-    def errors
-      @errors ||= RequestList.new
-    end
-
-    # A list of session requests received
-    #
-    # @return [RequestList] Received error requests
-    def sessions
-      @sessions ||= RequestList.new
-    end
-
-    # Whether the server thread is running
-    # An array of any invalid requests received.
-    # Each request is hash consisting of:
-    #   request: The original HTTPRequest object
-    #   reason: Reason for being considered invalid. Examples include invalid JSON and missing/invalid digest.
-    # @return [Array] An array of received requests
-    def invalid_requests
-      @invalid_requests ||= []
-    end
-
-    # Whether the server thread is running
-    #
-    # @return [Boolean] If the server is running
-    def running?
-      @thread&.alive?
-    end
-
-    # Starts the WEBrick server in a separate thread
-    def start
-      attempts = 0
-      $logger.info "Maze Runner v#{Maze::VERSION}"
-      $logger.info 'Starting mock server'
-      loop do
-        @thread = Thread.new do
-          server = WEBrick::HTTPServer.new(
-            Port: PORT,
-            Logger: $logger,
-            AccessLog: []
-          )
-          # When adding more endpoints, be sure to update the 'I should receive no requests' step
-          server.mount '/notify', Servlet, errors
-          server.mount '/sessions', Servlet, sessions
-          server.start
-        rescue StandardError => e
-          $logger.warn "Failed to start mock server: #{e.message}"
-        ensure
-          server&.shutdown
-        end
-
-        # Need a short sleep here as a dying thread is still alive momentarily
-        sleep 1
-        break if running?
-
-        # Bail out after 3 attempts
-        attempts += 1
-        raise 'Too many failed attempts to start mock server' if attempts == 3
-
-        # Failed to start - sleep before retrying
-        $logger.info 'Retrying in 5 seconds'
-        sleep 5
+      # The intended HTTP status code on a successful request
+      #
+      # @return [Integer] The HTTP status code, defaults to 200
+      def status_code
+        code = @status_code ||= 200
+        @status_code = 200 if reset_status_code
+        code
       end
-    end
 
-    # Stops the WEBrick server thread if it's running
-    def stop
-      @thread&.kill if @thread&.alive?
-      @thread = nil
+      def reset_status_code
+        @reset_status_code ||= false
+      end
+
+      # A list of error requests received
+      #
+      # @return [RequestList] Received error requests
+      def errors
+        @errors ||= RequestList.new
+      end
+
+      # A list of session requests received
+      #
+      # @return [RequestList] Received error requests
+      def sessions
+        @sessions ||= RequestList.new
+      end
+
+      # Whether the server thread is running
+      # An array of any invalid requests received.
+      # Each request is hash consisting of:
+      #   request: The original HTTPRequest object
+      #   reason: Reason for being considered invalid. Examples include invalid JSON and missing/invalid digest.
+      # @return [Array] An array of received requests
+      def invalid_requests
+        @invalid_requests ||= []
+      end
+
+      # Whether the server thread is running
+      #
+      # @return [Boolean] If the server is running
+      def running?
+        @thread&.alive?
+      end
+
+      # Starts the WEBrick server in a separate thread
+      def start
+        attempts = 0
+        $logger.info "Maze Runner v#{Maze::VERSION}"
+        $logger.info 'Starting mock server'
+        loop do
+          @thread = Thread.new do
+            server = WEBrick::HTTPServer.new(
+              Port: PORT,
+              Logger: $logger,
+              AccessLog: []
+            )
+            # When adding more endpoints, be sure to update the 'I should receive no requests' step
+            server.mount '/notify', Servlet, errors
+            server.mount '/sessions', Servlet, sessions
+            server.start
+          rescue StandardError => e
+            $logger.warn "Failed to start mock server: #{e.message}"
+          ensure
+            server&.shutdown
+          end
+
+          # Need a short sleep here as a dying thread is still alive momentarily
+          sleep 1
+          break if running?
+
+          # Bail out after 3 attempts
+          attempts += 1
+          raise 'Too many failed attempts to start mock server' if attempts == 3
+
+          # Failed to start - sleep before retrying
+          $logger.info 'Retrying in 5 seconds'
+          sleep 5
+        end
+      end
+
+      # Stops the WEBrick server thread if it's running
+      def stop
+        @thread&.kill if @thread&.alive?
+        @thread = nil
+      end
     end
   end
 end

--- a/lib/features/support/servlet.rb
+++ b/lib/features/support/servlet.rb
@@ -1,139 +1,141 @@
 # frozen_string_literal: true
 
 # Receives and parses the requests and payloads sent from the test fixture
-class Servlet < WEBrick::HTTPServlet::AbstractServlet
-  # Constructor
-  #
-  # @param server [HTTPServer] WEBrick HTTPServer
-  # @param requests [RequestList] Request list to add to
-  def initialize(server, requests)
-    super server
-    @requests = requests
-  end
+module Maze
+  class Servlet < WEBrick::HTTPServlet::AbstractServlet
+    # Constructor
+    #
+    # @param server [HTTPServer] WEBrick HTTPServer
+    # @param requests [RequestList] Request list to add to
+    def initialize(server, requests)
+      super server
+      @requests = requests
+    end
 
-  # Logs an incoming GET WEBrick request.
-  #
-  # @param request [HTTPRequest] The incoming GET request
-  # @param _response [HTTPResponse] The response to return
-  def do_GET(request, _response)
-    log_request(request)
-  end
+    # Logs an incoming GET WEBrick request.
+    #
+    # @param request [HTTPRequest] The incoming GET request
+    # @param _response [HTTPResponse] The response to return
+    def do_GET(request, _response)
+      log_request(request)
+    end
 
-  # Logs and parses an incoming POST request.
-  # Parses `multipart/form-data` and `application/json` content-types.
-  # Parsed requests are added to the requests list.
-  #
-  # @param request [HTTPRequest] The incoming GET request
-  # @param response [HTTPResponse] The response to return
-  def do_POST(request, response)
-    log_request(request)
-    case request['Content-Type']
-    when %r{^multipart/form-data; boundary=([^;]+)}
-      boundary = WEBrick::HTTPUtils::dequote($1)
-      body = WEBrick::HTTPUtils.parse_form_data(request.body, boundary)
-      hash = {
-        body: body,
+    # Logs and parses an incoming POST request.
+    # Parses `multipart/form-data` and `application/json` content-types.
+    # Parsed requests are added to the requests list.
+    #
+    # @param request [HTTPRequest] The incoming GET request
+    # @param response [HTTPResponse] The response to return
+    def do_POST(request, response)
+      log_request(request)
+      case request['Content-Type']
+      when %r{^multipart/form-data; boundary=([^;]+)}
+        boundary = WEBrick::HTTPUtils::dequote($1)
+        body = WEBrick::HTTPUtils.parse_form_data(request.body, boundary)
+        hash = {
+          body: body,
+          request: request
+        }
+      else
+        # "content-type" is assumed to be JSON (which mimics the behaviour of
+        # the actual API). This supports browsers that can't set this header for
+        # cross-domain requests (IE8/9)
+        digests = check_digest request
+        hash = {
+          body: JSON.parse(request.body),
+          request: request,
+          digests: digests
+        }
+      end
+      @requests.add(hash)
+      response.header['Access-Control-Allow-Origin'] = '*'
+      response.status = Server.status_code
+    rescue JSON::ParserError => e
+      msg = "Unable to parse request as JSON: #{e.message}"
+      $logger.error msg
+      Server.invalid_requests << {
+        reason: msg,
         request: request
       }
-    else
-      # "content-type" is assumed to be JSON (which mimics the behaviour of
-      # the actual API). This supports browsers that can't set this header for
-      # cross-domain requests (IE8/9)
-      digests = check_digest request
-      hash = {
-        body: JSON.parse(request.body),
-        request: request,
-        digests: digests
+    rescue StandardError => e
+      $logger.error "Invalid request: #{e.message}"
+      Server.invalid_requests << {
+        reason: e.message,
+        request: request
       }
     end
-    @requests.add(hash)
-    response.header['Access-Control-Allow-Origin'] = '*'
-    response.status = Server.status_code
-  rescue JSON::ParserError => e
-    msg = "Unable to parse request as JSON: #{e.message}"
-    $logger.error msg
-    Server.invalid_requests << {
-      reason: msg,
-      request: request
-    }
-  rescue StandardError => e
-    $logger.error "Invalid request: #{e.message}"
-    Server.invalid_requests << {
-      reason: e.message,
-      request: request
-    }
-  end
 
-  # Logs and returns a set of valid headers for this servlet.
-  #
-  # @param request [HTTPRequest] The incoming GET request
-  # @param response [HTTPResponse] The response to return
-  def do_OPTIONS(request, response)
-    log_request(request)
-    response.header['Access-Control-Allow-Origin'] = '*'
-    response.header['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
-    response.header['Access-Control-Allow-Headers'] = %w[Accept
-                                                         Bugsnag-Api-Key Bugsnag-Integrity
-                                                         Bugsnag-Payload-Version
-                                                         Bugsnag-Sent-At Content-Type
-                                                         Origin].join(',')
+    # Logs and returns a set of valid headers for this servlet.
+    #
+    # @param request [HTTPRequest] The incoming GET request
+    # @param response [HTTPResponse] The response to return
+    def do_OPTIONS(request, response)
+      log_request(request)
+      response.header['Access-Control-Allow-Origin'] = '*'
+      response.header['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
+      response.header['Access-Control-Allow-Headers'] = %w[Accept
+                                                           Bugsnag-Api-Key Bugsnag-Integrity
+                                                           Bugsnag-Payload-Version
+                                                           Bugsnag-Sent-At Content-Type
+                                                           Origin].join(',')
 
-    response.status = Server.status_code
-  end
-
-  private
-
-  def log_request(request)
-    $logger.debug "#{request.request_method} request received"
-    $logger.debug "URI: #{request.unparsed_uri}"
-    $logger.debug "HEADERS: #{request.raw_header}"
-    return if request.body.nil?
-
-    case request['Content-Type']
-    when nil
-      nil
-    when %r{^multipart/form-data; boundary=([^;]+)}
-      boundary = WEBrick::HTTPUtils.dequote(Regexp.last_match(1))
-      body = WEBrick::HTTPUtils.parse_form_data(request.body, boundary)
-      $logger.debug 'BODY:'
-      LogUtil.log_hash(Logger::Severity::DEBUG, body)
-    else
-      $logger.debug "BODY: #{JSON.pretty_generate(JSON.parse(request.body))}"
-    end
-  end
-
-  # Checks the Bugsnag-Integrity header, if present, against the request and based on configuration.
-  # If the header is present, if the digest must be correct.  However, the header need only be present
-  # if configuration says so.
-  def check_digest(request)
-    header = request['Bugsnag-Integrity']
-    if header.nil? && MazeRunner.config.enforce_bugsnag_integrity
-      raise 'Bugsnag-Integrity header must be present according to MazeRunner.config.enforce_bugsnag_integrity'
-    end
-    return if header.nil?
-
-    # Header must have type and digest
-    parts = header.split ' '
-    raise "Invalid Bugsnag-Integrity header: #{header}" unless parts.size == 2
-
-    # Both digest types are stored whatever
-    sha1 = Digest::SHA1.hexdigest(request.body)
-    simple = request.body.bytesize
-    $logger.debug "DIGESTS computed: sha1=#{sha1} simple=#{simple}"
-
-    # Check digests match
-    case parts[0]
-    when 'sha1'
-      raise "Given sha1 #{parts[1]} does not match the computed #{sha1}" unless parts[1] == sha1
-    when 'simple'
-      raise "Given simple digest #{parts[1].inspect} does not match the computed #{simple.inspect}" unless parts[1].to_i == simple
-    else
-      raise "Invalid Bugsnag-Integrity digest type: #{parts[0]}"
+      response.status = Server.status_code
     end
 
-    {
-      sha1: sha1,
-      simple: simple
-    }
+    private
+
+    def log_request(request)
+      $logger.debug "#{request.request_method} request received"
+      $logger.debug "URI: #{request.unparsed_uri}"
+      $logger.debug "HEADERS: #{request.raw_header}"
+      return if request.body.nil?
+
+      case request['Content-Type']
+      when nil
+        nil
+      when %r{^multipart/form-data; boundary=([^;]+)}
+        boundary = WEBrick::HTTPUtils.dequote(Regexp.last_match(1))
+        body = WEBrick::HTTPUtils.parse_form_data(request.body, boundary)
+        $logger.debug 'BODY:'
+        LogUtil.log_hash(Logger::Severity::DEBUG, body)
+      else
+        $logger.debug "BODY: #{JSON.pretty_generate(JSON.parse(request.body))}"
+      end
+    end
+
+    # Checks the Bugsnag-Integrity header, if present, against the request and based on configuration.
+    # If the header is present, if the digest must be correct.  However, the header need only be present
+    # if configuration says so.
+    def check_digest(request)
+      header = request['Bugsnag-Integrity']
+      if header.nil? && MazeRunner.config.enforce_bugsnag_integrity
+        raise 'Bugsnag-Integrity header must be present according to MazeRunner.config.enforce_bugsnag_integrity'
+      end
+      return if header.nil?
+
+      # Header must have type and digest
+      parts = header.split ' '
+      raise "Invalid Bugsnag-Integrity header: #{header}" unless parts.size == 2
+
+      # Both digest types are stored whatever
+      sha1 = Digest::SHA1.hexdigest(request.body)
+      simple = request.body.bytesize
+      $logger.debug "DIGESTS computed: sha1=#{sha1} simple=#{simple}"
+
+      # Check digests match
+      case parts[0]
+      when 'sha1'
+        raise "Given sha1 #{parts[1]} does not match the computed #{sha1}" unless parts[1] == sha1
+      when 'simple'
+        raise "Given simple digest #{parts[1].inspect} does not match the computed #{simple.inspect}" unless parts[1].to_i == simple
+      else
+        raise "Invalid Bugsnag-Integrity digest type: #{parts[0]}"
+      end
+
+      {
+        sha1: sha1,
+        simple: simple
+      }
+    end
   end
 end

--- a/lib/options/option.rb
+++ b/lib/options/option.rb
@@ -14,6 +14,7 @@ module Maze
     # BrowserStack-only options
     BS_LOCAL = 'bs-local'
     BS_DEVICE = 'device'
+    BS_BROWSER = 'browser'
     USERNAME = 'username'
     ACCESS_KEY = 'access-key'
     BS_APPIUM_VERSION = 'appium-version'

--- a/lib/options/option_parser.rb
+++ b/lib/options/option_parser.rb
@@ -62,6 +62,10 @@ module Maze
               'BrowserStack device to use (a key of Devices.DEVICE_HASH)',
               short: :none,
               type: :string
+          opt Option::BS_BROWSER,
+              'BrowserStack browser to use (an entry in browsers.yml)',
+              short: :none,
+              type: :string
           opt Option::USERNAME,
               'Device farm username. MAZE_DEVICE_FARM_USERNAME env var by default',
               short: '-u',

--- a/lib/options/option_processor.rb
+++ b/lib/options/option_processor.rb
@@ -28,8 +28,12 @@ module Maze
         # Farm specific options
         case config.farm
         when :bs then
-          config.bs_device = options[Maze::Option::BS_DEVICE]
-          config.os_version = Devices::DEVICE_HASH[config.bs_device]['os_version'].to_f
+          if options[Maze::Option::BS_DEVICE]
+            config.bs_device = options[Maze::Option::BS_DEVICE]
+            config.os_version = Devices::DEVICE_HASH[config.bs_device]['os_version'].to_f
+          else
+            config.bs_browser = options[Maze::Option::BS_BROWSER]
+          end
           config.bs_local = options[Maze::Option::BS_LOCAL]
           config.appium_version = options[Maze::Option::BS_APPIUM_VERSION]
           username = config.username = options[Maze::Option::USERNAME]

--- a/lib/options/option_validator.rb
+++ b/lib/options/option_validator.rb
@@ -42,7 +42,7 @@ module Maze
       bs_device = options[Maze::Option::BS_DEVICE]
       if bs_browser.nil? && bs_device.nil?
         errors << "Either --#{Maze::Option::BS_BROWSER} or --#{Maze::Option::BS_DEVICE} must be specified"
-      elsif !bs_browser.nil?
+      elsif bs_browser
 
         browsers = YAML.safe_load(File.read("#{__dir__}/../features/support/capabilities/browsers.yml"))
 
@@ -50,7 +50,7 @@ module Maze
           browser_list = browsers.keys.join ', '
           errors << "Browser type '#{bs_browser}' unknown on BrowserStack.  Must be one of: #{browser_list}."
         end
-      elsif !bs_device.nil?
+      elsif bs_device
         unless Devices::DEVICE_HASH.key? bs_device
           errors << "Device type '#{bs_device}' unknown on BrowserStack.  Must be one of #{Devices::DEVICE_HASH.keys}"
         end

--- a/test/fixtures/comparison/features/steps/scripting_steps.rb
+++ b/test/fixtures/comparison/features/steps/scripting_steps.rb
@@ -7,6 +7,6 @@ When(/^I send an? "(.+)"-type request$/) do |request_type|
 end
 
 Then('the requests match the following:') do |data_table|
-  requests = Server.errors.all
+  requests = Maze::Server.errors.all
   RequestSetAssertions.assert_requests_match requests, data_table
 end

--- a/test/options/options_parser_test.rb
+++ b/test/options/options_parser_test.rb
@@ -30,6 +30,7 @@ class OptionsParserTest < Test::Unit::TestCase
     # BrowserStack-only options
     assert_equal('/BrowserStackLocal', options[Maze::Option::BS_LOCAL])
     assert_nil(options[Maze::Option::BS_DEVICE])
+    assert_nil(options[Maze::Option::BS_BROWSER])
     assert_nil(options[Maze::Option::USERNAME])
     assert_nil(options[Maze::Option::ACCESS_KEY])
     assert_nil(options[Maze::Option::BS_APPIUM_VERSION])
@@ -52,6 +53,7 @@ class OptionsParserTest < Test::Unit::TestCase
       --capabilities=ARG_CAPABILITIES
       --bs-local=ARG_BS_LOCAL
       --device=ARG_DEVICE
+      --browser=ARG_BROWSER
       --username=ARG_USERNAME
       --access-key=ARG_ACCESS_KEY
       --appium-version=ARG_APPIUM_VERSION
@@ -74,6 +76,7 @@ class OptionsParserTest < Test::Unit::TestCase
     # BrowserStack-only options
     assert_equal('ARG_BS_LOCAL', options[Maze::Option::BS_LOCAL])
     assert_equal('ARG_DEVICE', options[Maze::Option::BS_DEVICE])
+    assert_equal('ARG_BROWSER', options[Maze::Option::BS_BROWSER])
     assert_equal('ARG_USERNAME', options[Maze::Option::USERNAME])
     assert_equal('ARG_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])
     assert_equal('ARG_APPIUM_VERSION', options[Maze::Option::BS_APPIUM_VERSION])

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -6,105 +6,107 @@ require 'webrick'
 require_relative '../lib/features/support/server'
 
 # noinspection RubyNilAnalysis
-class ServerTest < Test::Unit::TestCase
+module Maze
+  class ServerTest < Test::Unit::TestCase
 
-  def setup
-    @logger_mock = mock('logger')
-    $logger = @logger_mock
-  end
+    def setup
+      @logger_mock = mock('logger')
+      $logger = @logger_mock
+    end
 
-  def test_start_cleanily
-    # Expected logging calls
-    @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
-    @logger_mock.expects(:info).with('Starting mock server')
+    def test_start_cleanily
+      # Expected logging calls
+      @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
+      @logger_mock.expects(:info).with('Starting mock server')
 
-    # Force synchronous execution
-    Thread.expects(:new).yields
+      # Force synchronous execution
+      Thread.expects(:new).yields
 
-    # Expected HTTP server calls
-    mock_http_server = mock('http')
-    mock_http_server.expects(:mount).twice
-    mock_http_server.expects(:start)
-    mock_http_server.expects(:shutdown)
+      # Expected HTTP server calls
+      mock_http_server = mock('http')
+      mock_http_server.expects(:mount).twice
+      mock_http_server.expects(:start)
+      mock_http_server.expects(:shutdown)
 
-    # Expected WEBrick instantiation
-    WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
-                                           Logger: @logger_mock,
-                                           AccessLog: []).returns(mock_http_server)
+      # Expected WEBrick instantiation
+      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+                                             Logger: @logger_mock,
+                                             AccessLog: []).returns(mock_http_server)
 
-    # End of first and only loop
-    Server.expects(:sleep).with(1)
-    Server.expects(:running?).returns(true)
+      # End of first and only loop
+      Server.expects(:sleep).with(1)
+      Server.expects(:running?).returns(true)
 
-    # Call the method
-    Server.start
-  end
-
-  def test_start_on_retry
-    # Expected logging calls
-    @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
-    @logger_mock.expects(:info).with('Starting mock server')
-    @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
-    @logger_mock.expects(:info).with('Retrying in 5 seconds')
-
-    # Force synchronous execution
-    Thread.expects(:new).yields.twice
-
-    # Fails to start first time
-    WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
-                                           Logger: @logger_mock,
-                                           AccessLog: []).throws('Failed to start')
-
-    # Successful the second
-    mock_http_server = mock('http')
-    mock_http_server.expects(:mount).twice
-    mock_http_server.expects(:start)
-    mock_http_server.expects(:shutdown)
-    WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
-                                           Logger: @logger_mock,
-                                           AccessLog: []).returns(mock_http_server)
-
-    # End of loop
-    Server.expects(:sleep).with(1).twice
-    Server.expects(:sleep).with(5)
-    Server.expects(:running?).twice.returns(false).then.returns(true)
-
-    # Call the method
-    Server.start
-  end
-
-  def test_start_fails
-    # Expected logging calls
-    @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
-    @logger_mock.expects(:info).with('Starting mock server')
-    @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
-    @logger_mock.expects(:info).with('Retrying in 5 seconds')
-    @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
-    @logger_mock.expects(:info).with('Retrying in 5 seconds')
-    @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
-
-    # Force synchronous execution
-    Thread.expects(:new).yields.times(3)
-
-    # Fails to start every time
-    WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
-                                           Logger: @logger_mock,
-                                           AccessLog: []).throws('Failed to start')
-    WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
-                                           Logger: @logger_mock,
-                                           AccessLog: []).throws('Failed to start')
-    WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
-                                           Logger: @logger_mock,
-                                           AccessLog: []).throws('Failed to start')
-
-    # End of loop
-    Server.expects(:sleep).with(1).times(3)
-    Server.expects(:sleep).with(5).twice
-    Server.expects(:running?).twice.returns(false).times(3)
-
-    # Call the method
-    assert_raise RuntimeError do
+      # Call the method
       Server.start
+    end
+
+    def test_start_on_retry
+      # Expected logging calls
+      @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
+      @logger_mock.expects(:info).with('Starting mock server')
+      @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
+      @logger_mock.expects(:info).with('Retrying in 5 seconds')
+
+      # Force synchronous execution
+      Thread.expects(:new).yields.twice
+
+      # Fails to start first time
+      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+                                             Logger: @logger_mock,
+                                             AccessLog: []).throws('Failed to start')
+
+      # Successful the second
+      mock_http_server = mock('http')
+      mock_http_server.expects(:mount).twice
+      mock_http_server.expects(:start)
+      mock_http_server.expects(:shutdown)
+      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+                                             Logger: @logger_mock,
+                                             AccessLog: []).returns(mock_http_server)
+
+      # End of loop
+      Server.expects(:sleep).with(1).twice
+      Server.expects(:sleep).with(5)
+      Server.expects(:running?).twice.returns(false).then.returns(true)
+
+      # Call the method
+      Server.start
+    end
+
+    def test_start_fails
+      # Expected logging calls
+      @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
+      @logger_mock.expects(:info).with('Starting mock server')
+      @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
+      @logger_mock.expects(:info).with('Retrying in 5 seconds')
+      @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
+      @logger_mock.expects(:info).with('Retrying in 5 seconds')
+      @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
+
+      # Force synchronous execution
+      Thread.expects(:new).yields.times(3)
+
+      # Fails to start every time
+      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+                                             Logger: @logger_mock,
+                                             AccessLog: []).throws('Failed to start')
+      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+                                             Logger: @logger_mock,
+                                             AccessLog: []).throws('Failed to start')
+      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+                                             Logger: @logger_mock,
+                                             AccessLog: []).throws('Failed to start')
+
+      # End of loop
+      Server.expects(:sleep).with(1).times(3)
+      Server.expects(:sleep).with(5).twice
+      Server.expects(:running?).twice.returns(false).times(3)
+
+      # Call the method
+      assert_raise RuntimeError do
+        Server.start
+      end
     end
   end
 end


### PR DESCRIPTION
## Goal

Updates the Cucumber steps in order that the JS-Browser tests will run against separate notify/sessions endpoints.  I've also taken the opportunity to add the Selenium web driver code, currently present in the bugsnag-js repo.

## Design

The changes here follow the existing patterns for both the separation of endpoints and addition of a new `--browser` option to the Maze Runner command line.

Due to the increased use of Maze Runner outside of Docker (and the increased chance of clashes in the default namespace), I have also moved classes into their the `Maze` namespace where appropriate.

## Changeset

- Addition of Selenium webdriver code currently present in bugsnag-js
- New `--browser` option
- Updated/added Cucumber steps to support the separation of endpoints.

## Tests

Largely covered by CI and having successfully developed the necessary changes to JS-Browser on a branch.  However, it would be a fair review comment to ask for at least one e2e test of the new Browser capability to be added.