### PR TITLE
Disable BrowserStack network logs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# 3.7.0 - TBD
+# 3.7.0 - 2021/01/05
 
 ## Enhancements
 
 - Display version at startup [#191](https://github.com/bugsnag/maze-runner/pull/191)
+- Disable BrowserStack network logs by default [#194](https://github.com/bugsnag/maze-runner/pull/194)
 
 # 3.6.1 - 2020/12/16
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (3.6.1)
+    bugsnag-maze-runner (3.7.0)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -68,19 +68,21 @@ GEM
       props (>= 1.1.2)
       textutils (>= 0.10.0)
     metaclass (0.0.4)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.2)
     mocha (1.8.0)
       metaclass (~> 0.0.1)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.0)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
     power_assert (1.2.0)
     props (1.2.0)
       iniparser (>= 0.1.0)
+    racc (1.5.2)
     rake (12.3.3)
     redcarpet (3.5.0)
     rexml (3.2.4)
@@ -88,7 +90,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    test-unit (3.3.7)
+    test-unit (3.3.9)
       power_assert
     textutils (1.4.0)
       activesupport

--- a/lib/features/support/capabilities/capabilities.rb
+++ b/lib/features/support/capabilities/capabilities.rb
@@ -10,8 +10,7 @@ class Capabilities
       capabilities = {
         'browserstack.console' => 'errors',
         'browserstack.localIdentifier' => local_id,
-        'browserstack.local' => 'true',
-        'browserstack.networkLogs' => 'true'
+        'browserstack.local' => 'true'
       }
       capabilities.merge! Devices::DEVICE_HASH[device_type]
       capabilities.merge! JSON.parse(capabilities_option)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Maze
-  VERSION = '3.6.1'.freeze
+  VERSION = '3.7.0'.freeze
 end


### PR DESCRIPTION
## Goal

Disables network logs on BrowserStack by default.

## Design

All of our Android tests on version 4,6 and 7 have been failing for the last 2 weeks and this appears to have been due to a fault in the BrowserStack infrastructure when network logs are enabled (which we have always had set).  As a short (and possibly longer) term workaround, I've opted to disable network logging on BrowserStack by default.  It's pretty rare that I look at them anyway and the `--capabilities` option can be used to enable them selectively as required.

## Changeset

Remove setting of BrowserStack network logs capability.

## Tests

CI now passes!