### PR TITLE
Make platform-dependent tests independent of payload type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.3.0 - 2021/01/25
+
+## Enhancements
+
+- Platform-dependent steps made payload independent [#208](https://github.com/bugsnag/maze-runner/pull/208)
+
 # 4.2.1 - 2021/01/25
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.2.1)
+    bugsnag-maze-runner (4.3.0)
       appium_lib (~> 10.2)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -81,7 +81,7 @@ GEM
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
-    power_assert (1.2.0)
+    power_assert (2.0.0)
     props (1.2.0)
       iniparser (>= 0.1.0)
     racc (1.5.2)

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -24,13 +24,15 @@ end
 #
 # @step_input element_id [String] The locator id
 When('I click the element {string}') do |element_id|
-  Maze.driver.click_element(element_id)
-rescue StandardError
-  # AppiumForMac raises an to run a scenario that crashes the app
-  raise unless Maze.config.os == 'macos'
+  begin
+    Maze.driver.click_element(element_id)
+  rescue StandardError
+    # AppiumForMac raises an to run a scenario that crashes the app
+    raise unless Maze.config.os == 'macos'
 
-  $logger.warn 'Ignoring exception raised on click_element - this is normal for AppiumForMac if the button click ' \
-    'causes the app to crash.'
+    $logger.warn 'Ignoring exception raised on click_element - this is normal for AppiumForMac if the button click ' \
+      'causes the app to crash.'
+  end
 end
 
 # Sends the app to the background for a number of seconds

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -68,10 +68,11 @@ end
 #
 # If the expected value is set to "@skip", the check should be skipped.
 #
+# @step_input request_type [String] The type of request (error, session, etc)
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then('the error payload field {string} equals the platform-dependent string:') do |field_path, platform_values|
-  test_string_platform_values(field_path, platform_values)
+Then('the {word} payload field {string} equals the platform-dependent string:') do |request_type, field_path, platform_values|
+  test_string_platform_values(request_type, field_path, platform_values)
 end
 
 # See `the error payload field {string} equals the platform-dependent string:`
@@ -79,7 +80,7 @@ end
 # @step_input field_path [String] The field to test, prepended with "events.0"
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
 Then('the event {string} equals the platform-dependent string:') do |field_path, platform_values|
-  test_string_platform_values("events.0.#{field_path}", platform_values)
+  test_string_platform_values('error', "events.0.#{field_path}", platform_values)
 end
 
 # Tests that the given payload value is correct for the target BrowserStack platform.
@@ -92,10 +93,11 @@ end
 #
 # If the expected value is set to "@skip", the check should be skipped.
 #
+# @step_input request_type [String] The type of request (error, session, etc)
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then('the error payload field {string} equals the platform-dependent numeric:') do |field_path, platform_values|
-  test_numeric_platform_values(field_path, platform_values)
+Then('the {word} payload field {string} equals the platform-dependent numeric:') do |request_type, field_path, platform_values|
+  test_numeric_platform_values(request_type, field_path, platform_values)
 end
 
 # See `the payload field {string} equals the platform-dependent numeric:`
@@ -103,7 +105,7 @@ end
 # @step_input field_path [String] The field to test, prepended with "events.0"
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
 Then('the event {string} equals the platform-dependent numeric:') do |field_path, platform_values|
-  test_numeric_platform_values("events.0.#{field_path}", platform_values)
+  test_numeric_platform_values('error', "events.0.#{field_path}", platform_values)
 end
 
 # Tests that the given payload value is correct for the target BrowserStack platform.
@@ -116,10 +118,11 @@ end
 #
 # If the expected value is set to "@skip", the check should be skipped.
 #
+# @step_input request_type [String] The type of request (error, session, etc)
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then('the error payload field {string} equals the platform-dependent boolean:') do |field_path, platform_values|
-  test_boolean_platform_values(field_path, platform_values)
+Then('the {word} payload field {string} equals the platform-dependent boolean:') do |request_type, field_path, platform_values|
+  test_boolean_platform_values(request_type, field_path, platform_values)
 end
 
 # See `the payload field {string} equals the platform-dependent boolean:`
@@ -127,7 +130,7 @@ end
 # @step_input field_path [String] The field to test, prepended with "events.0"
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
 Then('the event {string} equals the platform-dependent boolean:') do |field_path, platform_values|
-  test_boolean_platform_values("events.0.#{field_path}", platform_values)
+  test_boolean_platform_values('error', "events.0.#{field_path}", platform_values)
 end
 
 # See `the payload field {string} equals the platform-dependent string:`
@@ -135,7 +138,7 @@ end
 # @step_input field_path [String] The field to test, prepended with "events.0.exceptions.0."
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
 Then('the exception {string} equals the platform-dependent string:') do |field_path, platform_values|
-  test_string_platform_values("events.0.exceptions.0.#{field_path}", platform_values)
+  test_string_platform_values('error', "events.0.exceptions.0.#{field_path}", platform_values)
 end
 
 # See `the payload field {string} equals the platform-dependent string:`
@@ -144,7 +147,7 @@ end
 # @step_input field_path [String] The index of the stack frame to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
 Then('the {string} of stack frame {int} equals the platform-dependent string:') do |field_path, num, platform_values|
-  test_string_platform_values("events.0.exceptions.0.stacktrace.#{num}.#{field_path}", platform_values)
+  test_string_platform_values('error', "events.0.exceptions.0.stacktrace.#{num}.#{field_path}", platform_values)
 end
 
 # Sends keys to a given element, clearing it first
@@ -170,15 +173,16 @@ def should_skip_platform_check(expected_value)
   expected_value.eql?('@skip')
 end
 
-def test_string_platform_values(field_path, platform_values)
+def test_string_platform_values(request_type, field_path, platform_values)
   expected_value = get_expected_platform_value(platform_values)
   return if should_skip_platform_check(expected_value)
 
-  payload_value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], field_path)
+  list = Maze::Server.list_for(request_type)
+  payload_value = Maze::Helper.read_key_path(list.current[:body], field_path)
   assert_equal(expected_value, payload_value)
 end
 
-def test_boolean_platform_values(field_path, platform_values)
+def test_boolean_platform_values(request_type, field_path, platform_values)
   expected_value = get_expected_platform_value(platform_values)
   return if should_skip_platform_check(expected_value)
 
@@ -189,14 +193,16 @@ def test_boolean_platform_values(field_path, platform_values)
                   else
                     expected_value
                   end
-  payload_value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], field_path)
+  list = Maze::Server.list_for(request_type)
+  payload_value = Maze::Helper.read_key_path(list.current[:body], field_path)
   assert_equal(expected_bool, payload_value)
 end
 
-def test_numeric_platform_values(field_path, platform_values)
+def test_numeric_platform_values(request_type, field_path, platform_values)
   expected_value = get_expected_platform_value(platform_values)
   return if should_skip_platform_check(expected_value)
 
-  payload_value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], field_path)
+  list = Maze::Server.list_for(request_type)
+  payload_value = Maze::Helper.read_key_path(list.current[:body], field_path)
   assert_equal(expected_value.to_f, payload_value)
 end

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.2.1'
+  VERSION = '4.3.0'
 
   class << self
     attr_accessor :driver
@@ -19,4 +19,3 @@ module Maze
     end
   end
 end
-


### PR DESCRIPTION
## Goal

Generalises the payload type used when making platform-dependent checks, allowing platform-dependent assertions to be made against session payloads.
