### PR TITLE
Enable the use of regexes when testing received STDOUT lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.8.0 - TBD
+
+## Enhancements
+
+- Add steps to check interactive CLI STDOUT logs using a regex [#220](https://github.com/bugsnag/maze-runner/pull/220)
+
 # 4.7.0 - 2021/02/08
 
 ## Enhancements

--- a/test/fixtures/cli/features/CLI.feature
+++ b/test/fixtures/cli/features/CLI.feature
@@ -9,6 +9,15 @@ Feature: Interactive CLI support
     And I wait for the shell to output "AAAAA" to stdout
     Then the last interactive command exited successfully
 
+  Scenario: Supports regexes
+    Given I start a new shell
+    When I input "./features/fixtures/node_script" interactively
+    And I wait for the shell to output a match for the regex "node script" to stdout
+    Then the current stdout line contains "Repeat 5 times "
+    When I input "A" interactively
+    And I wait for the shell to output a match for the regex "A{5}" to stdout
+    Then the last interactive command exited successfully
+
   Scenario: Allows reading of errors
     Given I start a new shell
     When I input "./features/fixtures/error_script" interactively


### PR DESCRIPTION
## Goal

This enables the use of regexes in testing stdout lines, which allows flexibility in certain circumstances (and mitigates flakes where the exact message is not important).

This updates the exit code steps to use a regex as well, meaning in the event the shell prompt is present in the stdout (which appears inconsistently) we are more resilient to it.

## Tests

Added scenario testing new regex steps to current CLI feature.
