### PR TITLE
Correct expansion of app option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.10.1 - 2021/02/16
+
+## Fixes
+
+- Only expand `--app` option when uploading to BrowserStack (complete fix) [#226](https://github.com/bugsnag/maze-runner/pull/226)
+
 # 4.10.0 - 2021/02/16
 
 ## Enhancements
@@ -8,7 +14,7 @@
 
 ## Fixes
 
-- Only expand `--app` option when uploading to BrowserStack [#225](https://github.com/bugsnag/maze-runner/pull/225)
+- Only expand `--app` option when uploading to BrowserStack (incomplete fix) [#225](https://github.com/bugsnag/maze-runner/pull/225)
 
 # 4.9.0 - 2021/02/12
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.10.0)
+    bugsnag-maze-runner (4.10.1)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -28,7 +28,7 @@ GEM
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (4.4.0)
+    appium_lib_core (4.4.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.20.2)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.10.0'
+  VERSION = '4.10.1'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/option/validator.rb
+++ b/lib/maze/option/validator.rb
@@ -54,11 +54,14 @@ module Maze
             errors << "Device type '#{bs_device}' unknown on BrowserStack.  Must be one of #{Maze::Devices::DEVICE_HASH.keys}"
           end
           # App
-          app = Maze::Helper.expand_path options[Option::APP]
+          app = options[Option::APP]
           if app.nil?
             errors << "--#{Option::APP} must be provided when running on a device"
           else
-            errors << "app file '#{app}' not found" unless app.start_with?('bs://') || File.exist?(app)
+            unless app.start_with?('bs://')
+              app = Maze::Helper.expand_path app
+              errors << "app file '#{app}' not found" unless File.exist?(app)
+            end
           end
         end
 


### PR DESCRIPTION
2nd attempt at fixing the erroneous expansion of app paths.  This affected only BrowserStack usage, which I have now tested locally with:
- A previously uploaded app `bs://` style
- A relative path
- A path starting with a tilde