### PR TITLE
Remove triggering of notifier builds for new master

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -163,27 +163,6 @@ steps:
 
   - wait
 
-  - label: 'Trigger Android build against new master'
-    branches: 'master'
-    trigger: 'android-bugsnag-notifier'
-    build:
-      branch: 'maze-runner-master'
-    async: true
-
-  - label: 'Trigger Cocoa build against new master'
-    branches: 'master'
-    trigger: 'cocoa-bugsnag-notifier'
-    build:
-      branch: 'maze-runner-master'
-    async: true
-
-  - label: 'Trigger JS build against new master'
-    branches: 'master'
-    trigger: 'at-bugsnag-js'
-    build:
-      branch: 'maze-runner-master'
-    async: true
-
   - label: 'Update docs'
     if: build.tag =~ /^v[2-9]\.[0-9]+\.[0-9]+\$/
     plugins:


### PR DESCRIPTION
## Goal

Removes triggering of notifier builds against the the new MazeRunner master.

## Design

This mechanism has been overtaken by events by a large extent and drifted out of use.  The custom branches it triggers are no longer up to date and I can't remember the last time I wanted to look at the results.  We have got better at adding tests to the MazeRunner pipeline as we go and are also very reactive to any issues with new release, so it has become more of a burden having to wait for them to run and cancel the triggered builds to avoid unnecessary resource use.

I suggest we now remove these - if we really find the need to run the notifier pipelines in advance of a release we can do this manually.

## Changeset

Notifier pipeline build triggers removed.

## Tests

Covered by CI.