### PR TITLE
Only expand paths when actually uploading to BrowserStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.9.1 - 2021/02/15
+
+## Fixes
+
+- Only expand `--app` option when uploading to BrowserStack [#225](https://github.com/bugsnag/maze-runner/pull/225)
+
 # 4.9.0 - 2021/02/12
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.9.0)
+    bugsnag-maze-runner (4.9.1)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -28,7 +28,7 @@ GEM
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (4.3.1)
+    appium_lib_core (4.4.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.20.2)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.9.0'
+  VERSION = '4.9.1'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/browser_stack_utils.rb
+++ b/lib/maze/browser_stack_utils.rb
@@ -13,12 +13,13 @@ module Maze
           app_url = app
           $logger.info "Using pre-uploaded app from #{app}"
         else
-          $logger.info "Uploading app: #{app}"
+          expanded_app = Maze::Helper.expand_path(app)
+          $logger.info "Uploading app: #{expanded_app}"
 
           uri = URI('https://api-cloud.browserstack.com/app-automate/upload')
           request = Net::HTTP::Post.new(uri)
           request.basic_auth(username, access_key)
-          request.set_form({ 'file' => File.new(app, 'rb') }, 'multipart/form-data')
+          request.set_form({ 'file' => File.new(expanded_app, 'rb') }, 'multipart/form-data')
 
           res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
             http.request(request)

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -13,7 +13,7 @@ module Maze
         # @param options [Hash] Parsed command line options
         def populate(config, options)
           config.appium_session_isolation = options[Maze::Option::SEPARATE_SESSIONS]
-          config.app = Maze::Helper.expand_path(options[Maze::Option::APP])
+          config.app = options[Maze::Option::APP]
           config.resilient = options[Maze::Option::RESILIENT]
           farm = options[Maze::Option::FARM]
           config.farm = case farm

--- a/test/browser_stack_utils_test.rb
+++ b/test/browser_stack_utils_test.rb
@@ -5,6 +5,7 @@ require 'json'
 require 'open3'
 require 'test_helper'
 require_relative '../lib/maze/browser_stack_utils'
+require_relative '../lib/maze/helper'
 
 class BrowserStackUtilsTest < Test::Unit::TestCase
 
@@ -56,6 +57,7 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
     $logger.expects(:info).with("Uploading app: #{APP}").once
 
     File.expects(:new)&.with(APP, 'rb')&.returns('file')
+    Maze::Helper.expects(:expand_path).with(APP).returns(APP)
 
     post_mock = mock('request')
     post_mock.expects(:basic_auth).with(USERNAME, ACCESS_KEY)

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -14,8 +14,6 @@ class ProcessorTest < Test::Unit::TestCase
     ENV.delete('MAZE_DEVICE_FARM_ACCESS_KEY')
 
     Maze::Helper.stubs(:expand_path).with('/BrowserStackLocal').returns('/BrowserStackLocal')
-    Maze::Helper.stubs(:expand_path).with('my_app.apk').returns('my_app.apk')
-    Maze::Helper.stubs(:expand_path).with(nil).returns(nil)
   end
 
   def test_populate_bs_config_separate


### PR DESCRIPTION
## Goal

Only expand the `--app` option to a full file path (dealing with, for example, tilde use) when uploading to BrowserStack.  Avoids erroneous expansion of Mac and pre-uploaded apps. 

## Tests

Covered by unit testing.