### PR TITLE
Add logs endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# TBD
+# 4.6.0 - TBD
 
 ## Enhancements
 
-- Add `builds` endpoint for receiving build requests [#213](https://github.com/bugsnag/maze-runner/pull/213)
+- Adds `/logs` endpoint for receiving log messages [#212](https://github.com/bugsnag/maze-runner/pull/212)
+- Add `/builds` endpoint for receiving build requests [#213](https://github.com/bugsnag/maze-runner/pull/213)
 
 # 4.5.0 - 2021/02/01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Enhancements
 
-- Adds `/logs` endpoint for receiving log messages [#212](https://github.com/bugsnag/maze-runner/pull/212)
-- Add `/builds` endpoint for receiving build requests [#213](https://github.com/bugsnag/maze-runner/pull/213)
+- Adds `/logs` endpoint for receiving log messages [#214](https://github.com/bugsnag/maze-runner/pull/214)
+- Adds `/builds` endpoint for receiving build requests [#213](https://github.com/bugsnag/maze-runner/pull/213)
 
 # 4.5.0 - 2021/02/01
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.5.0)
+    bugsnag-maze-runner (4.6.0)
       appium_lib (~> 10.2)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -70,12 +70,14 @@ GEM
       props (>= 1.1.2)
       textutils (>= 0.10.0)
     metaclass (0.0.4)
+    mini_portile2 (2.5.0)
     minitest (5.14.3)
     mocha (1.8.0)
       metaclass (~> 0.0.1)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/lib/features/steps/log_steps.rb
+++ b/lib/features/steps/log_steps.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# @!group Log assertion steps
+
+# Tests that a log request matches a given level and message.
+#
+# @step_input log_level [String] The expected log level
+# @step_input message [String] The expected message
+Then('the {string} level log message equals {string}') do |log_level, message|
+  log = Maze::Server.logs.current[:body]
+  assert_equal(log_level, Maze::Helper.read_key_path(log, 'level'))
+  assert_equal(message, Maze::Helper.read_key_path(log, 'message'))
+end
+
+# Tests that a log request matches a given level and message regex.
+#
+# @step_input log_level [String] The expected log level
+# @step_input message_regex [String] Regex for the expected message
+Then('the {string} level log message matches the regex {string}') do |log_level, message_regex|
+  log = Maze::Server.logs.current[:body]
+  assert_equal(log_level, Maze::Helper.read_key_path(log, 'level'))
+  regex = Regexp.new(message_regex)
+  assert_match(regex, Maze::Helper.read_key_path(log, 'message'))
+end

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -144,6 +144,7 @@ ensure
   Maze::Server.errors.clear
   Maze::Server.sessions.clear
   Maze::Server.builds.clear
+  Maze::Server.logs.clear
   Maze::Server.invalid_requests.clear
   Maze::Runner.environment.clear
   Maze::Store.values.clear

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.5.0'
+  VERSION = '4.6.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -47,6 +47,8 @@ module Maze
           sessions
         when 'build', 'builds'
           builds
+        when 'log', 'logs'
+          logs
         else
           raise "Invalid request type '#{type}'"
         end
@@ -71,6 +73,13 @@ module Maze
       # @return [RequestList] Received build requests
       def builds
         @builds ||= RequestList.new
+      end
+
+      # A list of log requests received
+      #
+      # @return [RequestList] Received log requests
+      def logs
+        @logs ||= RequestList.new
       end
 
       # Whether the server thread is running
@@ -115,6 +124,7 @@ module Maze
             server.mount '/notify', Servlet, errors
             server.mount '/sessions', Servlet, sessions
             server.mount '/builds', Servlet, builds
+            server.mount '/logs', Servlet, logs
             server.start
           rescue StandardError => e
             $logger.warn "Failed to start mock server: #{e.message}"

--- a/test/fixtures/comparison/features/scripts/send_request.sh
+++ b/test/fixtures/comparison/features/scripts/send_request.sh
@@ -3,7 +3,13 @@
 require 'net/http'
 
 http = Net::HTTP.new('localhost', ENV['MOCK_API_PORT'])
-request = Net::HTTP::Post.new('/notify')
+endpoint = if ENV['request_type'].end_with? '-log'
+             '/logs'
+           else
+             '/notify'
+           end
+STDOUT.puts "sending to endpoint #{endpoint}"
+request = Net::HTTP::Post.new(endpoint)
 request['Content-Type'] = 'application/json'
 
 request.body = case ENV['request_type']
@@ -37,6 +43,10 @@ when 'ordered 2'
  '{"foo":"b", "bar":"a"}'
 when 'values'
  '{"values":{"uuid":"123e4567-e89b-12d3-a456-426614174000","number":1.23,"integer":123,"date":"2001-02-03"}}'
+when 'info-log'
+ '{"level":"INFO","message":"Today is 2021-02-03"}'
+when 'error-log'
+ '{"level":"ERROR","message":"The world is still on pause"}'
 else
   exit(1)
 end

--- a/test/fixtures/comparison/features/test_log_requests.feature
+++ b/test/fixtures/comparison/features/test_log_requests.feature
@@ -1,0 +1,9 @@
+Feature: Checks on log requests
+
+  Scenario: Checks on values of different types
+    When I send an "info-log"-type request
+    And I send an "error-log"-type request
+    And I wait to receive 2 logs
+    Then the "INFO" level log message matches the regex "^Today is \d{4}\-\d{2}\-\d{2}$"
+    And I discard the oldest log
+    Then the "ERROR" level log message equals "The world is still on pause"

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -25,7 +25,7 @@ module Maze
       # Expected HTTP server calls
       mock_http_server = mock('http')
       mock_http_server.expects(:mount_proc).once
-      mock_http_server.expects(:mount).times(3)
+      mock_http_server.expects(:mount).times(4)
       mock_http_server.expects(:start)
       mock_http_server.expects(:shutdown)
 
@@ -60,7 +60,7 @@ module Maze
       # Successful the second
       mock_http_server = mock('http')
       mock_http_server.expects(:mount_proc).once
-      mock_http_server.expects(:mount).times(3)
+      mock_http_server.expects(:mount).times(4)
       mock_http_server.expects(:start)
       mock_http_server.expects(:shutdown)
       WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,


### PR DESCRIPTION
## Goal

Provides a new endpoint on `/logs` for clients to `POST` log messages to and write assertions upon.

## Design

The new endpoint follows the existing design for multiple endpoints.  The new steps chosen for the verification of log messages make the assumption that clients will be controlled in what they choose to send, so that stepping though request one at a time (as we do with requests and sessions) is not egregious to use.

## Changeset

New endpoint with Cucumber steps.

## Tests

Verified by the addition of a new test scenario.
