### PR TITLE
Step corrections for separation of endpoints

### DIFF
--- a/lib/features/steps/browser_steps.rb
+++ b/lib/features/steps/browser_steps.rb
@@ -5,7 +5,7 @@ When('I navigate to the URL {string}') do |path|
   Maze.driver.navigate.to path
 end
 
-Then(/^the request is a valid browser payload for the error reporting API$/) do
+Then(/^the error is a valid browser payload for the error reporting API$/) do
   if !/^ie_(8|9|10)$/.match(Maze.config.bs_browser)
     steps %(
       Then the error "Bugsnag-API-Key" header is not null
@@ -37,7 +37,7 @@ Then(/^the request is a valid browser payload for the error reporting API$/) do
   )
 end
 
-Then('the request is a valid browser payload for the session tracking API') do
+Then('the session is a valid browser payload for the session tracking API') do
   if !/^ie_(8|9|10)$/.match(Maze.config.bs_browser)
     steps %(
       Then the session "Bugsnag-API-Key" header is not null

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -7,7 +7,7 @@
 #
 # @step_input version [String] The payload version expected
 # @step_input name [String] The expected name of the notifier
-Then('the request is valid for the error reporting API version {string} for the {string} notifier') do |version, name|
+Then('the error is valid for the error reporting API version {string} for the {string} notifier') do |version, name|
   steps %(
     Then the error "Bugsnag-Api-Key" header equals "#{$api_key}"
     And the error payload field "apiKey" equals "#{$api_key}"

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -8,25 +8,38 @@
 # @step_input version [String] The payload version expected
 # @step_input name [String] The expected name of the notifier
 Then('the error is valid for the error reporting API version {string} for the {string} notifier') do |version, name|
+  step "the error is valid for the error reporting API version \"#{version}\"" \
+       " for the \"#{name}\" notifier with the apiKey \"#{$api_key}\""
+end
+
+# Verifies that generic elements of an error payload are present.
+#
+# @step_input version [String] The payload version expected
+# @step_input name [String] The expected name of the notifier
+# @step_input api_key [String] The API key expected
+Then('the error is valid for the error reporting API version {string}' \
+     ' for the {string} notifier with the apiKey {string}') do |payload_version, notifier_name, api_key|
   steps %(
-    Then the error "Bugsnag-Api-Key" header equals "#{$api_key}"
-    And the error payload field "apiKey" equals "#{$api_key}"
-    And the error "Bugsnag-Payload-Version" header equals "#{version}"
-    And the error payload contains the payloadVersion "#{version}"
-    And the error "Content-Type" header equals "application/json"
-    And the error "Bugsnag-Sent-At" header is a timestamp
+    Then the "Bugsnag-Api-Key" header equals "#{api_key}"
+    And the payload field "apiKey" equals "#{api_key}"
+    And the "Bugsnag-Payload-Version" header equals "#{payload_version}"
+    And the payload contains the payloadVersion "#{payload_version}"
+    And the "Content-Type" header equals "application/json"
+    And the "Bugsnag-Sent-At" header is a timestamp
+    And the Bugsnag-Integrity header is valid
 
-    And the error payload field "notifier.name" equals "#{name}"
-    And the error payload field "notifier.url" is not null
-    And the error payload field "notifier.version" is not null
-    And the error payload field "events" is a non-empty array
+    And the payload field "notifier.name" equals "#{notifier_name}"
+    And the payload field "notifier.url" is not null
+    And the payload field "notifier.version" is not null
+    And the payload field "events" is a non-empty array
 
-    And each element in error payload field "events" has "severity"
-    And each element in error payload field "events" has "severityReason.type"
-    And each element in error payload field "events" has "unhandled"
-    And each element in error payload field "events" has "exceptions"
+    And each element in payload field "events" has "severity"
+    And each element in payload field "events" has "severityReason.type"
+    And each element in payload field "events" has "unhandled"
+    And each element in payload field "events" has "exceptions"
   )
 end
+
 
 # Verifies that an event is correct for an unhandled error
 # This checks various elements of the payload matching an unhandled error including:

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -20,23 +20,23 @@ end
 Then('the error is valid for the error reporting API version {string}' \
      ' for the {string} notifier with the apiKey {string}') do |payload_version, notifier_name, api_key|
   steps %(
-    Then the "Bugsnag-Api-Key" header equals "#{api_key}"
-    And the payload field "apiKey" equals "#{api_key}"
-    And the "Bugsnag-Payload-Version" header equals "#{payload_version}"
-    And the payload contains the payloadVersion "#{payload_version}"
-    And the "Content-Type" header equals "application/json"
-    And the "Bugsnag-Sent-At" header is a timestamp
+    Then the error "Bugsnag-Api-Key" header equals "#{api_key}"
+    And the error payload field "apiKey" equals "#{api_key}"
+    And the error "Bugsnag-Payload-Version" header equals "#{payload_version}"
+    And the error payload contains the payloadVersion "#{payload_version}"
+    And the error "Content-Type" header equals "application/json"
+    And the error "Bugsnag-Sent-At" header is a timestamp
     And the Bugsnag-Integrity header is valid
 
-    And the payload field "notifier.name" equals "#{notifier_name}"
-    And the payload field "notifier.url" is not null
-    And the payload field "notifier.version" is not null
-    And the payload field "events" is a non-empty array
+    And the error payload field "notifier.name" equals "#{notifier_name}"
+    And the error payload field "notifier.url" is not null
+    And the error payload field "notifier.version" is not null
+    And the error payload field "events" is a non-empty array
 
-    And each element in payload field "events" has "severity"
-    And each element in payload field "events" has "severityReason.type"
-    And each element in payload field "events" has "unhandled"
-    And each element in payload field "events" has "exceptions"
+    And each element in error payload field "events" has "severity"
+    And each element in error payload field "events" has "severityReason.type"
+    And each element in error payload field "events" has "unhandled"
+    And each element in error payload field "events" has "exceptions"
   )
 end
 
@@ -194,6 +194,7 @@ Then('the event {string} is greater than {int}') do |keypath, int|
   assert_false(value.nil?, "The event #{keypath} is nil")
   assert_true(value > int)
 end
+
 # Tests whether a value in the first exception of the first event entry starts with a string.
 #
 # @step_input field [String] The relative location of the value to test

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -26,7 +26,7 @@ Then('the error is valid for the error reporting API version {string}' \
     And the error payload contains the payloadVersion "#{payload_version}"
     And the error "Content-Type" header equals "application/json"
     And the error "Bugsnag-Sent-At" header is a timestamp
-    And the Bugsnag-Integrity header is valid
+    And the error Bugsnag-Integrity header is valid
 
     And the error payload field "notifier.name" equals "#{notifier_name}"
     And the error payload field "notifier.url" is not null

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -182,6 +182,18 @@ Then('the event {string} matches the JSON fixture in {string}') do |field, fixtu
   step "the error payload field \"events.0.#{field}\" matches the JSON fixture in \"#{fixture_path}\""
 end
 
+Then('the event {string} string is empty') do |keypath|
+  value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], keypath)
+  assert_block("The #{keypath} is not empty: '#{value}'") do
+    value.nil? || value.empty?
+  end
+end
+
+Then('the event {string} is greater than {int}') do |keypath, int|
+  value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{keypath}")
+  assert_false(value.nil?, "The event #{keypath} is nil")
+  assert_true(value > int)
+end
 # Tests whether a value in the first exception of the first event entry starts with a string.
 #
 # @step_input field [String] The relative location of the value to test

--- a/lib/features/steps/header_steps.rb
+++ b/lib/features/steps/header_steps.rb
@@ -53,8 +53,9 @@ end
 
 # Checks that the Bugsnag-Integrity header is a SHA1 or simple digest
 #
-When('the Bugsnag-Integrity header is valid') do
-  assert_true(Maze::Helper.valid_bugsnag_integrity_header(Maze::Server.errors.current),
+# @step_input request_type [String] The type of request (error, session, etc)
+When('the {word} Bugsnag-Integrity header is valid') do |request_type|
+  assert_true(Maze::Helper.valid_bugsnag_integrity_header(Maze::Server.list_for(request_type).current),
               'Invalid Bugsnag-Integrity header detected')
 end
 

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -32,13 +32,6 @@ def assert_received_requests(request_count, list, list_name)
   assert_equal(request_count, list.size, "#{list.size} #{list_name} received")
 end
 
-# Assert that the test Server hasn't received any requests at all.
-Then('I should receive no requests') do
-  sleep Maze.config.receive_no_requests_wait
-  assert_equal(0, Maze::Server.errors.size, "#{Maze::Server.errors.size} errors received")
-  assert_equal(0, Maze::Server.sessions.size, "#{Maze::Server.sessions.size} sessions received")
-end
-
 #
 # Error request assertions
 #
@@ -63,8 +56,14 @@ end
 # @step_input request_type [String] The type of request (error, session, etc)
 Then('I should receive no {word}') do |request_type|
   sleep Maze.config.receive_no_requests_wait
-  list = Maze::Server.list_for(request_type).size
-  assert_equal(0, list, "#{list.size} #{request_type} received")
+  if request_type == 'requests'
+    # Assert that the test Server hasn't received any requests at all.
+    assert_equal(0, Maze::Server.errors.size, "#{Maze::Server.errors.size} errors received")
+    assert_equal(0, Maze::Server.sessions.size, "#{Maze::Server.sessions.size} sessions received")
+  else
+    list = Maze::Server.list_for(request_type).size
+    assert_equal(0, list, "#{list.size} #{request_type} received")
+  end
 end
 
 # Moves to the next request

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -51,9 +51,10 @@ Then('I wait to receive {int} {word}') do |request_count, request_type|
   assert_received_requests request_count, Maze::Server.list_for(request_type), request_type
 end
 
-# Assert that the test Server hasn't received any requests of a given type.
+# Assert that the test Server hasn't received any requests - of a specific, or any, type.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request ('error', 'session', etc), or 'requests' to assert on all
+#   request types.
 Then('I should receive no {word}') do |request_type|
   sleep Maze.config.receive_no_requests_wait
   if request_type == 'requests'

--- a/lib/maze/helper.rb
+++ b/lib/maze/helper.rb
@@ -46,9 +46,13 @@ module Maze
         value
       end
 
+      # Determines if the Bugsnag-Integrity header is valid.
+      # Whether a missing header is deemed valid depends on @see Maze.config.enforce_bugsnag_integrity.
+      #
+      # @return [Boolean] True if the header is present and valid, or not present and not enforced.  False otherwise.
       def valid_bugsnag_integrity_header(request)
         header = request[:request]['Bugsnag-Integrity']
-        return false if header.nil?
+        return !Maze.config.enforce_bugsnag_integrity if header.nil?
 
         digests = request[:digests]
         if header.start_with?('sha1')

--- a/lib/maze/request_list.rb
+++ b/lib/maze/request_list.rb
@@ -48,7 +48,7 @@ module Maze
       @count -= 1
     end
 
-    # A frozen clone of all requests held, including those already orocessed
+    # A frozen clone of all requests held, including those already processed
     def all
       @requests.clone.freeze
     end

--- a/test/fixtures/browserstack-app/app/build.gradle
+++ b/test/fixtures/browserstack-app/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android:5.2.3'
+    implementation 'com.bugsnag:bugsnag-android:5.5.0'
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     testImplementation 'junit:junit:4.12'

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -4,8 +4,7 @@ Scenario: Test Handled Android Exception
   Given the element "trigger_error" is present
   When I click the element "trigger_error"
   Then I wait to receive an error
-  # TODO Uncomment this once Android is released with the Integrity header
-  # And the Bugsnag-Integrity header is valid
+  And the error Bugsnag-Integrity header is valid
   And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
   And the exception "errorClass" equals "java.lang.Exception"
   And the exception "message" equals "HandledException!"
@@ -27,8 +26,7 @@ Scenario: Verify "equals the correct platform value" step
   Given the element "trigger_error" is present within 30 seconds
   When I click the element "trigger_error"
   Then I wait to receive an error
-  # TODO Uncomment this once Android is released with the Integrity header
-  # And the Bugsnag-Integrity header is valid
+  And the error Bugsnag-Integrity header is valid
   And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
   # Verify string comparisons
   And the event "exceptions.0.errorClass" equals the platform-dependent string:

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -6,7 +6,7 @@ Scenario: Test Handled Android Exception
   Then I wait to receive an error
   # TODO Uncomment this once Android is released with the Integrity header
   # And the Bugsnag-Integrity header is valid
-  And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+  And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
   And the exception "errorClass" equals "java.lang.Exception"
   And the exception "message" equals "HandledException!"
   # Verifies the environment variable change works
@@ -19,7 +19,7 @@ Scenario: Verify text entry and clearing steps
   And I clear and send the keys "Listen to me!" to the element "metadata"
   And I click the element "trigger_error"
   Then I wait to receive an error
-  And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+  And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
   And the exception "errorClass" equals "java.lang.Exception"
   And the exception "message" equals "Listen to me!"
 
@@ -29,7 +29,7 @@ Scenario: Verify "equals the correct platform value" step
   Then I wait to receive an error
   # TODO Uncomment this once Android is released with the Integrity header
   # And the Bugsnag-Integrity header is valid
-  And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+  And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
   # Verify string comparisons
   And the event "exceptions.0.errorClass" equals the platform-dependent string:
     | android | java.lang.Exception |

--- a/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
@@ -3,7 +3,7 @@ Feature: Testing helper methods respond correctly
     Scenario: The request body matches an expected error payload
         When I send a "payload"-type request
         Then I wait to receive an error
-        And the request is valid for the error reporting API version "4.0" for the "Maze-runner" notifier
+        And the error is valid for the error reporting API version "4.0" for the "Maze-runner" notifier
 
     Scenario: The request body matches an expected session payload
         When I send a "session"-type request


### PR DESCRIPTION
## Goal

Corrects some errors that came to light as part of updating the Android pipeline to use what is now a candidate for MazeRunner v4.

## Changeset

Cucumber step corrections and refactoring.  Also updated the Android notifier that the end-to-end tests use in order that the `Bugnsag-Integrity` header step can be brought in.

## Tests

Covered by CI combined with Android PR https://github.com/bugsnag/bugsnag-android/pull/1080, which uses it.