### PR TITLE
Log links to BrowserStack build/sessions for browser runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 4.6.1 - 2021/02/08
+# 4.7.0 - 2021/02/08
+
+## Enhancements
+
+- Log BrowserStack link for browser builds [#218](https://github.com/bugsnag/maze-runner/pull/218)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.6.1)
+    bugsnag-maze-runner (4.7.0)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -28,7 +28,7 @@ GEM
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (4.3.0)
+    appium_lib_core (4.3.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.20.2)
@@ -70,14 +70,12 @@ GEM
       props (>= 1.1.2)
       textutils (>= 0.10.0)
     metaclass (0.0.4)
-    mini_portile2 (2.5.0)
     minitest (5.14.3)
     mocha (1.8.0)
       metaclass (~> 0.0.1)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.1)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.1-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -71,10 +71,14 @@ AfterConfiguration do |_cucumber_config|
     Maze.driver.start_driver unless config.appium_session_isolation
   end
 
-  if config.farm == :bs && config.bs_device
+  if config.farm == :bs && (config.bs_device || config.bs_browser)
     # Log a link to the BrowserStack session search dashboard
-    build = Maze.driver.caps[:build]
-    url = "https://app-automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"
+    build = Maze.driver.capabilities[:build]
+    url = if config.bs_device
+            "https://app-automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"
+          else
+            "https://automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"
+          end
     if ENV['BUILDKITE']
       $logger.info Maze::LogUtil.linkify url, 'BrowserStack session(s)'
     else

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.6.1'
+  VERSION = '4.7.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -1,17 +1,27 @@
+# frozen_string_literal: true
+
 require 'selenium-webdriver'
 
 module Maze
   module Driver
     # Handles browser automation fundamentals
     class Browser
+      # @!attribute [r] capabilities
+      #   @return [Hash] The capabilities used to launch the BrowserStack instance
+      attr_reader :capabilities
+
       def initialize(selenium_url, capabilities)
+        # Sets up identifiers for ease of connecting jobs
+        @capabilities = capabilities
+        @capabilities.merge! project_name_capabilities
+
         @driver = ::Selenium::WebDriver.for :remote,
                                             url: selenium_url,
-                                            desired_capabilities: capabilities
+                                            desired_capabilities: @capabilities
       end
 
       def find_element(*args)
-        @driver.find_element *args
+        @driver.find_element(*args)
       end
 
       def navigate
@@ -46,6 +56,24 @@ module Maze
         return false
       }
         JAVASCRIPT
+      end
+
+      # Determines and returns sensible project and build capabilities
+      #
+      # @return [Hash] A hash containing the 'project' and 'build' capabilities
+      def project_name_capabilities
+        # Default to values for running locally
+        project = 'local'
+        build = SecureRandom.uuid
+
+        if ENV['BUILDKITE']
+          # Project
+          project = ENV['BUILDKITE_PIPELINE_NAME']
+        end
+        {
+          project: project,
+          build: build
+        }
       end
     end
   end

--- a/test/appium_driver_test.rb
+++ b/test/appium_driver_test.rb
@@ -31,7 +31,7 @@ class AppiumDriverTest < Test::Unit::TestCase
   def test_capabilities
     start_logger_mock
     driver = Maze::Driver::Appium.new SERVER_URL, @capabilities
-    assert_equal('value', driver.caps[:key])
+    assert_equal('value', driver.capabilities[:key])
   end
 
   def test_click_element_defaults


### PR DESCRIPTION
## Goal

Logs a link to the BrowserStack build (and sessions onwards) for browser test runs.

## Design

Follows the existing pattern for Appium runs.

## Changeset

A little extra plumbing was needed in order to pass the build name (that we decide) through to BrowserStack as a capability in order to search against.

## Tests

Regression to logging for Appium runs is covered by CI.  I've tested the new feature for browser testing both locally and via a custom CI run in the `bugsnag-js-browser` pipeline.