### PR TITLE
Nullable platform dependence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# 4.4.0 - TBD
+# 4.4.0 - 2021/01/28
 
 ## Enhancements
 
 - Adds in-built appium server control for local testing [#202](https://github.com/bugsnag/maze-runner/pull/202)
+- Allow the use of @null and @non-null in platform-dependent assertion tables[#210](https://github.com/bugsnag/maze-runner/pull/210)
 
 # 4.3.1 - 2021/01/26
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.3.1)
+    bugsnag-maze-runner (4.4.0)
       appium_lib (~> 10.2)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -31,7 +31,7 @@ GEM
     appium_lib_core (3.11.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
-    backports (3.20.1)
+    backports (3.20.2)
     boring (0.1.0)
     builder (3.2.4)
     childprocess (3.0.0)

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -168,9 +168,9 @@ When('I clear and send the keys {string} to the element {string}') do |keys, ele
 end
 
 def get_expected_platform_value(platform_values)
-  raise('This step should only be used when running tests with Appium') if Maze.driver.nil?
+  # raise('This step should only be used when running tests with Appium') if Maze.driver.nil?
 
-  os = Maze.config.capabilities['os']
+  os = 'android'
   expected_value = Hash[platform_values.raw][os]
   raise("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
 
@@ -214,11 +214,14 @@ def test_numeric_platform_values(request_type, field_path, platform_values)
   payload_value = Maze::Helper.read_key_path(list.current[:body], field_path)
 
   # Need to do a little more processing here to allow floats
-  expectation = expected_value.to_f unless expected_value.eql?('@null') || expected_value.eql?('@not_null')
+  special_value = expected_value.eql?('@null') || expected_value.eql?('@not_null')
+  expectation = special_value ? expected_value : expected_value.to_f
   assert_equal_with_nullability(expectation, payload_value)
 end
 
 def assert_equal_with_nullability(expected_value, payload_value)
+  pp "EXPECTED_VALUE: #{expected_value}"
+  pp "PAYLOAD_VALUE: #{payload_value}"
   if expected_value.eql?('@null')
     assert_nil(payload_value)
   elsif expected_value.eql?('@not_null')

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -68,7 +68,9 @@ end
 #   | android | Java.lang.RuntimeException |
 #   | ios     | NSException                |
 #
-# If the expected value is set to "@skip", the check should be skipped.
+# If the expected value is set to "@skip", the check should be skipped
+# If the expected value is set to "@null", the check will be for null
+# If the expected value is set to "@not_null", the check will be for a non-null value
 #
 # @step_input request_type [String] The type of request (error, session, etc)
 # @step_input field_path [String] The field to test
@@ -93,7 +95,9 @@ end
 #   | android | 1  |
 #   | ios     | 5.5 |
 #
-# If the expected value is set to "@skip", the check should be skipped.
+# If the expected value is set to "@skip", the check should be skipped
+# If the expected value is set to "@null", the check will be for null
+# If the expected value is set to "@not_null", the check will be for a non-null value
 #
 # @step_input request_type [String] The type of request (error, session, etc)
 # @step_input field_path [String] The field to test
@@ -118,7 +122,9 @@ end
 #   | android | 1 |
 #   | ios     | 5 |
 #
-# If the expected value is set to "@skip", the check should be skipped.
+# If the expected value is set to "@skip", the check should be skipped
+# If the expected value is set to "@null", the check will be for null
+# If the expected value is set to "@not_null", the check will be for a non-null value
 #
 # @step_input request_type [String] The type of request (error, session, etc)
 # @step_input field_path [String] The field to test
@@ -181,7 +187,7 @@ def test_string_platform_values(request_type, field_path, platform_values)
 
   list = Maze::Server.list_for(request_type)
   payload_value = Maze::Helper.read_key_path(list.current[:body], field_path)
-  assert_equal(expected_value, payload_value)
+  assert_equal_with_nullability(expected_value, payload_value)
 end
 
 def test_boolean_platform_values(request_type, field_path, platform_values)
@@ -197,7 +203,7 @@ def test_boolean_platform_values(request_type, field_path, platform_values)
                   end
   list = Maze::Server.list_for(request_type)
   payload_value = Maze::Helper.read_key_path(list.current[:body], field_path)
-  assert_equal(expected_bool, payload_value)
+  assert_equal_with_nullability(expected_bool, payload_value)
 end
 
 def test_numeric_platform_values(request_type, field_path, platform_values)
@@ -206,5 +212,15 @@ def test_numeric_platform_values(request_type, field_path, platform_values)
 
   list = Maze::Server.list_for(request_type)
   payload_value = Maze::Helper.read_key_path(list.current[:body], field_path)
-  assert_equal(expected_value.to_f, payload_value)
+  assert_equal_with_nullability(expected_value.to_f, payload_value)
+end
+
+def assert_equal_with_nullability(expected_value, payload_value)
+  if expected_value.eql?('@null')
+    assert_nil(payload_value)
+  elsif expected_value.eql?('@non-null')
+    assert_not_nil(payload_value)
+  else
+    assert_equal(expected_value, payload_value)
+  end
 end

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -214,14 +214,14 @@ def test_numeric_platform_values(request_type, field_path, platform_values)
   payload_value = Maze::Helper.read_key_path(list.current[:body], field_path)
 
   # Need to do a little more processing here to allow floats
-  expectation = expected_value.to_f unless expected_value.eql?('@null') || expected_value.eql?('@non-null')
+  expectation = expected_value.to_f unless expected_value.eql?('@null') || expected_value.eql?('@not_null')
   assert_equal_with_nullability(expectation, payload_value)
 end
 
 def assert_equal_with_nullability(expected_value, payload_value)
   if expected_value.eql?('@null')
     assert_nil(payload_value)
-  elsif expected_value.eql?('@non-null')
+  elsif expected_value.eql?('@not_null')
     assert_not_nil(payload_value)
   else
     assert_equal(expected_value, payload_value)

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -212,7 +212,10 @@ def test_numeric_platform_values(request_type, field_path, platform_values)
 
   list = Maze::Server.list_for(request_type)
   payload_value = Maze::Helper.read_key_path(list.current[:body], field_path)
-  assert_equal_with_nullability(expected_value.to_f, payload_value)
+
+  # Need to do a little more processing here to allow floats
+  expectation = expected_value.to_f unless expected_value.eql?('@null') || expected_value.eql?('@non-null')
+  assert_equal_with_nullability(expectation, payload_value)
 end
 
 def assert_equal_with_nullability(expected_value, payload_value)

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -170,7 +170,7 @@ end
 def get_expected_platform_value(platform_values)
   raise('This step should only be used when running tests with Appium') if Maze.driver.nil?
 
-  os = 'android'
+  os = Maze.config.capabilities['os']
   expected_value = Hash[platform_values.raw][os]
   raise("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
 
@@ -220,8 +220,6 @@ def test_numeric_platform_values(request_type, field_path, platform_values)
 end
 
 def assert_equal_with_nullability(expected_value, payload_value)
-  pp "EXPECTED_VALUE: #{expected_value}"
-  pp "PAYLOAD_VALUE: #{payload_value}"
   if expected_value.eql?('@null')
     assert_nil(payload_value)
   elsif expected_value.eql?('@not_null')

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -168,7 +168,7 @@ When('I clear and send the keys {string} to the element {string}') do |keys, ele
 end
 
 def get_expected_platform_value(platform_values)
-  # raise('This step should only be used when running tests with Appium') if Maze.driver.nil?
+  raise('This step should only be used when running tests with Appium') if Maze.driver.nil?
 
   os = 'android'
   expected_value = Hash[platform_values.raw][os]

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.3.1'
+  VERSION = '4.4.0'
 
   class << self
     attr_accessor :driver

--- a/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/browserstack-app/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -36,6 +36,7 @@ class MainActivity : AppCompatActivity() {
             event.addMetadata("test", "boolean_true", true)
             event.addMetadata("test", "float", 1.55)
             event.addMetadata("test", "integer", 2)
+            event.addMetadata("test", "null", null)
 
             true
         })

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -74,8 +74,8 @@ Scenario: Verify "equals the correct platform value" step
   And the error payload field "events.0.metaData.test.null" equals the platform-dependent numeric:
     | android | @null |
   And the error payload field "events.0.exceptions.0.errorClass" equals the platform-dependent string:
-    | android | @non-null |
+    | android | @not_null |
   And the error payload field "events.0.metaData.test.boolean_true" equals the platform-dependent boolean:
-    | android | @non-null |
+    | android | @not_null |
   And the error payload field "events.0.metaData.test.integer" equals the platform-dependent numeric:
-    | android | @non-null |
+    | android | @not_null |

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -66,3 +66,16 @@ Scenario: Verify "equals the correct platform value" step
     | android | @skip |
   # Verifies the environment variable change works
   And the error payload field "apiKey" equals the environment variable "BUGSNAG_API_KEY"
+  # Verifies the null and non-null capabilities
+  And the error payload field "events.0.metaData.test.null" equals the platform-dependent string:
+    | android | @null |
+  And the error payload field "events.0.metaData.test.null" equals the platform-dependent boolean:
+    | android | @null |
+  And the error payload field "events.0.metaData.test.null" equals the platform-dependent numeric:
+    | android | @null |
+  And the error payload field "exceptions.0.errorClass" equals the platform-dependent string:
+    | android | @non-null |
+  And the error payload field "events.0.metaData.test.boolean_true" equals the platform-dependent boolean:
+    | android | @non-null |
+  And the error payload field "events.0.metaData.test.integer" equals the platform-dependent numeric:
+    | android | @non-null |

--- a/test/fixtures/browserstack-app/features/handled_exception.feature
+++ b/test/fixtures/browserstack-app/features/handled_exception.feature
@@ -73,7 +73,7 @@ Scenario: Verify "equals the correct platform value" step
     | android | @null |
   And the error payload field "events.0.metaData.test.null" equals the platform-dependent numeric:
     | android | @null |
-  And the error payload field "exceptions.0.errorClass" equals the platform-dependent string:
+  And the error payload field "events.0.exceptions.0.errorClass" equals the platform-dependent string:
     | android | @non-null |
   And the error payload field "events.0.metaData.test.boolean_true" equals the platform-dependent boolean:
     | android | @non-null |


### PR DESCRIPTION
## Goal

Adds `@null` and `@not_null` tags for use with platform-dependence steps.

This allows:
- Asserting that a value is present (with an unknown value) on a specific platform using `@not_null`
- Asserting that a value will not be present, or be null, on a specific platform using `@null`

## Tests

Added to the platform-dependence e2e tests.
