### PR TITLE
Back-port of receive_requests_wait config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.9.0 - 2021/02/19
+
+## Enhancements
+
+- Back-port of `receive_requests_wait` configuration setting
+  [#227](https://github.com/bugsnag/maze-runner/pull/227)
+ 
 # 2.8.1 - 2021/02/12
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (2.8.1)
+    bugsnag-maze-runner (2.9.0)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -17,7 +17,7 @@ end
 #
 # @step_input request_count [Integer] The amount of requests expected
 Then('I wait to receive {int} request(s)') do |request_count|
-  max_attempts = 300
+  max_attempts = MazeRunner.configuration.receive_requests_wait * 10
   attempts = 0
   received = false
   until (attempts >= max_attempts) || received
@@ -25,7 +25,7 @@ Then('I wait to receive {int} request(s)') do |request_count|
     received = (Server.stored_requests.size >= request_count)
     sleep 0.1
   end
-  raise "Requests not received in 30s (received #{Server.stored_requests.size})" unless received
+  raise "Requests not received in #{Configuration.receive_requests_wait}s (received #{Server.stored_requests.size})" unless received
   assert_equal(request_count, Server.stored_requests.size, "#{Server.stored_requests.size} requests received")
 end
 

--- a/lib/features/support/configuration.rb
+++ b/lib/features/support/configuration.rb
@@ -5,8 +5,12 @@ class Configuration
 
   def initialize
     @appium_session_isolation = false
+    @receive_requests_wait = 30
   end
 
   # Whether each scenario should have its own Appium session
   attr_accessor :appium_session_isolation
+
+  # Maximum time in seconds to wait in the `I wait to receive {int} error(s)/session(s)/build(s)` steps
+  attr_accessor :receive_requests_wait
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '2.8.1'.freeze
+  VERSION = '2.9.0'.freeze
 end


### PR DESCRIPTION
## Goal

Allow notifiers (and back-ports) still using MazeRunner v2 to change the time given for requests to be received in the `I wait to receive {int} request(s)` step.

## Design

We recently found (in Android v5) that some requests can take longer than 30s to reach the Maze Runner server (in the BrowserStack environment).  We have some backports to perform on Android v4, hence the desire to backport the capability in Maze Runner.

## Tests

CI is sufficient to show that the existing functionality if not broken.  It's more time consuming to test the new functionality works with a notifier test suite, but the risk of it not doing so seems minimal.