### PR TITLE
Logs endpoint fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.6.1 - 2021/02/08
+
+## Fixes
+
+- Correct processing of `/logs` endpoint requests [#216](https://github.com/bugsnag/maze-runner/pull/216)
+
 # 4.6.0 - 2021/02/05
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.6.0)
+    bugsnag-maze-runner (4.6.1)
       appium_lib (~> 10.2)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -70,14 +70,12 @@ GEM
       props (>= 1.1.2)
       textutils (>= 0.10.0)
     metaclass (0.0.4)
-    mini_portile2 (2.5.0)
     minitest (5.14.3)
     mocha (1.8.0)
       metaclass (~> 0.0.1)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.1)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.1-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/lib/features/steps/log_steps.rb
+++ b/lib/features/steps/log_steps.rb
@@ -7,7 +7,9 @@
 # @step_input log_level [String] The expected log level
 # @step_input message [String] The expected message
 Then('the {string} level log message equals {string}') do |log_level, message|
-  log = Maze::Server.logs.current[:body]
+  request = Maze::Server.logs.current
+  assert_not_nil(request, 'No log message to check')
+  log = request[:body]
   assert_equal(log_level, Maze::Helper.read_key_path(log, 'level'))
   assert_equal(message, Maze::Helper.read_key_path(log, 'message'))
 end
@@ -17,7 +19,10 @@ end
 # @step_input log_level [String] The expected log level
 # @step_input message_regex [String] Regex for the expected message
 Then('the {string} level log message matches the regex {string}') do |log_level, message_regex|
-  log = Maze::Server.logs.current[:body]
+  request = Maze::Server.logs.current
+  assert_not_nil(request, 'No log message to check')
+
+  log = request[:body]
   assert_equal(log_level, Maze::Helper.read_key_path(log, 'level'))
   regex = Regexp.new(message_regex)
   assert_match(regex, Maze::Helper.read_key_path(log, 'message'))

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -128,6 +128,7 @@ After do |scenario|
     output_received_requests('errors')
     output_received_requests('sessions')
     output_received_requests('builds')
+    output_received_requests('logs')
   end
 
   if Maze.config.appium_session_isolation

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.6.0'
+  VERSION = '4.6.1'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -124,7 +124,7 @@ module Maze
             server.mount '/notify', Servlet, errors
             server.mount '/sessions', Servlet, sessions
             server.mount '/builds', Servlet, builds
-            server.mount '/logs', Servlet, logs
+            server.mount '/logs', Servlet, logs, true
             server.start
           rescue StandardError => e
             $logger.warn "Failed to start mock server: #{e.message}"

--- a/lib/maze/servlet.rb
+++ b/lib/maze/servlet.rb
@@ -7,9 +7,11 @@ module Maze
     #
     # @param server [HTTPServer] WEBrick HTTPServer
     # @param requests [RequestList] Request list to add to
-    def initialize(server, requests)
+    # @param no_check_digest [Boolean] Whether all digest checks should be disabled for the endpoint.
+    def initialize(server, requests, no_check_digest = false)
       super server
       @requests = requests
+      @no_check_digest = no_check_digest
     end
 
     # Logs an incoming GET WEBrick request.
@@ -107,6 +109,9 @@ module Maze
     # If the header is present, if the digest must be correct.  However, the header need only be present
     # if configuration says so.
     def check_digest(request)
+      # Some endpoints, e.g. /logs, should never have digest checks applied.
+      return if @no_check_digest
+
       header = request['Bugsnag-Integrity']
       if header.nil? && Maze.config.enforce_bugsnag_integrity
         raise 'Bugsnag-Integrity header must be present according to Maze.config.enforce_bugsnag_integrity'


### PR DESCRIPTION
## Goal

Corrects some issues with the new `/logs` endpoint:
- Disables `Bugsnag-Integrity` header checking for all requests on the endpoint
- Fails gracefully if log message checks are attempts before waiting to receive them
- Prints logs received at the end of any failing scenarios

## Tests

Testing using the in-development Android test fixture on branch `PLAT-5905/ndk-on-error`.  The scenarios did not pass as-is (I assume because it is still in development), but I was able to demonstrate the receipt and checking of a log message from a real test fixture.