### PR TITLE
Further Android 4 and 5 devices added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.2.0 - 2021/01/21
+
+## Enhancements
+
+- Further Android 4.4 and 5.0 devices added [#205](https://github.com/bugsnag/maze-runner/pull/205)
+
 # 4.1.0 - 2021/01/21
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 4.2.0 - 2021/01/21
+# 4.2.0 - 2021/01/22
 
 ## Enhancements
 
-- Further Android 4.4 and 5.0 devices added [#205](https://github.com/bugsnag/maze-runner/pull/205)
+- Further Android 4.4 and 5.0 devices added [#206](https://github.com/bugsnag/maze-runner/pull/206)
 
 # 4.1.0 - 2021/01/21
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.1.0)
+    bugsnag-maze-runner (4.2.0)
       appium_lib (~> 10.2)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.1.0'
+  VERSION = '4.2.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/devices.rb
+++ b/lib/maze/devices.rb
@@ -92,8 +92,10 @@ module Maze
         add_android 'Motorola Moto X 2nd Gen', '6.0', APPIUM_1_6_5, hash  # ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN
         add_android 'Google Nexus 6', '6.0', APPIUM_1_6_5, hash           # ANDROID_6_0_GOOGLE_NEXUS_6
         add_android 'Samsung Galaxy S7', '6.0', APPIUM_1_6_5, hash        # ANDROID_6_0_SAMSUNG_GALAXY_S7
+        add_android 'Google Nexus 6', '5.0', APPIUM_1_6_5, hash           # ANDROID_5_0_GOOGLE_NEXUS_6
         add_android 'Samsung Galaxy S6', '5.0', APPIUM_1_6_5, hash        # ANDROID_5_0_SAMSUNG_GALAXY_S6
         add_android 'Samsung Galaxy Note 4', '4.4', APPIUM_1_6_5, hash    # ANDROID_4_4_SAMSUNG_GALAXY_NOTE_4
+        add_android 'Samsung Galaxy Tab 4', '4.4', APPIUM_1_6_5, hash     # ANDROID_4_4_SAMSUNG_GALAXY_TAB_4
 
         # Specific iOS devices
         add_ios 'iPhone 8 Plus', '11.0', hash                             # IOS_11_0_IPHONE_8_PLUS


### PR DESCRIPTION
## Goal

Adds the remaining set of Android 4 and 5 devices available on BrowserStack.

## Tests

Use tested locally.