### PR TITLE
Additional Android 4 and 5 devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 4.0.1 - 2021/01/21
+# 4.1.0 - 2021/01/21
+
+## Enhancements
+
+- Additional device options added for Android 4.4 and 5.0 [#204](https://github.com/bugsnag/maze-runner/pull/204)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.0.1)
+    bugsnag-maze-runner (4.1.0)
       appium_lib (~> 10.2)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION ||= '4.0.1'
+  VERSION = '4.1.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/devices.rb
+++ b/lib/maze/devices.rb
@@ -92,6 +92,8 @@ module Maze
         add_android 'Motorola Moto X 2nd Gen', '6.0', APPIUM_1_6_5, hash  # ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN
         add_android 'Google Nexus 6', '6.0', APPIUM_1_6_5, hash           # ANDROID_6_0_GOOGLE_NEXUS_6
         add_android 'Samsung Galaxy S7', '6.0', APPIUM_1_6_5, hash        # ANDROID_6_0_SAMSUNG_GALAXY_S7
+        add_android 'Samsung Galaxy S6', '5.0', APPIUM_1_6_5, hash        # ANDROID_5_0_SAMSUNG_GALAXY_S6
+        add_android 'Samsung Galaxy Note 4', '4.4', APPIUM_1_6_5, hash    # ANDROID_4_4_SAMSUNG_GALAXY_NOTE_4
 
         # Specific iOS devices
         add_ios 'iPhone 8 Plus', '11.0', hash                             # IOS_11_0_IPHONE_8_PLUS


### PR DESCRIPTION
## Goal

Adds two more devices from the BrowserStack pool.

## Design

Follows the existing pattern.

## Changeset

Adds the Galaxy S6 and Note 4, both of which look like they have more power than the Android 4/5 devices currently in use. 

## Tests

Tested locally.