### PR TITLE
Add build endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Enhancements
+
+- Add `builds` endpoint for receiving build requests [#213](https://github.com/bugsnag/maze-runner/pull/213)
+
 # 4.5.0 - 2021/02/01
 
 ## Enhancements

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -72,7 +72,7 @@ end
 # If the expected value is set to "@null", the check will be for null
 # If the expected value is set to "@not_null", the check will be for a non-null value
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
 Then('the {word} payload field {string} equals the platform-dependent string:') do |request_type, field_path, platform_values|
@@ -99,7 +99,7 @@ end
 # If the expected value is set to "@null", the check will be for null
 # If the expected value is set to "@not_null", the check will be for a non-null value
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
 Then('the {word} payload field {string} equals the platform-dependent numeric:') do |request_type, field_path, platform_values|
@@ -126,7 +126,7 @@ end
 # If the expected value is set to "@null", the check will be for null
 # If the expected value is set to "@not_null", the check will be for a non-null value
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
 Then('the {word} payload field {string} equals the platform-dependent boolean:') do |request_type, field_path, platform_values|

--- a/lib/features/steps/build_api_steps.rb
+++ b/lib/features/steps/build_api_steps.rb
@@ -4,22 +4,22 @@
 
 # Tests whether the top-most payload is valid for the Bugsnag build API
 # APIKey fields and headers are tested against the '$api_key' global variable
-Then('the request is valid for the Build API') do
+Then('the build is valid for the Build API') do
   steps %(
-    And the error payload field "apiKey" equals "#{$api_key}"
-    And the error payload field "appVersion" is not null
+    And the build payload field "apiKey" equals "#{$api_key}"
+    And the build payload field "appVersion" is not null
   )
 end
 
 # Tests whether the top-most payload is valid for the Android mapping API
 # APIKey fields and headers are tested against the '$api_key' global variable
-Then('the request is valid for the Android Mapping API') do
+Then('the build is valid for the Android Mapping API') do
   steps %(
-    And the error payload field "apiKey" equals "#{$api_key}"
-    And the error payload field "proguard" is not null
-    And the error payload field "appId" is not null
-    And the error payload field "versionCode" is not null
-    And the error payload field "buildUUID" is not null
-    And the error payload field "versionName" is not null
+    And the build payload field "apiKey" equals "#{$api_key}"
+    And the build payload field "proguard" is not null
+    And the build payload field "appId" is not null
+    And the build payload field "versionCode" is not null
+    And the build payload field "buildUUID" is not null
+    And the build payload field "versionName" is not null
   )
 end

--- a/lib/features/steps/header_steps.rb
+++ b/lib/features/steps/header_steps.rb
@@ -4,7 +4,7 @@
 
 # Tests that a request header is not null
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
 Then('the {word} {string} header is not null') do |request_type, header_name|
   assert_not_nil(Maze::Server.list_for(request_type).current[:request][header_name],
@@ -13,7 +13,7 @@ end
 
 # Tests that request header equals a string
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
 # @step_input header_value [String] The string it should match
 Then('the {word} {string} header equals {string}') do |request_type, header_name, header_value|
@@ -24,7 +24,7 @@ end
 
 # Tests that a request header matches a regex
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
 # @step_input regex_string [String] The regex to match with
 Then('the {word} {string} header matches the regex {string}') do |request_type, header_name, regex_string|
@@ -35,7 +35,7 @@ end
 
 # Tests that a request header matches one of a list of strings
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
 # @step_input header_values [DataTable] A parsed data table
 Then('the {word} {string} header equals one of:') do |request_type, header_name, header_values|
@@ -44,7 +44,7 @@ end
 
 # Tests that a request header is a timestamp.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
 Then('the {word} {string} header is a timestamp') do |request_type, header_name|
   header = Maze::Server.list_for(request_type).current[:request][header_name]
@@ -53,7 +53,7 @@ end
 
 # Checks that the Bugsnag-Integrity header is a SHA1 or simple digest
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 When('the {word} Bugsnag-Integrity header is valid') do |request_type|
   assert_true(Maze::Helper.valid_bugsnag_integrity_header(Maze::Server.list_for(request_type).current),
               'Invalid Bugsnag-Integrity header detected')

--- a/lib/features/steps/payload_steps.rb
+++ b/lib/features/steps/payload_steps.rb
@@ -4,7 +4,7 @@
 
 # Tests the payload body does not match a JSON fixture.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input fixture_path [String] Path to a JSON fixture
 Then('the {word} payload body does not match the JSON fixture in {string}') do |request_type, fixture_path|
   payload_value = Maze::Server.list_for(request_type).current[:body]
@@ -15,7 +15,7 @@ end
 
 # Test the payload body matches a JSON fixture.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input fixture_path [String] Path to a JSON fixture
 Then('the {word} payload body matches the JSON fixture in {string}') do |request_type, fixture_path|
   payload_value = Maze::Server.list_for(request_type).current[:body]
@@ -27,7 +27,7 @@ end
 
 # Test that a payload element matches a JSON fixture.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
 # @step_input fixture_path [String] Path to a JSON fixture
 Then('the {word} payload field {string} matches the JSON fixture in {string}') \
@@ -42,7 +42,7 @@ end
 
 # Tests that a request element is true.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
 Then('the {word} payload field {string} is true') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
@@ -51,7 +51,7 @@ end
 
 # Tests that a request element is false.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
 Then('the {word} payload field {string} is false') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
@@ -60,7 +60,7 @@ end
 
 # Tests that a request element is null.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
 Then('the {word} payload field {string} is null') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
@@ -69,7 +69,7 @@ end
 
 # Tests that a request element is not null.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
 Then('the {word} payload field {string} is not null') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
@@ -78,7 +78,7 @@ end
 
 # Tests that a payload element equals an integer.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
 # @step_input int_value [Integer] The value to test against
 Then('the {word} payload field {string} equals {int}') do |request_type, field_path, int_value|
@@ -87,7 +87,7 @@ end
 
 # Tests the payload field value against an environment variable.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input env_var [String] The environment variable to test against
 Then('the {word} payload field {string} equals the environment variable {string}') \
@@ -102,7 +102,7 @@ end
 
 # Tests a payload field contains a number larger than a value.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input int_value [Integer] The value to compare against
 Then('the {word} payload field {string} is greater than {int}') do |request_type, field_path, int_value|
@@ -114,7 +114,7 @@ end
 
 # Tests a payload field contains a number smaller than a value.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input int_value [Integer] The value to compare against
 Then('the {word} payload field {string} is less than {int}') do |request_type, field_path, int_value|
@@ -126,7 +126,7 @@ end
 
 # Tests a payload field equals a string.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
 Then('the {word} payload field {string} equals {string}') do |request_type, field_path, string_value|
@@ -136,7 +136,7 @@ end
 
 # Tests a payload field starts with a string.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
 Then('the {word} payload field {string} starts with {string}') do |request_type, field_path, string_value|
@@ -149,7 +149,7 @@ end
 
 # Tests a payload field ends with a string.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
 Then('the {word} payload field {string} ends with {string}') do |request_type, field_path, string_value|
@@ -162,7 +162,7 @@ end
 
 # Tests a payload field is an array with a specific element count.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload element to test
 # @step_input count [Integer] The value expected
 Then('the {word} payload field {string} is an array with {int} elements') do |request_type, field, count|
@@ -174,7 +174,7 @@ end
 
 # Tests a payload field is an array with at least one element.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload element to test
 Then('the {word} payload field {string} is a non-empty array') do |request_type, field|
   list = Maze::Server.list_for(request_type)
@@ -186,7 +186,7 @@ end
 
 # Tests a payload field matches a regex.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload element to test
 # @step_input regex [String] The regex to test against
 Then('the {word} payload field {string} matches the regex {string}') do |request_type, field, regex_string|
@@ -198,7 +198,7 @@ end
 
 # Tests a payload field is a numeric timestamp.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload element to test
 Then('the {word} payload field {string} is a parsable timestamp in seconds') do |request_type, field|
   list = Maze::Server.list_for(request_type)
@@ -214,7 +214,7 @@ end
 
 # Tests that every element in an array contains a specified key-value pair.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input key_path [String] The path to the tested array
 # @step_input element_key_path [String] The key for the expected element inside the array
 Then('each element in {word} payload field {string} has {string}') do |request_type, key_path, element_key_path|

--- a/lib/features/steps/query_parameter_steps.rb
+++ b/lib/features/steps/query_parameter_steps.rb
@@ -4,7 +4,7 @@
 
 # Tests that a query parameter matches a string.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input parameter_name [String] The parameter to test
 # @step_input parameter_value [String] The expected value
 Then('the {word} {string} query parameter equals {string}') do |request_type, parameter_name, parameter_value|
@@ -13,7 +13,7 @@ end
 
 # Tests that a query parameter is present and not null.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input parameter_name [String] The parameter to test
 Then('the {word} {string} query parameter is not null') do |request_type, parameter_name|
   assert_not_nil(Maze::Helper.parse_querystring(Maze::Server.list_for(request_type).current)[parameter_name][0],
@@ -22,7 +22,7 @@ end
 
 # Tests that a query parameter is a timestamp.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input parameter_name [String] The parameter to test
 Then('the {word} {string} query parameter is a timestamp') do |request_type, parameter_name|
   param = Maze::Helper.parse_querystring(Maze::Server.list_for(request_type).current)[parameter_name][0]

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -37,7 +37,7 @@ end
 #
 # Shortcut to waiting to receive a single request of the given type
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 Then('I wait to receive a(n) {word}') do |request_type|
   step "I wait to receive 1 #{request_type}"
 end
@@ -47,7 +47,7 @@ end
 # If all expected requests are received and have the Bugsnag-Sent-At header, they
 # will be sorted by the header.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input request_count [Integer] The amount of requests expected
 Then('I wait to receive {int} {word}') do |request_count, request_type|
   list = Maze::Server.list_for(request_type)
@@ -57,7 +57,7 @@ end
 
 # Assert that the test Server hasn't received any requests - of a specific, or any, type.
 #
-# @step_input request_type [String] The type of request ('error', 'session', etc), or 'requests' to assert on all
+# @step_input request_type [String] The type of request ('error', 'session', build, etc), or 'requests' to assert on all
 #   request types.
 Then('I should receive no {word}') do |request_type|
   sleep Maze.config.receive_no_requests_wait
@@ -73,7 +73,7 @@ end
 
 # Moves to the next request
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 Then('I discard the oldest {word}') do |request_type|
   raise "No #{request_type} to discard" if Maze::Server.list_for(request_type).current.nil?
 

--- a/lib/features/steps/value_steps.rb
+++ b/lib/features/steps/value_steps.rb
@@ -4,7 +4,7 @@ require 'date'
 
 # Stores a payload value against a key for cross-request comparisons.
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to store
 # @step_input key [String] The key to store the value against
 Then('the {word} payload field {string} is stored as the value {string}') do |request_type, field, key|
@@ -15,7 +15,7 @@ end
 
 # Tests whether a payload field matches a previously stored payload value
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
 Then('the {word} payload field {string} equals the stored value {string}') do |request_type, field, key|
@@ -28,7 +28,7 @@ end
 
 # Tests whether a payload field is distinct from a previously stored payload value
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
 Then('the {word} payload field {string} does not equal the stored value {string}') do |request_type, field, key|
@@ -41,7 +41,7 @@ end
 
 # Tests whether a payload field is a number (Numeric according to Ruby)
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
 Then('the {word} payload field {string} is a number') do |request_type, field|
   list = Maze::Server.list_for request_type
@@ -51,7 +51,7 @@ end
 
 # Tests whether a payload field is an integer (Integer according to Ruby)
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
 Then('the {word} payload field {string} is an integer') do |request_type, field|
   list = Maze::Server.list_for request_type
@@ -61,7 +61,7 @@ end
 
 # Tests whether a payload field is a date (parseable as a Date, according to Ruby)
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
 Then('the {word} payload field {string} is a date') do |request_type, field|
   list = Maze::Server.list_for request_type
@@ -76,7 +76,7 @@ end
 
 # Tests whether a payload field (loosely) matches a UUID regex (/[a-fA-F0-9-]{36}/)
 #
-# @step_input request_type [String] The type of request (error, session, etc)
+# @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
 Then('the {word} payload field {string} is a UUID') do |request_type, field|
   list = Maze::Server.list_for request_type

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -146,6 +146,17 @@ After do |scenario|
         Maze::LogUtil.log_hash(Logger::Severity::INFO, request)
       end
     end
+
+    if Maze::Server.builds.empty?
+      $logger.info 'No valid builds received'
+    else
+      count = Maze::Server.builds.size_all
+      $logger.info "#{count} builds were received:"
+      Maze::Server.builds.all.each.with_index(1) do |request, number|
+        STDOUT.puts "--- Request #{number} of #{count}"
+        Maze::LogUtil.log_hash(Logger::Severity::INFO, request)
+      end
+    end
   end
 
   if Maze.config.appium_session_isolation
@@ -161,6 +172,7 @@ ensure
   # when a test fixture starts (which can be before the first Before scenario hook fires).
   Maze::Server.errors.clear
   Maze::Server.sessions.clear
+  Maze::Server.builds.clear
   Maze::Server.invalid_requests.clear
   Maze::Runner.environment.clear
   Maze::Store.values.clear

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -125,38 +125,9 @@ After do |scenario|
   # Log unprocessed requests if the scenario fails
   if scenario.failed?
     STDOUT.puts '^^^ +++'
-    if Maze::Server.sessions.empty?
-      $logger.info 'No valid sessions received'
-    else
-      count = Maze::Server.sessions.size_all
-      $logger.info "#{count} sessions were received:"
-      Maze::Server.sessions.all.each.with_index(1) do |request, number|
-        STDOUT.puts "--- Session #{number} of #{count}"
-        Maze::LogUtil.log_hash(Logger::Severity::INFO, request)
-      end
-    end
-
-    if Maze::Server.errors.empty?
-      $logger.info 'No valid errors received'
-    else
-      count = Maze::Server.errors.size_all
-      $logger.info "#{count} errors were received:"
-      Maze::Server.errors.all.each.with_index(1) do |request, number|
-        STDOUT.puts "--- Request #{number} of #{count}"
-        Maze::LogUtil.log_hash(Logger::Severity::INFO, request)
-      end
-    end
-
-    if Maze::Server.builds.empty?
-      $logger.info 'No valid builds received'
-    else
-      count = Maze::Server.builds.size_all
-      $logger.info "#{count} builds were received:"
-      Maze::Server.builds.all.each.with_index(1) do |request, number|
-        STDOUT.puts "--- Request #{number} of #{count}"
-        Maze::LogUtil.log_hash(Logger::Severity::INFO, request)
-      end
-    end
+    output_failed_requests('errors')
+    output_failed_requests('sessions')
+    output_failed_requests('builds')
   end
 
   if Maze.config.appium_session_isolation
@@ -176,6 +147,20 @@ ensure
   Maze::Server.invalid_requests.clear
   Maze::Runner.environment.clear
   Maze::Store.values.clear
+end
+
+def output_failed_requests(request_type)
+  request_queue = Maze::Server.list_for(request_type)
+  if request_queue.empty?
+    $logger.info "No valid #{request_type} received"
+  else
+    count = request_queue.size_all
+    $logger.info "#{count} #{request_type} were received:"
+    request_queue.all.each.with_index(1) do |request, number|
+      STDOUT.puts "--- #{request_type} #{number} of #{count}"
+      Maze::LogUtil.log_hash(Logger::Severity::INFO, request)
+    end
+  end
 end
 
 # Check for invalid requests after each scenario.  This is its own hook as failing a scenario raises an exception

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -125,9 +125,9 @@ After do |scenario|
   # Log unprocessed requests if the scenario fails
   if scenario.failed?
     STDOUT.puts '^^^ +++'
-    output_failed_requests('errors')
-    output_failed_requests('sessions')
-    output_failed_requests('builds')
+    output_received_requests('errors')
+    output_received_requests('sessions')
+    output_received_requests('builds')
   end
 
   if Maze.config.appium_session_isolation
@@ -149,7 +149,7 @@ ensure
   Maze::Store.values.clear
 end
 
-def output_failed_requests(request_type)
+def output_received_requests(request_type)
   request_queue = Maze::Server.list_for(request_type)
   if request_queue.empty?
     $logger.info "No valid #{request_type} received"

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -45,7 +45,7 @@ module Maze
     # Time in seconds to wait in the `I should receive no requests` step
     attr_accessor :receive_no_requests_wait
 
-    # Maximum time in seconds to wait in the `I wait to receive {int} error(s)/session(s)` steps
+    # Maximum time in seconds to wait in the `I wait to receive {int} error(s)/session(s)/build(s)` steps
     attr_accessor :receive_requests_wait
 
     # Whether presence of the Bugsnag-Integrity header should be enforced

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -45,6 +45,8 @@ module Maze
           errors
         when 'session', 'sessions'
           sessions
+        when 'build', 'builds'
+          builds
         else
           raise "Invalid request type '#{type}'"
         end
@@ -62,6 +64,13 @@ module Maze
       # @return [RequestList] Received error requests
       def sessions
         @sessions ||= RequestList.new
+      end
+
+      # A list of build requests received
+      #
+      # @return [RequestList] Received build requests
+      def builds
+        @builds ||= RequestList.new
       end
 
       # Whether the server thread is running
@@ -105,6 +114,7 @@ module Maze
             # When adding more endpoints, be sure to update the 'I should receive no requests' step
             server.mount '/notify', Servlet, errors
             server.mount '/sessions', Servlet, sessions
+            server.mount '/builds', Servlet, builds
             server.start
           rescue StandardError => e
             $logger.warn "Failed to start mock server: #{e.message}"

--- a/test/fixtures/payload-helpers/features/build_endpoint.feature
+++ b/test/fixtures/payload-helpers/features/build_endpoint.feature
@@ -1,0 +1,23 @@
+Feature: Build endpoint tests
+    Scenario: Build verification steps work correctly
+        When I send a "build"-type request
+        And I wait to receive a build
+        Then the build is valid for the Build API
+
+    Scenario: Android Mapping API verification works correctly
+        When I send a "build"-type request
+        And I wait to receive a build
+        Then the build is valid for the Android Mapping API
+
+    Scenario: General purpose steps work with build payloads
+        When I send a "build"-type request
+        And I wait to receive a build
+        Then the build payload field "apiKey" equals the environment variable "BUGSNAG_API_KEY"
+        And the build payload field "appVersion" equals "SEBT£"
+        And the build payload field "genesis" is true
+        And the build payload field "yes" is false
+        And the build payload field "wakeman" is null
+        And the build payload field "proguard" is not null
+        And the build payload field "albums" equals 15
+        And the build payload field "live_albums" is greater than 5
+        And the build payload field "live_albums" is less than 7

--- a/test/fixtures/payload-helpers/features/scripts/send_request.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_request.sh
@@ -7,6 +7,8 @@ require 'time'
 http = Net::HTTP.new('localhost', ENV['MOCK_API_PORT'])
 endpoint = if ENV['request_type'] == 'session'
              '/sessions'
+           elsif ENV['request_type'] == 'build'
+             '/builds'
            else
              '/notify'
            end
@@ -212,6 +214,23 @@ templates = {
       ]
     }
   },
+  'build' => {
+    'headers' => {},
+    'body' => {
+      'apiKey' => ENV['BUGSNAG_API_KEY'],
+      'appVersion' => 'SEBT£',
+      'proguard' => 'rutherford',
+      'appId' => 'banks',
+      'versionCode' => 'ABACAB',
+      'buildUUID' => 'gabriel',
+      'versionName' => 'collins',
+      'genesis' => true,
+      'yes' => false,
+      'wakeman' => nil,
+      'albums' => 15,
+      'live_albums' => 6
+    }
+  }
 }
 
 exit(1) if ENV['request_type'].nil?

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -25,7 +25,7 @@ module Maze
       # Expected HTTP server calls
       mock_http_server = mock('http')
       mock_http_server.expects(:mount_proc).once
-      mock_http_server.expects(:mount).twice
+      mock_http_server.expects(:mount).times(3)
       mock_http_server.expects(:start)
       mock_http_server.expects(:shutdown)
 
@@ -60,7 +60,7 @@ module Maze
       # Successful the second
       mock_http_server = mock('http')
       mock_http_server.expects(:mount_proc).once
-      mock_http_server.expects(:mount).twice
+      mock_http_server.expects(:mount).times(3)
       mock_http_server.expects(:start)
       mock_http_server.expects(:shutdown)
       WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,


### PR DESCRIPTION
## Goal

Allows requests to be received on `/builds` and then tested using the payload steps with `build` as the request type

## Tests

Added basic tests to the payload helper e2e test set to verify requests are received and payload steps work correctly
