### PR TITLE
Add step to set response delay on next HTTP request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Add steps to delay the response to the next received HTTP request [#224](https://github.com/bugsnag/maze-runner/pull/224)
 
+# 4.9.1 - 2021/02/15
+
+## Fixes
+
+- Only expand `--app` option when uploading to BrowserStack [#225](https://github.com/bugsnag/maze-runner/pull/225)
+
 # 4.9.0 - 2021/02/12
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 4.9.1 - 2021/02/15
+# 4.10.0 - 2021/02/16
 
-## Fixes
+## Enhancements
 
-- Only expand `--app` option when uploading to BrowserStack [#225](https://github.com/bugsnag/maze-runner/pull/225)
+- Add steps to delay the response to the next received HTTP request [#224](https://github.com/bugsnag/maze-runner/pull/224)
 
 # 4.9.0 - 2021/02/12
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.9.1)
+    bugsnag-maze-runner (4.10.0)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -18,7 +18,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.1)
+    activesupport (6.1.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -35,7 +35,7 @@ GEM
     boring (0.1.0)
     builder (3.2.4)
     childprocess (3.0.0)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     cucumber (3.1.2)
       builder (>= 2.1.2)
       cucumber-core (~> 3.2.0)
@@ -59,7 +59,7 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     gherkin (5.1.0)
-    i18n (1.8.7)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     iniparser (1.0.1)
     kramdown (2.3.0)

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -23,10 +23,18 @@ When('I set the HTTP status code for the next request to {int}') do |status_code
   Maze::Server.status_code = status_code
 end
 
+# Sets the response delay to be used for all subsequent requests
+#
+# @step_input response_delay_ms [Integer] The delay in milliseconds
+When('I set the response delay to {int} milliseconds') do |response_delay_ms|
+  Maze::Server.response_delay_ms = response_delay_ms
+end
+
 # Sets the response delay to be used for the next request
 #
-# @step_input delay [Integer] The number of milliseconds to delay the response by
+# @step_input delay [Integer] The delay in milliseconds
 When('I set the response delay for the next request to {int} milliseconds') do |delay|
+  Maze::Server.reset_response_delay = true
   Maze::Server.response_delay_ms = delay
 end
 

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -25,9 +25,9 @@ end
 
 # Sets the response delay to be used for the next request
 #
-# @step_input status_code [Integer] The status code to return
+# @step_input delay [Integer] The number of milliseconds to delay the response by
 When('I set the response delay for the next request to {int} milliseconds') do |delay|
-  Maze::Server.response_delay = delay
+  Maze::Server.response_delay_ms = delay
 end
 
 # Attempts to open a URL.

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -23,6 +23,13 @@ When('I set the HTTP status code for the next request to {int}') do |status_code
   Maze::Server.status_code = status_code
 end
 
+# Sets the response delay to be used for the next request
+#
+# @step_input status_code [Integer] The status code to return
+When('I set the response delay for the next request to {int} milliseconds') do |delay|
+  Maze::Server.response_delay = delay
+end
+
 # Attempts to open a URL.
 #
 # @step_input url [String] The URL to open.

--- a/lib/features/steps/payload_steps.rb
+++ b/lib/features/steps/payload_steps.rb
@@ -109,7 +109,7 @@ Then('the {word} payload field {string} is greater than {int}') do |request_type
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
   assert_kind_of Integer, value
-  assert(value > int_value, "The payload field '#{field_path}' is not greater than '#{int_value}'")
+  assert(value > int_value, "The payload field '#{field_path}' (#{value}) is not greater than '#{int_value}'")
 end
 
 # Tests a payload field contains a number smaller than a value.

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -36,6 +36,14 @@ When('I run the script {string} synchronously') do |script_path|
   Maze::Runner.run_script(script_path, blocking: true)
 end
 
+# Runs a script with a given interpreter, blocking until it returns.
+#
+# @step_input interpreter [String] The interpreter to use, e.g. 'ruby'
+# @step_input script_path [String] Path to the script to be run
+When('I run the {word} script {string} synchronously') do |interpreter, script_path|
+  Maze::Runner.run_interpreter(interpreter, script_path, blocking: true)
+end
+
 # Runs a script.
 #
 # @step_input script_path [String] Path to the script to be run

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -38,10 +38,10 @@ end
 
 # Runs a script with a given interpreter, blocking until it returns.
 #
-# @step_input interpreter [String] The interpreter to use, e.g. 'ruby'
 # @step_input script_path [String] Path to the script to be run
-When('I run the {word} script {string} synchronously') do |interpreter, script_path|
-  Maze::Runner.run_interpreter(interpreter, script_path, blocking: true)
+# @step_input command [String] The command to run the script with, e.g. 'ruby'
+When('I run the script {string} using {word} synchronously') do |script_path, command|
+  Maze::Runner.run_script(script_path, blocking: true, command: command)
 end
 
 # Runs a script.

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -112,7 +112,10 @@ After do |scenario|
   # Make sure we reset to HTTP 200 return status after each scenario
   Maze::Server.status_code = 200
   Maze::Server.reset_status_code = false
+
+  # Similarly for the response delay
   Maze::Server.response_delay_ms = 0
+  Maze::Server.reset_response_delay = false
 
   # This is here to stop sessions from one test hitting another.
   # However this does mean that tests take longer.

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -112,6 +112,7 @@ After do |scenario|
   # Make sure we reset to HTTP 200 return status after each scenario
   Maze::Server.status_code = 200
   Maze::Server.reset_status_code = false
+  Maze::Server.response_delay = 0
 
   # This is here to stop sessions from one test hitting another.
   # However this does mean that tests take longer.

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -112,7 +112,7 @@ After do |scenario|
   # Make sure we reset to HTTP 200 return status after each scenario
   Maze::Server.status_code = 200
   Maze::Server.reset_status_code = false
-  Maze::Server.response_delay = 0
+  Maze::Server.response_delay_ms = 0
 
   # This is here to stop sessions from one test hitting another.
   # However this does mean that tests take longer.

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.9.1'
+  VERSION = '4.10.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/log_servlet.rb
+++ b/lib/maze/log_servlet.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Maze
+  # Receives log requests sent from the test fixture
+  class LogServlet < WEBrick::HTTPServlet::AbstractServlet
+    # Constructor
+    #
+    # @param server [HTTPServer] WEBrick HTTPServer
+    def initialize(server)
+      super server
+      @requests = Server.logs
+    end
+
+    # Logs and parses an incoming POST request.
+    # Parses `multipart/form-data` and `application/json` content-types.
+    # Parsed requests are added to the requests list.
+    #
+    # @param request [HTTPRequest] The incoming GET request
+    # @param response [HTTPResponse] The response to return
+    def do_POST(request, response)
+      hash = {
+        body: JSON.parse(request.body),
+        request: request
+      }
+      @requests.add(hash)
+
+      response.header['Access-Control-Allow-Origin'] = '*'
+      response.status = Server.status_code
+    rescue JSON::ParserError => e
+      msg = "Unable to parse request as JSON: #{e.message}"
+      $logger.error msg
+      Server.invalid_requests << {
+        reason: msg,
+        request: request
+      }
+    rescue StandardError => e
+      $logger.error "Invalid request: #{e.message}"
+      Server.invalid_requests << {
+        reason: e.message,
+        request: request
+      }
+    end
+
+    # Logs and returns a set of valid headers for this servlet.
+    #
+    # @param request [HTTPRequest] The incoming GET request
+    # @param response [HTTPResponse] The response to return
+    def do_OPTIONS(request, response)
+      log_request(request)
+      response.header['Access-Control-Allow-Origin'] = '*'
+      response.header['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
+      response.header['Access-Control-Allow-Headers'] = %w[Accept
+                                                           Bugsnag-Api-Key Bugsnag-Integrity
+                                                           Bugsnag-Payload-Version
+                                                           Bugsnag-Sent-At Content-Type
+                                                           Origin].join(',')
+
+      response.status = Server.status_code
+    end
+  end
+end

--- a/lib/maze/runner.rb
+++ b/lib/maze/runner.rb
@@ -61,16 +61,33 @@ module Maze
       # @return [Array] If blocking, the output and exit_status are returned
       def run_script(script_name, blocking: false, success_codes: [0])
         script_path = File.join(SCRIPT_PATH, script_name)
-        script_path = File.join(Dir.pwd, script_name) unless File.exists? script_path
+        script_path = File.join(Dir.pwd, script_name) unless File.exist? script_path
         if Gem.win_platform?
-          # windows does not support the shebang that we use in the scripts so it
+          # Windows does not support the shebang that we use in the scripts so it
           # needs to know how to execute the script. Passing `cmd /c` tells windows
-          # to use it's known file associations to execute this path. If ruby is
-          # installed on windows then it will know that `rb` files should be exceuted
-          # using ruby etc.
+          # to use its known file associations to execute this path. If Ruby is
+          # installed on Windows then it will know that `rb` files should be executed
+          # using Ruby etc.
           script_path = "cmd /c #{script_path}"
         end
         run_command(script_path, blocking: blocking, success_codes: success_codes)
+      end
+
+      # Runs a script with a given interpreter in the script directory indicated by the SCRIPT_PATH environment
+      # variable.
+      #
+      # @param script_name [String] The name of the script to run
+      # @param interpreter [String] The interpreter to use
+      # @param blocking [Boolean] Optional. Whether to wait for a return code before proceeding
+      # @param success_codes [Array] Optional. An array of integer codes which indicate the run was successful
+      #
+      # @return [Array] If blocking, the output and exit_status are returned
+      def run_interpreter(interpreter, script_name, blocking: false, success_codes: [0])
+        script_path = File.join(SCRIPT_PATH, script_name)
+        script_path = File.join(Dir.pwd, script_name) unless File.exists? script_path
+        command = "#{interpreter} #{script_path}"
+
+        run_command(command, blocking: blocking, success_codes: success_codes)
       end
 
       # Creates a new interactive session. Can only be called if no session already

--- a/lib/maze/runner.rb
+++ b/lib/maze/runner.rb
@@ -82,6 +82,7 @@ module Maze
       # @param success_codes [Array] Optional. An array of integer codes which indicate the run was successful
       #
       # @return [Array] If blocking, the output and exit_status are returned
+      # TODO: Merge this into run_script above
       def run_interpreter(interpreter, script_name, blocking: false, success_codes: [0])
         script_path = File.join(SCRIPT_PATH, script_name)
         script_path = File.join(Dir.pwd, script_name) unless File.exists? script_path

--- a/lib/maze/runner.rb
+++ b/lib/maze/runner.rb
@@ -57,12 +57,15 @@ module Maze
       # @param script_name [String] The name of the script to run
       # @param blocking [Boolean] Optional. Whether to wait for a return code before proceeding
       # @param success_codes [Array] Optional. An array of integer codes which indicate the run was successful
+      # @param command [String] Optional.  Command to run the script with, e.g. 'ruby'.
       #
       # @return [Array] If blocking, the output and exit_status are returned
-      def run_script(script_name, blocking: false, success_codes: [0])
+      def run_script(script_name, blocking: false, success_codes: [0], command: nil)
         script_path = File.join(SCRIPT_PATH, script_name)
         script_path = File.join(Dir.pwd, script_name) unless File.exist? script_path
-        if Gem.win_platform?
+        if command
+          script_path = "#{command} #{script_path}"
+        elsif Gem.win_platform?
           # Windows does not support the shebang that we use in the scripts so it
           # needs to know how to execute the script. Passing `cmd /c` tells windows
           # to use its known file associations to execute this path. If Ruby is
@@ -71,24 +74,6 @@ module Maze
           script_path = "cmd /c #{script_path}"
         end
         run_command(script_path, blocking: blocking, success_codes: success_codes)
-      end
-
-      # Runs a script with a given interpreter in the script directory indicated by the SCRIPT_PATH environment
-      # variable.
-      #
-      # @param script_name [String] The name of the script to run
-      # @param interpreter [String] The interpreter to use
-      # @param blocking [Boolean] Optional. Whether to wait for a return code before proceeding
-      # @param success_codes [Array] Optional. An array of integer codes which indicate the run was successful
-      #
-      # @return [Array] If blocking, the output and exit_status are returned
-      # TODO: Merge this into run_script above
-      def run_interpreter(interpreter, script_name, blocking: false, success_codes: [0])
-        script_path = File.join(SCRIPT_PATH, script_name)
-        script_path = File.join(Dir.pwd, script_name) unless File.exists? script_path
-        command = "#{interpreter} #{script_path}"
-
-        run_command(command, blocking: blocking, success_codes: success_codes)
       end
 
       # Creates a new interactive session. Can only be called if no session already

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -19,6 +19,9 @@ module Maze
       # Allows overwriting of the server status code
       attr_writer :status_code
 
+      # Allows a delay before responding to HTTP requests to be set
+      attr_writer :response_delay
+
       # Dictates if the status code should be reset after used
       attr_writer :reset_status_code
 
@@ -33,6 +36,10 @@ module Maze
 
       def reset_status_code
         @reset_status_code ||= false
+      end
+
+      def response_delay
+        @response_delay ||= 0
       end
 
       # Provides dynamic access to request lists by name

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -19,8 +19,8 @@ module Maze
       # Allows overwriting of the server status code
       attr_writer :status_code
 
-      # Allows a delay before responding to HTTP requests to be set
-      attr_writer :response_delay
+      # Allows a delay in milliseconds before responding to HTTP requests to be set
+      attr_writer :response_delay_ms
 
       # Dictates if the status code should be reset after used
       attr_writer :reset_status_code
@@ -38,8 +38,8 @@ module Maze
         @reset_status_code ||= false
       end
 
-      def response_delay
-        @response_delay ||= 0
+      def response_delay_ms
+        @response_delay_ms ||= 0
       end
 
       # Provides dynamic access to request lists by name

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -20,11 +20,14 @@ module Maze
       # Allows overwriting of the server status code
       attr_writer :status_code
 
+      # Dictates if the status code should be reset after use
+      attr_writer :reset_status_code
+
       # Allows a delay in milliseconds before responding to HTTP requests to be set
       attr_writer :response_delay_ms
 
-      # Dictates if the status code should be reset after used
-      attr_writer :reset_status_code
+      # Dictates if the response delay should be reset after use
+      attr_writer :reset_response_delay
 
       # The intended HTTP status code on a successful request
       #
@@ -40,7 +43,13 @@ module Maze
       end
 
       def response_delay_ms
-        @response_delay_ms ||= 0
+        delay = @response_delay_ms ||= 0
+        @response_delay_ms = 0 if reset_response_delay
+        delay
+      end
+
+      def reset_response_delay
+        @reset_response_delay ||= false
       end
 
       # Provides dynamic access to request lists by name

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -3,6 +3,7 @@
 require 'json'
 require 'webrick'
 require_relative './servlet'
+require_relative './log_servlet'
 require_relative './logger'
 require_relative './request_list'
 
@@ -131,7 +132,7 @@ module Maze
             server.mount '/notify', Servlet, errors
             server.mount '/sessions', Servlet, sessions
             server.mount '/builds', Servlet, builds
-            server.mount '/logs', Servlet, logs, true
+            server.mount '/logs', LogServlet
             server.start
           rescue StandardError => e
             $logger.warn "Failed to start mock server: #{e.message}"

--- a/lib/maze/servlet.rb
+++ b/lib/maze/servlet.rb
@@ -50,6 +50,13 @@ module Maze
         }
       end
       @requests.add(hash)
+
+      # For the response, delaying if configured to do so
+      if Server.response_delay.positive?
+        $logger.info "Waiting #{Server.response_delay} milliseconds before responding"
+        sleep Server.response_delay / 1000.0
+        Server.response_delay = 0
+      end
       response.header['Access-Control-Allow-Origin'] = '*'
       response.status = Server.status_code
     rescue JSON::ParserError => e

--- a/lib/maze/servlet.rb
+++ b/lib/maze/servlet.rb
@@ -7,11 +7,9 @@ module Maze
     #
     # @param server [HTTPServer] WEBrick HTTPServer
     # @param requests [RequestList] Request list to add to
-    # @param no_check_digest [Boolean] Whether all digest checks should be disabled for the endpoint.
-    def initialize(server, requests, no_check_digest = false)
+    def initialize(server, requests)
       super server
       @requests = requests
-      @no_check_digest = no_check_digest
     end
 
     # Logs an incoming GET WEBrick request.
@@ -116,9 +114,6 @@ module Maze
     # If the header is present, if the digest must be correct.  However, the header need only be present
     # if configuration says so.
     def check_digest(request)
-      # Some endpoints, e.g. /logs, should never have digest checks applied.
-      return if @no_check_digest
-
       header = request['Bugsnag-Integrity']
       if header.nil? && Maze.config.enforce_bugsnag_integrity
         raise 'Bugsnag-Integrity header must be present according to Maze.config.enforce_bugsnag_integrity'

--- a/lib/maze/servlet.rb
+++ b/lib/maze/servlet.rb
@@ -52,10 +52,10 @@ module Maze
       @requests.add(hash)
 
       # For the response, delaying if configured to do so
-      if Server.response_delay.positive?
-        $logger.info "Waiting #{Server.response_delay} milliseconds before responding"
-        sleep Server.response_delay / 1000.0
-        Server.response_delay = 0
+      if Server.response_delay_ms.positive?
+        $logger.info "Waiting #{Server.response_delay_ms} milliseconds before responding"
+        sleep Server.response_delay_ms / 1000.0
+        Server.response_delay_ms = 0
       end
       response.header['Access-Control-Allow-Origin'] = '*'
       response.status = Server.status_code

--- a/lib/maze/servlet.rb
+++ b/lib/maze/servlet.rb
@@ -50,10 +50,10 @@ module Maze
       @requests.add(hash)
 
       # For the response, delaying if configured to do so
-      if Server.response_delay_ms.positive?
-        $logger.info "Waiting #{Server.response_delay_ms} milliseconds before responding"
-        sleep Server.response_delay_ms / 1000.0
-        Server.response_delay_ms = 0
+      response_delay_ms = Server.response_delay_ms
+      if response_delay_ms.positive?
+        $logger.info "Waiting #{response_delay_ms} milliseconds before responding"
+        sleep response_delay_ms / 1000.0
       end
       response.header['Access-Control-Allow-Origin'] = '*'
       response.status = Server.status_code

--- a/test/fixtures/http-response/features/scripts/send_request.rb
+++ b/test/fixtures/http-response/features/scripts/send_request.rb
@@ -20,11 +20,15 @@ second_request.body = %({
   "first_time" : #{duration.to_i}
 })
 
+before = Time.now.to_f
 second_response = http.request(second_request)
+duration = (Time.now.to_f - before) * 1000
 
 third_request = Net::HTTP::Post.new('/notify')
 third_request['Content-Type'] = 'application/json'
-
-third_request.body = "{\"second_code\": \"#{second_response.code}\"}"
+third_request.body = %({
+  "second_code": "#{second_response.code}",
+  "second_time" : #{duration.to_i}
+})
 
 http.request(third_request)

--- a/test/fixtures/http-response/features/scripts/send_request.rb
+++ b/test/fixtures/http-response/features/scripts/send_request.rb
@@ -1,5 +1,6 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
+require 'date'
 require 'net/http'
 
 http = Net::HTTP.new('localhost', '9339')
@@ -7,12 +8,17 @@ first_request = Net::HTTP::Post.new('/notify')
 first_request['Content-Type'] = 'application/json'
 first_request.body = '{"req": "first!"}'
 
+before = Time.now.to_f
 first_response = http.request(first_request)
+duration = (Time.now.to_f - before) * 1000
 
 second_request = Net::HTTP::Post.new('/notify')
 second_request['Content-Type'] = 'application/json'
 
-second_request.body = "{\"first_code\": \"#{first_response.code}\"}"
+second_request.body = %({
+  "first_code": "#{first_response.code}",
+  "first_time" : #{duration.to_i}
+})
 
 second_response = http.request(second_request)
 

--- a/test/fixtures/http-response/features/set_different_responses.feature
+++ b/test/fixtures/http-response/features/set_different_responses.feature
@@ -1,17 +1,19 @@
 Feature: Setting different response codes
 
     Scenario: Default response codes (200) are present
-        When I run the script "features/scripts/send_request.sh" synchronously
+        When I set the response delay for the next request to 5100 milliseconds
+        And I run the ruby script "features/scripts/send_request.rb" synchronously
         And I wait to receive 3 errors
         Then the error payload field "req" equals "first!"
         And I discard the oldest error
         And the error payload field "first_code" equals "200"
+        And the error payload field "first_time" is greater than 5000
         And I discard the oldest error
         And the error payload field "second_code" equals "200"
 
     Scenario: Server response code can be set for all subsequent requests (400)
         Given I set the HTTP status code to 400
-        When I run the script "features/scripts/send_request.sh" synchronously
+        When I run the ruby script "features/scripts/send_request.rb" synchronously
         And I wait to receive 3 errors
         Then the error payload field "req" equals "first!"
         And I discard the oldest error
@@ -21,7 +23,7 @@ Feature: Setting different response codes
 
     Scenario: Server response code can be set a single request (503)
         Given I set the HTTP status code for the next request to 503
-        When I run the script "features/scripts/send_request.sh" synchronously
+        When I run the ruby script "features/scripts/send_request.rb" synchronously
         And I wait to receive 3 errors
         Then the error payload field "req" equals "first!"
         And I discard the oldest error

--- a/test/fixtures/http-response/features/set_different_responses.feature
+++ b/test/fixtures/http-response/features/set_different_responses.feature
@@ -1,25 +1,29 @@
 Feature: Setting different response codes
 
     Scenario: Default response codes (200) are present
-        When I set the response delay for the next request to 5100 milliseconds
+        When I set the response delay for the next request to 3100 milliseconds
         And I run the script "features/scripts/send_request.rb" using ruby synchronously
         And I wait to receive 3 errors
         Then the error payload field "req" equals "first!"
         And I discard the oldest error
         And the error payload field "first_code" equals "200"
-        And the error payload field "first_time" is greater than 5000
+        And the error payload field "first_time" is greater than 3000
         And I discard the oldest error
         And the error payload field "second_code" equals "200"
+        And the error payload field "second_time" is less than 3000
 
-    Scenario: Server response code can be set for all subsequent requests (400)
+    Scenario: Server behaviour can be set for all subsequent requests (400)
         Given I set the HTTP status code to 400
+        And I set the response delay to 3100 milliseconds
         When I run the script "features/scripts/send_request.rb" using ruby synchronously
         And I wait to receive 3 errors
         Then the error payload field "req" equals "first!"
         And I discard the oldest error
         And the error payload field "first_code" equals "400"
+        And the error payload field "first_time" is greater than 3000
         And I discard the oldest error
         And the error payload field "second_code" equals "400"
+        And the error payload field "second_time" is greater than 3000
 
     Scenario: Server response code can be set a single request (503)
         Given I set the HTTP status code for the next request to 503

--- a/test/fixtures/http-response/features/set_different_responses.feature
+++ b/test/fixtures/http-response/features/set_different_responses.feature
@@ -2,7 +2,7 @@ Feature: Setting different response codes
 
     Scenario: Default response codes (200) are present
         When I set the response delay for the next request to 5100 milliseconds
-        And I run the ruby script "features/scripts/send_request.rb" synchronously
+        And I run the script "features/scripts/send_request.rb" using ruby synchronously
         And I wait to receive 3 errors
         Then the error payload field "req" equals "first!"
         And I discard the oldest error
@@ -13,7 +13,7 @@ Feature: Setting different response codes
 
     Scenario: Server response code can be set for all subsequent requests (400)
         Given I set the HTTP status code to 400
-        When I run the ruby script "features/scripts/send_request.rb" synchronously
+        When I run the script "features/scripts/send_request.rb" using ruby synchronously
         And I wait to receive 3 errors
         Then the error payload field "req" equals "first!"
         And I discard the oldest error
@@ -23,7 +23,7 @@ Feature: Setting different response codes
 
     Scenario: Server response code can be set a single request (503)
         Given I set the HTTP status code for the next request to 503
-        When I run the ruby script "features/scripts/send_request.rb" synchronously
+        When I run the script "features/scripts/send_request.rb" using ruby synchronously
         And I wait to receive 3 errors
         Then the error payload field "req" equals "first!"
         And I discard the oldest error


### PR DESCRIPTION
## Goal

Adds a new step to allow tests to delay responses to an HTTP request.

## Design

Takes a similar approach to the existing status code functionality.

## Changeset

I've also added a new mechanism for running scripts with an interpreter - this was purely so that I could rename the script that's run to have an `.rb` extension and benefit from the language aware facilities of my IDE.

## Tests

Covered by CI, with a new test having been added..