### PR TITLE
Sort received requests by Bugsnag-Sent-At header

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,8 +78,6 @@ steps:
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
       --device=ANDROID_6_0
-      --username=$BROWSER_STACK_USERNAME
-      --access-key=$BROWSER_STACK_ACCESS_KEY
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -93,8 +91,6 @@ steps:
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
       --device=ANDROID_7_1
-      --username=$BROWSER_STACK_USERNAME
-      --access-key=$BROWSER_STACK_ACCESS_KEY
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -109,8 +105,6 @@ steps:
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
       --device=ANDROID_8_1
-      --username=$BROWSER_STACK_USERNAME
-      --access-key=$BROWSER_STACK_ACCESS_KEY
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -124,8 +118,6 @@ steps:
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
       --device=ANDROID_9_0
-      --username=$BROWSER_STACK_USERNAME
-      --access-key=$BROWSER_STACK_ACCESS_KEY
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -139,8 +131,6 @@ steps:
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
       --device=ANDROID_10_0
-      --username=$BROWSER_STACK_USERNAME
-      --access-key=$BROWSER_STACK_ACCESS_KEY
       --appium-version=1.17.0
     concurrency: 10
     concurrency_group: 'browserstack-app'
@@ -155,8 +145,6 @@ steps:
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
       --device=ANDROID_11_0
-      --username=$BROWSER_STACK_USERNAME
-      --access-key=$BROWSER_STACK_ACCESS_KEY
       --appium-version=1.17.0
     concurrency: 10
     concurrency_group: 'browserstack-app'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.3.1 - 2021/01/26
+
+## Fixes
+
+- Ensure received requests are in order by sent time [#209](https://github.com/bugsnag/maze-runner/pull/209)
+
 # 4.3.0 - 2021/01/25
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Enhancements
 
 - Further Android 4.4 and 5.0 devices added [#206](https://github.com/bugsnag/maze-runner/pull/206)
+- Sort received requests by Bugsnag-Sent-At header [#207](https://github.com/bugsnag/maze-runner/pull/207)
 
 # 4.1.0 - 2021/01/21
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.3.0)
+    bugsnag-maze-runner (4.3.1)
       appium_lib (~> 10.2)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       BUILDKITE:
       BUILDKITE_BUILD_NUMBER:
       BUILDKITE_STEP_KEY:
+      MAZE_DEVICE_FARM_USERNAME:
+      MAZE_DEVICE_FARM_ACCESS_KEY:
 
   cli-tests:
     build:

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -30,6 +30,7 @@ def assert_received_requests(request_count, list, list_name)
   end
 
   assert_equal(request_count, list.size, "#{list.size} #{list_name} received")
+  list.sort_by_sent_at request_count
 end
 
 #

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -30,7 +30,6 @@ def assert_received_requests(request_count, list, list_name)
   end
 
   assert_equal(request_count, list.size, "#{list.size} #{list_name} received")
-  list.sort_by_sent_at! request_count
 end
 
 #

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -30,7 +30,7 @@ def assert_received_requests(request_count, list, list_name)
   end
 
   assert_equal(request_count, list.size, "#{list.size} #{list_name} received")
-  list.sort_by_sent_at request_count
+  list.sort_by_sent_at! request_count
 end
 
 #
@@ -43,13 +43,17 @@ Then('I wait to receive a(n) {word}') do |request_type|
   step "I wait to receive 1 #{request_type}"
 end
 
-# Continually checks to see if the required amount of requests have been received.
-# Times out according to @see Maze.config.receive_requests_wait.
+# Continually checks to see if the required amount of requests have been received,
+# timing out according to @see Maze.config.receive_requests_wait.
+# If all expected requests are received and have the Bugsnag-Sent-At header, they
+# will be sorted by the header.
 #
 # @step_input request_type [String] The type of request (error, session, etc)
 # @step_input request_count [Integer] The amount of requests expected
 Then('I wait to receive {int} {word}') do |request_count, request_type|
-  assert_received_requests request_count, Maze::Server.list_for(request_type), request_type
+  list = Maze::Server.list_for(request_type)
+  assert_received_requests request_count, list, request_type
+  list.sort_by_sent_at! request_count
 end
 
 # Assert that the test Server hasn't received any requests - of a specific, or any, type.

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.3.0'
+  VERSION = '4.3.1'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/request_list.rb
+++ b/lib/maze/request_list.rb
@@ -72,7 +72,7 @@ module Maze
       header = 'Bugsnag-Sent-At'
       sub_list = @requests[@current...@current + count]
 
-      return unless sub_list.all? { |r| !r[:request][header].nil? }
+      return if sub_list.any? { |r| r[:request][header].nil? }
 
       # Sort sublist by Bugsnag-Sent-At and overwrite in the main list
       sub_list.sort_by! { |r| DateTime.parse(r[:request][header]) }

--- a/lib/maze/request_list.rb
+++ b/lib/maze/request_list.rb
@@ -64,5 +64,11 @@ module Maze
       @current = 0
       @count = 0
     end
+
+    # Sorts the first `count` elements of the list by the Bugsnag-Sent-At header, if present
+    def sort_by_sent_at(count)
+      header =
+      return unless @requests.all? {|r| r.has? '' }
+    end
   end
 end

--- a/lib/maze/request_list.rb
+++ b/lib/maze/request_list.rb
@@ -71,13 +71,12 @@ module Maze
 
       header = 'Bugsnag-Sent-At'
       sub_list = @requests[@current...@current + count]
-      return unless sub_list.all? { |r| r.key? header }
+
+      return unless sub_list.all? { |r| !r[:request][header].nil? }
 
       # Sort sublist by Bugsnag-Sent-At and overwrite in the main list
-      sub_list.sort_by! { |r| DateTime.parse(r[header]) }
+      sub_list.sort_by! { |r| DateTime.parse(r[:request][header]) }
       sub_list.each_with_index { |r, i| @requests[@current + i] = r }
-
-      puts sub_list
     end
   end
 end

--- a/lib/maze/request_list.rb
+++ b/lib/maze/request_list.rb
@@ -65,10 +65,19 @@ module Maze
       @count = 0
     end
 
-    # Sorts the first `count` elements of the list by the Bugsnag-Sent-At header, if present
-    def sort_by_sent_at(count)
-      header =
-      return unless @requests.all? {|r| r.has? '' }
+    # Sorts the first `count` elements of the list by the Bugsnag-Sent-At header, if present in all of those elements
+    def sort_by_sent_at!(count)
+      return unless count > 1
+
+      header = 'Bugsnag-Sent-At'
+      sub_list = @requests[@current...@current + count]
+      return unless sub_list.all? { |r| r.key? header }
+
+      # Sort sublist by Bugsnag-Sent-At and overwrite in the main list
+      sub_list.sort_by! { |r| DateTime.parse(r[header]) }
+      sub_list.each_with_index { |r, i| @requests[@current + i] = r }
+
+      puts sub_list
     end
   end
 end

--- a/test/request_list_test.rb
+++ b/test/request_list_test.rb
@@ -13,6 +13,15 @@ class RequestListTest < Test::Unit::TestCase
     }
   end
 
+  def build_item_with_header(id, time)
+    header = 'Bugsnag-Sent-At'
+    {
+      id: id,
+      body: "{id: '#{id}'}",
+      header => time
+    }
+  end
+
   def test_fresh_state
     list = Maze::RequestList.new
     assert_nil list.current
@@ -125,5 +134,22 @@ class RequestListTest < Test::Unit::TestCase
     # Check that remaining does not change when inspected
     remaining = list.remaining
     assert_equal [item2, item3], remaining
+  end
+
+  def test_sort_by_sent_at_all_requests
+    time1 = '2021-01-21T14:36:00.000Z'
+    time2 = '2021-01-21T16:37:00.000Z'
+    time3 = '2021-01-21T15:37:00.000Z'
+
+    request1 = build_item_with_header 1, time1
+    request2 = build_item_with_header 2, time2
+    request3 = build_item_with_header 3, time3
+
+    list = Maze::RequestList.new
+    list.add request1
+    list.add request2
+    list.add request3
+
+    list.sort_by_sent_at 3
   end
 end

--- a/test/request_list_test.rb
+++ b/test/request_list_test.rb
@@ -16,9 +16,9 @@ class RequestListTest < Test::Unit::TestCase
   def build_item_with_header(id, time)
     header = 'Bugsnag-Sent-At'
     {
+      header => time,
       id: id,
-      body: "{id: '#{id}'}",
-      header => time
+      body: "{id: '#{id}'}"
     }
   end
 
@@ -136,10 +136,10 @@ class RequestListTest < Test::Unit::TestCase
     assert_equal [item2, item3], remaining
   end
 
-  def test_sort_by_sent_at_all_requests
-    time1 = '2021-01-21T14:36:00.000Z'
-    time2 = '2021-01-21T16:37:00.000Z'
-    time3 = '2021-01-21T15:37:00.000Z'
+  def test_sort_by_all_requests
+    time1 = '2021-02-21T15:00:00.001Z'
+    time2 = '2021-01-21T14:00:00.000Z'
+    time3 = '2021-02-21T15:00:00.000Z'
 
     request1 = build_item_with_header 1, time1
     request2 = build_item_with_header 2, time2
@@ -150,6 +150,72 @@ class RequestListTest < Test::Unit::TestCase
     list.add request2
     list.add request3
 
-    list.sort_by_sent_at 3
+    list.sort_by_sent_at! 3
+
+    assert_equal [request2, request3, request1], list.remaining
+  end
+
+  def test_sort_by_missing header
+    time1 = '2021-02-21T15:00:00.001Z'
+    time2 = '2021-02-21T15:00:00.000Z'
+
+    request1 = build_item_with_header 1, time1
+    request2 = build_item 2
+    request3 = build_item_with_header 3, time2
+
+    list = Maze::RequestList.new
+    list.add request1
+    list.add request2
+    list.add request3
+
+    list.sort_by_sent_at! 3
+
+    assert_equal [request1, request2, request3], list.remaining
+  end
+
+  def test_sort_by_remaining_requests
+    time1 = '2021-02-21T15:00:00.001Z'
+    time2 = '2021-01-21T14:00:00.000Z'
+    time3 = '2021-02-21T15:00:00.000Z'
+
+    request1 = build_item 1
+    request2 = build_item_with_header 2, time1
+    request3 = build_item_with_header 3, time2
+    request4 = build_item_with_header 4, time3
+
+    list = Maze::RequestList.new
+    list.add request1
+    list.add request2
+    list.add request3
+    list.next
+    list.add request4
+
+    list.sort_by_sent_at! 3
+
+    assert_equal [request3, request4, request2], list.remaining
+  end
+
+  def test_sort_by_with_subsequent_request
+    time1 = '2021-02-21T15:00:00.001Z'
+    time2 = '2021-01-21T14:00:00.000Z'
+    time3 = '2021-02-21T15:00:00.000Z'
+
+    request1 = build_item 1
+    request2 = build_item_with_header 2, time1 # Sort
+    request3 = build_item_with_header 3, time2 # Sort
+    request4 = build_item_with_header 4, time3 # Do not sort
+    request5 = build_item 5 # No header, but out of scope
+
+    list = Maze::RequestList.new
+    list.add request1
+    list.add request2
+    list.add request3
+    list.next
+    list.add request4
+    list.add request5
+
+    list.sort_by_sent_at! 2
+
+    assert_equal [request3, request2, request4, request5], list.remaining
   end
 end

--- a/test/request_list_test.rb
+++ b/test/request_list_test.rb
@@ -9,16 +9,20 @@ class RequestListTest < Test::Unit::TestCase
   def build_item(id)
     {
       id: id,
-      body: "{id: '#{id}'}"
+      request: {
+        body: "{id: '#{id}'}"
+      }
     }
   end
 
   def build_item_with_header(id, time)
     header = 'Bugsnag-Sent-At'
     {
-      header => time,
       id: id,
-      body: "{id: '#{id}'}"
+      request: {
+        header => time,
+        body: "{id: '#{id}'}"
+      }
     }
   end
 


### PR DESCRIPTION
## Goal

Ensures the batch of requests captured by the `I wait to receive {int} {word}` step are sorted by the `Bugsnag-Sent-At` header, if it is present on all requests.  If requests are sent very close together (perhaps <0.1s), they can end up being stored out of order, resulting in test flakes.

## Design

It is important that sorting of requests does not intrude upon:
- requests previously captured and already processed
- requests that arrive due to subsequent actions, whilst the batch is still being processed.
The unit tests added are designed to ensure this.

## Changeset

- New method on the `RequestList` class to sort by header in-situ.  
- Plumbing into the Cucumber step
- Incidental pipeline change to reduce unnecessary noise (values are now set in the environment)

## Tests

Logic for sorting of the requests sub-list is covered by unit tests.  I've also run some Android tests locally against it that expect batches of requests to be received.  This shows that it expects the right form of data structure.