### PR TITLE
[PLAT-PLAT-5827] Add root endpoint for connectivity checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# TBD
+# 4.5.0 - 2021/02/01
+
+## Enhancements
+
+- Adds root `/` endpoint for use in connectivity checks [#211](https://github.com/bugsnag/maze-runner/pull/211)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.4.0)
+    bugsnag-maze-runner (4.5.0)
       appium_lib (~> 10.2)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -70,14 +70,12 @@ GEM
       props (>= 1.1.2)
       textutils (>= 0.10.0)
     metaclass (0.0.4)
-    mini_portile2 (2.5.0)
     minitest (5.14.3)
     mocha (1.8.0)
       metaclass (~> 0.0.1)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.1)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.1-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -199,5 +199,3 @@ at_exit do
   Maze.driver.driver_quit unless Maze.config.appium_session_isolation
   Maze::AppiumServer.stop if Maze::AppiumServer.running
 end
-
-

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.4.0'
+  VERSION = '4.5.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -93,6 +93,14 @@ module Maze
               Logger: $logger,
               AccessLog: []
             )
+
+            # Mount a block to respond to all requests with status:200
+            server.mount_proc '/' do |_request, response|
+              $logger.info 'Received request on server root, responding with 200'
+              response.header['Access-Control-Allow-Origin'] = '*'
+              response.status = 200
+            end
+
             # When adding more endpoints, be sure to update the 'I should receive no requests' step
             server.mount '/notify', Servlet, errors
             server.mount '/sessions', Servlet, sessions

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -98,6 +98,7 @@ module Maze
             server.mount_proc '/' do |_request, response|
               $logger.info 'Received request on server root, responding with 200'
               response.header['Access-Control-Allow-Origin'] = '*'
+              response.body = 'Maze runner received request'
               response.status = 200
             end
 

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -24,6 +24,7 @@ module Maze
 
       # Expected HTTP server calls
       mock_http_server = mock('http')
+      mock_http_server.expects(:mount_proc).once
       mock_http_server.expects(:mount).twice
       mock_http_server.expects(:start)
       mock_http_server.expects(:shutdown)
@@ -58,6 +59,7 @@ module Maze
 
       # Successful the second
       mock_http_server = mock('http')
+      mock_http_server.expects(:mount_proc).once
       mock_http_server.expects(:mount).twice
       mock_http_server.expects(:start)
       mock_http_server.expects(:shutdown)


### PR DESCRIPTION
## Goal

Adds an endpoint to the basic server on `/` that logs responds to all requests with a `200` status code.
This will be used for certain platforms that need to establish the server is reachable before attempting to run tests.

## Tests

Manually tested to ensure logging and status codes are correct

## Thoughts

- It may be useful to add more debug logging for received requests, but I'd be reluctant to do too much as this endpoint shouldn't typically be used.
- We could record a hit here and add steps for testing whether something has hit the endpoint, but this seems unnecessary for our purposes.

Changelog entry incoming
