### PR TITLE
Strip ansi escape codes from CLI stdout/stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.7.3 - 2021/01/08
+
+- Strip ANSI escape codes from interactive CLI output to improve reliability [#197](https://github.com/bugsnag/maze-runner/pull/197)
+
 # 3.7.2 - 2021/01/07
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (3.7.2)
+    bugsnag-maze-runner (3.7.3)
       appium_lib (~> 10.2)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     bugsnag-maze-runner (3.7.2)
       appium_lib (~> 10.2)
+      boring (~> 0.1.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
@@ -31,6 +32,7 @@ GEM
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.18.2)
+    boring (0.1.0)
     builder (3.2.4)
     childprocess (3.0.0)
     concurrent-ruby (1.1.7)

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'optimist', '~> 3.0.1'
   spec.add_dependency 'rake', '~> 12.3.3'
   spec.add_dependency 'selenium-webdriver', '~> 3.11'
+  spec.add_dependency 'boring', '~> 0.1.0'
 
   spec.add_development_dependency 'markdown', '~> 1.2'
   spec.add_development_dependency 'mocha', '~> 1.8.0'

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Maze
-  VERSION = '3.7.2'.freeze
+  VERSION = '3.7.3'.freeze
 end

--- a/test/fixtures/docker-app/features/fixtures/interactive/guessing-game
+++ b/test/fixtures/docker-app/features/fixtures/interactive/guessing-game
@@ -12,9 +12,9 @@ loop do
   guess.chomp!
 
   if guess.to_i == number
-    puts "Yeah, it's #{number}!"
+    puts "\e[0;32;1mYeah\e[0m, it's \e[0;1m#{number}\e[0m!"
     break
   end
 
-  puts "Nope, it's not #{guess}. Try again!"
+  puts "\e[0;31;1mNope\e[0m, it's not \e[0;1m#{guess}\e[0m. Try again!"
 end


### PR DESCRIPTION
## Goal

Strip ansi escape codes from CLI stdout/stderr, which seems to help reduce flakes in the RN CLI pipeline