### PR TITLE
Correct link to BrowserStack dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.7.2 - 2021/01/07
+
+## Fixes
+
+- Fix broken link to BrowserStack dashboard [#196](https://github.com/bugsnag/maze-runner/pull/196)
+
 # 3.7.1 - 2021/01/06
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (3.7.1)
+    bugsnag-maze-runner (3.7.2)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -68,12 +68,14 @@ GEM
       props (>= 1.1.2)
       textutils (>= 0.10.0)
     metaclass (0.0.4)
+    mini_portile2 (2.5.0)
     minitest (5.14.2)
     mocha (1.8.0)
       metaclass (~> 0.0.1)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -53,7 +53,7 @@ AfterConfiguration do |_cucumber_config|
   if config.farm == :bs
     # Log a link to the BrowserStack session search dashboard
     build = MazeRunner.driver.caps[:build]
-    url = "https://app-automate.browserstack.com/dashboard/v2/?searchQuery=#{build}"
+    url = "https://app-automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"
     if ENV['BUILDKITE']
       $logger.info LogUtil.linkify url, 'BrowserStack session(s)'
     else

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Maze
-  VERSION = '3.7.1'.freeze
+  VERSION = '3.7.2'.freeze
 end


### PR DESCRIPTION
## Goal

Fix the broken link to the BrowserStack dashboard, which has just been updated.

## Tests

Can be seen working in the build for this PR:

![image](https://user-images.githubusercontent.com/5239394/103896364-c48b5600-50e9-11eb-96f3-90030662c8d8.png)
