### PR TITLE
AWS SAM CLI integration for Lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# TBD
+# 4.9.0 - 2021/02/12
 
 ## Enhancements
 
 - Add additional CLI and file verification steps [#221](https://github.com/bugsnag/maze-runner/pull/221)
+- Add integration with AWS SAM CLI to test Lambda functions [#223](https://github.com/bugsnag/maze-runner/pull/223)
 
 # 4.8.0 - 2021/02/10
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.8.0)
+    bugsnag-maze-runner (4.9.0)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)

--- a/lib/features/steps/aws_sam_steps.rb
+++ b/lib/features/steps/aws_sam_steps.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require_relative '../../maze'
+require_relative '../../maze/aws/sam'
+
+# @!group AWS SAM steps
+
+# Invoke a lambda directly with 'sam invoke'
+#
+# @step_input lambda_name [String] The name of the lambda to invoke
+# @step_input directory [String] The directory to invoke the lambda in
+Given('I invoke the {string} lambda in {string}') do |lambda_name, directory|
+  Maze::Aws::Sam.invoke(directory, lambda_name)
+end
+
+# Invoke a lambda directly with 'sam invoke' and the given event
+#
+# @step_input lambda_name [String] The name of the lambda to invoke
+# @step_input directory [String] The directory to invoke the lambda in
+# @step_input event_file [String] The event file to call the lambda with
+Given('I invoke the {string} lambda in {string} with the {string} event') do |lambda_name, directory, event_file|
+  Maze::Aws::Sam.invoke(directory, lambda_name, event_file)
+end
+
+# Test the exit code of the SAM CLI process.
+#
+# @step_input expected [Integer] The expected exit code
+Then('the SAM exit code equals {int}') do |expected|
+  assert_equal(expected, Maze::Aws::Sam.last_exit_code)
+end
+
+# Test a Lambda response field equals the given string.
+#
+# @step_input key_path [String] The response element to test
+# @step_input expected [String] The string to test against
+Then('the lambda response {string} equals {string}') do |key_path, expected|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_equal(expected, actual)
+end
+
+# Test a Lambda response field equals the given integer.
+#
+# @step_input key_path [String] The response element to test
+# @step_input expected [Integer] The integer to test against
+Then('the lambda response {string} equals {int}') do |key_path, expected|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_equal(expected, actual)
+end
+
+# Test a Lambda response field is true.
+#
+# @step_input key_path [String] The response element to test
+Then('the lambda response {string} is true') do |key_path|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_true(actual)
+end
+
+# Test a Lambda response field is false.
+#
+# @step_input key_path [String] The response element to test
+Then('the lambda response {string} is false') do |key_path|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_false(actual)
+end
+
+# Test a Lambda response field is null.
+#
+# @step_input key_path [String] The response element to test
+Then('the lambda response {string} is null') do |key_path|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_nil(actual)
+end
+
+# Test a Lambda response field is not null.
+#
+# @step_input key_path [String] The response element to test
+Then('the lambda response {string} is not null') do |key_path|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_not_nil(actual)
+end
+
+# Test a Lambda response field is greater than the given integer.
+#
+# @step_input key_path [String] The response element to test
+# @step_input expected [Integer] The integer to test against
+Then('the lambda response {string} is greater than {int}') do |key_path, expected|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_operator(actual, :>, expected)
+end
+
+# Test a Lambda response field is less than the given integer.
+#
+# @step_input key_path [String] The response element to test
+# @step_input expected [Integer] The integer to test against
+Then('the lambda response {string} is less than {int}') do |key_path, expected|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_operator(actual, :<, expected)
+end
+
+# Test a Lambda response field starts with the given string.
+#
+# @step_input key_path [String] The response element to test
+# @step_input expected [String] The string to test against
+Then('the lambda response {string} starts with {string}') do |key_path, expected|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_kind_of(String, actual)
+  assert(
+    actual.start_with?(expected),
+    "Field '#{key_path}' value ('#{actual}') does not start with '#{expected}'"
+  )
+end
+
+# Test a Lambda response field ends with the given string.
+#
+# @step_input key_path [String] The response element to test
+# @step_input expected [String] The string to test against
+Then('the lambda response {string} ends with {string}') do |key_path, expected|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_kind_of(String, actual)
+  assert(
+    actual.end_with?(expected),
+    "Field '#{key_path}' value ('#{actual}') does not start with '#{expected}'"
+  )
+end
+
+# Test a Lambda response field is an array with a specific number of elements.
+#
+# @step_input key_path [String] The response element to test
+# @step_input expected [Integer] The expected number of elements
+Then('the lambda response {string} is an array with {int} element(s)') do |key_path, expected|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_kind_of(Array, actual)
+  assert_equal(expected, actual.length)
+end
+
+# Test a Lambda response field is an array with at least 1 element.
+#
+# @step_input key_path [String] The response element to test
+Then('the lambda response {string} is a non-empty array') do |key_path|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_kind_of(Array, actual)
+  assert_false(actual.empty?)
+end
+
+# Test a Lambda response field matches the given regex.
+#
+# @step_input key_path [String] The response element to test
+# @step_input expected [String] The regex to match against
+Then('the lambda response {string} matches the regex {string}') do |key_path, regex|
+  expected = Regexp.new(regex)
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_match(expected, actual)
+end

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -153,6 +153,7 @@ ensure
   Maze::Server.invalid_requests.clear
   Maze::Runner.environment.clear
   Maze::Store.values.clear
+  Maze::Aws::Sam.reset!
 end
 
 def output_received_requests(request_type)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.8.0'
+  VERSION = '4.9.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/aws/sam.rb
+++ b/lib/maze/aws/sam.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'shellwords'
+
+module Maze
+  module Aws
+    # Interacts with the AWS SAM CLI to invoke Lambda functions
+    # Note that the SAM CLI must be installed on the host machine as it does not
+    # run in a Docker container! For this reason the "start-api" command is not
+    # supported as it could easily cause port clashes and zombie processes
+    class Sam
+      class << self
+        attr_reader :last_response, :last_exit_code
+
+        # Invoke the given lambda with an optional event
+        #
+        # This happens synchronously so there is no need to wait for a response
+        #
+        # @param directory [String] The directory containing the lambda
+        # @param lambda [String] The name of the lambda to invoke
+        # @param event [String, nil] An optional event file to invoke with
+        #
+        # @return [void]
+        def invoke(directory, lambda, event = nil)
+          command = build_invoke_command(lambda, event)
+
+          output, @last_exit_code = Maze::Runner.run_command("cd #{directory} && #{command}")
+
+          @last_response = parse(output)
+        end
+
+        # Reset the last response and last exit code
+        #
+        # @return [void]
+        def reset!
+          @last_response = nil
+          @last_exit_code = nil
+        end
+
+        private
+
+        # Build the command to invoke the given lambda with the given event
+        #
+        # @param lambda [String] The name of the lambda to invoke
+        # @param event [String, nil] An optional event file to invoke with
+        #
+        # @return [String]
+        def build_invoke_command(lambda, event)
+          command = "sam local invoke #{Shellwords.escape(lambda)}"
+          command += " --event #{Shellwords.escape(event)}" unless event.nil?
+          command += " --docker-network #{Shellwords.escape(ENV['NETWORK_NAME'])}" if ENV.key?('NETWORK_NAME')
+
+          command
+        end
+
+        # The command output contains all stdout/stderr lines in an array. The
+        # Lambda response is the last line of output as JSON. The response body is
+        # also JSON, so we have to parse twice to get a Hash from the output
+        #
+        # @param output [Array<String>] The command's output as an array of lines
+        #
+        # @return [Hash]
+        def parse(output)
+          parsed_output = JSON.parse(output.last)
+
+          # Error output has no "body" of additional JSON so we can stop here
+          return parsed_output unless parsed_output.key?('body')
+
+          parsed_output['body'] = JSON.parse(parsed_output['body'])
+
+          parsed_output
+        rescue JSON::ParserError
+          raise <<~ERROR
+            Unable to parse Lambda output!
+            The likely cause is:
+              > #{output.last.chomp}
+
+            Full output:
+              > #{output.map(&:chomp).join("\n  > ")}
+          ERROR
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/aws-sam/Gemfile
+++ b/test/fixtures/aws-sam/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'bugsnag-maze-runner', path: '../../..'

--- a/test/fixtures/aws-sam/features/fixtures/node-app/events/event.json
+++ b/test/fixtures/aws-sam/features/fixtures/node-app/events/event.json
@@ -1,0 +1,62 @@
+{
+  "body": "{\"message\": \"hello world\"}",
+  "resource": "/{proxy+}",
+  "path": "/path/to/resource",
+  "httpMethod": "POST",
+  "isBase64Encoded": false,
+  "queryStringParameters": {
+    "foo": "bar"
+  },
+  "pathParameters": {
+    "proxy": "/path/to/resource"
+  },
+  "stageVariables": {
+    "baz": "qux"
+  },
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/path/to/resource",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "POST",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/fixtures/aws-sam/features/fixtures/node-app/hello-world/app.js
+++ b/test/fixtures/aws-sam/features/fixtures/node-app/hello-world/app.js
@@ -1,0 +1,10 @@
+exports.lambdaHandler = async (event, context) => {
+    return {
+        'statusCode': 201,
+        'body': JSON.stringify({
+            message: 'ah hah',
+            event,
+            context
+        })
+    }
+}

--- a/test/fixtures/aws-sam/features/fixtures/node-app/template.yaml
+++ b/test/fixtures/aws-sam/features/fixtures/node-app/template.yaml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  node-app
+
+  Sample SAM Template for node-app
+  
+# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    Timeout: 3
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: hello-world/
+      Handler: app.lambdaHandler
+      Runtime: nodejs14.x
+      Events:
+        HelloWorld:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            Path: /hello
+            Method: get
+
+Outputs:
+  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
+  # Find out more about other implicit resources you can reference within SAM
+  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
+  HelloWorldApi:
+    Description: "API Gateway endpoint URL for Prod stage for Hello World function"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+  HelloWorldFunction:
+    Description: "Hello World Lambda Function ARN"
+    Value: !GetAtt HelloWorldFunction.Arn
+  HelloWorldFunctionIamRole:
+    Description: "Implicit IAM Role created for Hello World function"
+    Value: !GetAtt HelloWorldFunctionRole.Arn

--- a/test/fixtures/aws-sam/features/fixtures/ruby-app/events/error event.json
+++ b/test/fixtures/aws-sam/features/fixtures/ruby-app/events/error event.json
@@ -1,0 +1,62 @@
+{
+  "body": "{\"message\": \"hello world\"}",
+  "resource": "/{proxy+}",
+  "path": "/path/to/resource",
+  "httpMethod": "POST",
+  "isBase64Encoded": false,
+  "queryStringParameters": {
+    "raise": "yes"
+  },
+  "pathParameters": {
+    "proxy": "/path/to/resource"
+  },
+  "stageVariables": {
+    "baz": "qux"
+  },
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/path/to/resource",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "POST",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/fixtures/aws-sam/features/fixtures/ruby-app/events/example-event.json
+++ b/test/fixtures/aws-sam/features/fixtures/ruby-app/events/example-event.json
@@ -1,0 +1,62 @@
+{
+  "body": "{\"message\": \"hello world\"}",
+  "resource": "/{proxy+}",
+  "path": "/path/to/resource",
+  "httpMethod": "POST",
+  "isBase64Encoded": false,
+  "queryStringParameters": {
+    "foo": "bar"
+  },
+  "pathParameters": {
+    "proxy": "/path/to/resource"
+  },
+  "stageVariables": {
+    "baz": "qux"
+  },
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/path/to/resource",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "POST",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/fixtures/aws-sam/features/fixtures/ruby-app/hello_world/app.rb
+++ b/test/fixtures/aws-sam/features/fixtures/ruby-app/hello_world/app.rb
@@ -1,0 +1,35 @@
+require 'json'
+
+def lambda_handler(event:, context:)
+  # Sample pure Lambda function
+
+  # Parameters
+  # ----------
+  # event: Hash, required
+  #     API Gateway Lambda Proxy Input Format
+  #     Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+
+  # context: object, required
+  #     Lambda Context runtime methods and attributes
+  #     Context doc: https://docs.aws.amazon.com/lambda/latest/dg/ruby-context.html
+
+  # Returns
+  # ------
+  # API Gateway Lambda Proxy Output Format: dict
+  #     'statusCode' and 'body' are required
+  #     # api-gateway-simple-proxy-for-lambda-output-format
+  #     Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+
+  raise "oh no" if event["queryStringParameters"] && event["queryStringParameters"]["raise"] == "yes"
+
+  {
+    statusCode: 200,
+    body: {
+      message: "Hello World!",
+      is_lambda: true,
+      is_not_lambda: false,
+      empty_array: [],
+      numbers: [1, 2, 3, 4, 5]
+    }.to_json
+  }
+end

--- a/test/fixtures/aws-sam/features/fixtures/ruby-app/template.yaml
+++ b/test/fixtures/aws-sam/features/fixtures/ruby-app/template.yaml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  ruby-app
+
+  Sample SAM Template for ruby-app
+
+# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    Timeout: 3
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: hello_world/
+      Handler: app.lambda_handler
+      Runtime: ruby2.7
+      Events:
+        HelloWorld:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            Path: /hello
+            Method: get
+
+Outputs:
+  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
+  # Find out more about other implicit resources you can reference within SAM
+  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
+  HelloWorldApi:
+    Description: "API Gateway endpoint URL for Prod stage for Hello World function"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+  HelloWorldFunction:
+    Description: "Hello World Lambda Function ARN"
+    Value: !GetAtt HelloWorldFunction.Arn
+  HelloWorldFunctionIamRole:
+    Description: "Implicit IAM Role created for Hello World function"
+    Value: !GetAtt HelloWorldFunctionRole.Arn

--- a/test/fixtures/aws-sam/features/invoke.feature
+++ b/test/fixtures/aws-sam/features/invoke.feature
@@ -1,0 +1,66 @@
+Feature: Using the AWS SAM CLI to directly invoke Lambda functions
+
+Scenario: Executing a lambda function with 'sam invoke'
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app"
+  Then the lambda response "body.message" equals "Hello World!"
+  And the lambda response "body.message" starts with "Hello"
+  And the lambda response "body.message" ends with "World!"
+  And the lambda response "body.message" matches the regex "W[d-r]{4}!$"
+  And the lambda response "body.message" is not null
+  And the lambda response "body.does.not.exist" is null
+  And the lambda response "body.is_lambda" is true
+  And the lambda response "body.is_not_lambda" is false
+  And the lambda response "body.empty_array" is an array with 0 elements
+  And the lambda response "body.numbers" is a non-empty array
+  And the lambda response "body.numbers" is an array with 5 elements
+  And the lambda response "body.numbers.0" equals 1
+  And the lambda response "body.numbers.4" equals 5
+  And the lambda response "statusCode" equals 200
+  And the lambda response "statusCode" is greater than 199
+  And the lambda response "statusCode" is less than 201
+  And the SAM exit code equals 0
+
+Scenario: Executing a lambda function with 'sam invoke' and an event
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app" with the "events/example-event.json" event
+  Then the lambda response "body.message" equals "Hello World!"
+  And the lambda response "statusCode" equals 200
+  And the SAM exit code equals 0
+
+Scenario: Executing a lambda function with 'sam invoke' that raises
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app" with the "events/error event.json" event
+  Then the lambda response "errorMessage" equals "oh no"
+  And the lambda response "errorType" is not null
+  And the lambda response "stackTrace" is an array with 1 element
+  And the lambda response "body" is null
+  And the lambda response "statusCode" is null
+  And the SAM exit code equals 0
+
+Scenario: Executing a node lambda function with 'sam invoke' and an event
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/node-app" with the "events/event.json" event
+  Then the lambda response "body.message" equals "ah hah"
+  And the lambda response "body.event.body" equals '{"message": "hello world"}'
+  And the lambda response "body.event.queryStringParameters.foo" equals "bar"
+  And the lambda response "body.event.httpMethod" equals "POST"
+  And the lambda response "body.event.headers.User-Agent" equals "Custom User Agent String"
+  And the lambda response "body.event.requestContext.identity.sourceIp" equals "127.0.0.1"
+  And the lambda response "body.context.callbackWaitsForEmptyEventLoop" is true
+  And the lambda response "statusCode" equals 201
+  And the SAM exit code equals 0
+
+Scenario: Executing two lambda functions with 'sam invoke'
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app"
+  Then the lambda response "body.message" equals "Hello World!"
+  And the lambda response "body.numbers" is an array with 5 elements
+  And the lambda response "statusCode" is greater than 199
+  And the lambda response "statusCode" is less than 201
+  And the SAM exit code equals 0
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/node-app" with the "events/event.json" event
+  Then the lambda response "body.message" equals "ah hah"
+  And the lambda response "body.event.body" equals '{"message": "hello world"}'
+  And the lambda response "body.event.queryStringParameters.foo" equals "bar"
+  And the lambda response "body.event.httpMethod" equals "POST"
+  And the lambda response "body.event.headers.User-Agent" equals "Custom User Agent String"
+  And the lambda response "body.event.requestContext.identity.sourceIp" equals "127.0.0.1"
+  And the lambda response "body.context.callbackWaitsForEmptyEventLoop" is true
+  And the lambda response "statusCode" equals 201
+  And the SAM exit code equals 0

--- a/test/fixtures/aws-sam/features/support/env.rb
+++ b/test/fixtures/aws-sam/features/support/env.rb
@@ -1,0 +1,3 @@
+AfterConfiguration do
+  Maze.config.enforce_bugsnag_integrity = false
+end


### PR DESCRIPTION
## Goal

Add the ability to use AWS' SAM CLI to test notifiers running in AWS Lambda functions

This has to run on the host machine because SAM doesn't run in Docker. Therefore we only have the ability to invoke Lambda functions directly (`sam local invoke`) and do not allow running the local API (`sam local start-api`). This makes everything a lot simpler as we don't need to worry about ports clashing or zombie processes. The downside to this is that we need to write event files to change any of the request parameters

## Changeset

- New `Maze::Aws::Sam` class that can invoke Lambda functions and parse their responses
- New set of steps for invoking & asserting against Lambda functions
- Tests and fixtures that exercise the new `Sam` class and associated steps

## Tests

Tests run locally. These need a new setup to run on CI as the SAM CLI doesn't run inside Docker