### PR TITLE
v2 logging improvements

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,7 +42,7 @@ steps:
   - label: 'Unit tests'
     plugins:
       docker-compose#v3.3.0:
-        run: ci
+        run: unit-test
     command: 'bundle exec rake'
 
   - label: 'Comparison tests'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,6 +30,15 @@ steps:
 
   - wait
 
+  - label: 'Push Docker image for branch'
+    plugins:
+      - docker-compose#v3.3.0:
+          build: cli
+          cache-from: cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
+      - docker-compose#v3.3.0:
+          push:
+            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
+
   - label: 'Unit tests'
     plugins:
       docker-compose#v3.3.0:
@@ -58,46 +67,6 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: 'Browserstack app-automate test - Android 7.1'
-    env:
-      DEVICE_TYPE: ANDROID_7_1
-    plugins:
-      docker-compose#v3.3.0:
-        run: browserstack-app-automate
-    command: 'bundle exec bugsnag-maze-runner'
-    concurrency: 9
-    concurrency_group: 'browserstack-app'
-
-  - label: 'Browserstack app-automate test - Android 8.1'
-    env:
-      DEVICE_TYPE: ANDROID_8_1
-    plugins:
-      docker-compose#v3.3.0:
-        run: browserstack-app-automate
-    command: 'bundle exec bugsnag-maze-runner'
-    concurrency: 9
-    concurrency_group: 'browserstack-app'
-
-  - label: 'Browserstack app-automate test - Android 9'
-    env:
-      DEVICE_TYPE: ANDROID_9_0
-    plugins:
-      docker-compose#v3.3.0:
-        run: browserstack-app-automate
-    command: 'bundle exec bugsnag-maze-runner'
-    concurrency: 9
-    concurrency_group: 'browserstack-app'
-
-  - label: 'Browserstack app-automate test - Android 10'
-    env:
-      DEVICE_TYPE: ANDROID_10_0
-    plugins:
-      docker-compose#v3.3.0:
-        run: browserstack-app-automate
-    command: 'bundle exec bugsnag-maze-runner'
-    concurrency: 9
-    concurrency_group: 'browserstack-app'
-
   - label: 'Browserstack app-automate test - Android 11'
     env:
       DEVICE_TYPE: ANDROID_11_0
@@ -113,17 +82,6 @@ steps:
       docker-compose#v3.3.0:
         run: payload-helper-tests
     command: 'bundle exec bugsnag-maze-runner'
-
-  - wait
-
-  - label: 'Push Docker image for branch'
-    plugins:
-      - docker-compose#v3.3.0:
-          build: cli
-          cache-from: cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
-      - docker-compose#v3.3.0:
-          push:
-            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
 
   - wait
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 2.9.1 - 2021/02/22
+# 2.10.0 - 2021/02/22
 
-## Fixes
+## Enhancements
 
-- Correction of variable name in error message
+- Logging improvements
   [#228](https://github.com/bugsnag/maze-runner/pull/228)
 
 # 2.9.0 - 2021/02/19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Logging improvements
+- Logging improvements and port Docker image to Ubuntu
   [#228](https://github.com/bugsnag/maze-runner/pull/228)
 
 # 2.9.0 - 2021/02/19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.9.1 - 2021/02/22
+
+## Fixes
+
+- Correction of variable name in error message
+  [#228](https://github.com/bugsnag/maze-runner/pull/228)
+
 # 2.9.0 - 2021/02/19
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (2.9.0)
+    bugsnag-maze-runner (2.9.1)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (2.9.1)
+    bugsnag-maze-runner (2.10.0)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,3 +53,9 @@ services:
       context: test/fixtures/payload-helpers
       args:
         BRANCH_NAME:
+
+  unit-test:
+    build:
+      dockerfile: dockerfiles/Dockerfile.ci
+      context: .
+      target: unit-test

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,36 +1,26 @@
-FROM docker/compose:1.24.0 as compose
-FROM ruby:2.7-alpine as ci
+FROM ubuntu:20.04 as ci
 
-ENV GLIBC_VERSION 2.28-r0
+RUN apt-get update && apt-get install -y ruby-full apt-utils docker-compose wget unzip bash bundler \
+                                        # Needed by nokogiri (a dependency of appium_lib)
+                                        zlib1g libpng-dev zlibc zlib1g zlib1g-dev curl \
+                                        # Needed by curb (a dependency of Cucumber)
+                                        libcurl4 libcurl4-openssl-dev
+RUN ruby -v
 
-RUN apk add --no-cache openssl ca-certificates curl-dev libgcc build-base ruby-dev build-base libffi-dev curl
-
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-  && wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk" \
-  && apk --no-cache add "glibc-$GLIBC_VERSION.apk" \
-  && rm "glibc-$GLIBC_VERSION.apk" \
-  && wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-bin-$GLIBC_VERSION.apk" \
-  && apk --no-cache add "glibc-bin-$GLIBC_VERSION.apk" \
-  && rm "glibc-bin-$GLIBC_VERSION.apk" \
-  && wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-i18n-$GLIBC_VERSION.apk" \
-  && apk --no-cache add "glibc-i18n-$GLIBC_VERSION.apk" \
-  && rm "glibc-i18n-$GLIBC_VERSION.apk" \
-  && ln -s /lib/libz.so.1 /usr/glibc-compat/lib/ \
-  && ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib \
-  && ln -s /usr/lib/libgcc_s.so.1 /usr/glibc-compat/lib \
-  && rm /etc/apk/keys/sgerrand.rsa.pub
-
-RUN wget -q https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip \
+RUN wget -q https://storage.googleapis.com/bugsnag-public-test-dependencies/BrowserStackLocal-linux-x64.zip \
   && unzip BrowserStackLocal-linux-x64.zip \
   && rm BrowserStackLocal-linux-x64.zip
 
-COPY --from=compose /usr/local/bin/docker /usr/local/bin/docker-compose /usr/local/bin/
-
 WORKDIR /app/
 
-# We dont copy the gemfile in because this builds a gem so it needs the source
-COPY . ./
+COPY bin/ bin/
+COPY lib/ lib/
+COPY Gemfile* bugsnag-maze-runner.gemspec ./
 RUN bundle install
 
 FROM ci as cli
 ENTRYPOINT ["bundle", "exec", "maze-runner"]
+
+FROM ci as unit-test
+COPY test/ test/
+COPY Rakefile .

--- a/lib/features/hooks/hooks.rb
+++ b/lib/features/hooks/hooks.rb
@@ -42,7 +42,7 @@ After do |scenario|
     else
       $logger.info 'The following requests were received:'
       Server.stored_requests.each.with_index(1) do |request, number|
-        $logger.info "Request #{number}:"
+        STDOUT.puts "--- Request #{number}:"
         LogUtil.log_hash(Logger::Severity::INFO, request)
       end
     end

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -25,7 +25,7 @@ Then('I wait to receive {int} request(s)') do |request_count|
     received = (Server.stored_requests.size >= request_count)
     sleep 0.1
   end
-  raise "Requests not received in #{Configuration.receive_requests_wait}s (received #{Server.stored_requests.size})" unless received
+  raise "Requests not received in #{MazeRunner.configuration.receive_requests_wait}s (received #{Server.stored_requests.size})" unless received
   assert_equal(request_count, Server.stored_requests.size, "#{Server.stored_requests.size} requests received")
 end
 

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -45,14 +45,15 @@ class AppAutomateDriver < Appium::Driver
     # Sets up identifiers for ease of connecting jobs
     name_capabilities = project_name_capabilities(target_device)
 
+    build = name_capabilities[:build]
     $logger.info 'Appium driver initialised for:'
     $logger.info "    project : #{name_capabilities[:project]}"
-    $logger.info "    build   : #{name_capabilities[:build]}"
+    $logger.info "    build   : #{build}"
     $logger.info "    name    : #{name_capabilities[:name]}"
 
     url = "https://app-automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"
     if ENV['BUILDKITE']
-      $logger.info Maze::LogUtil.linkify url, 'BrowserStack session(s)'
+      $logger.info linkify(url, 'BrowserStack session(s)')
     else
       $logger.info "BrowserStack session(s): #{url}"
     end

--- a/lib/features/support/app_automate_driver.rb
+++ b/lib/features/support/app_automate_driver.rb
@@ -50,6 +50,13 @@ class AppAutomateDriver < Appium::Driver
     $logger.info "    build   : #{name_capabilities[:build]}"
     $logger.info "    name    : #{name_capabilities[:name]}"
 
+    url = "https://app-automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"
+    if ENV['BUILDKITE']
+      $logger.info Maze::LogUtil.linkify url, 'BrowserStack session(s)'
+    else
+      $logger.info "BrowserStack session(s): #{url}"
+    end
+
     @capabilities = {
       'browserstack.console': 'errors',
       'browserstack.localIdentifier': local_id,
@@ -170,6 +177,10 @@ class AppAutomateDriver < Appium::Driver
   end
 
   private
+
+  def linkify(url, text)
+    "\033]1339;url='#{url}';content='#{text}'\a"
+  end
 
   def upload_app(username, access_key, app_location)
     res = `curl -u "#{username}:#{access_key}" -X POST "#{BROWSER_STACK_APP_UPLOAD_URI}" -F "file=@#{app_location}"`

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '2.9.0'.freeze
+  VERSION = '2.9.1'.freeze
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '2.9.1'.freeze
+  VERSION = '2.10.0'.freeze
 end

--- a/test/app_automate_driver_test.rb
+++ b/test/app_automate_driver_test.rb
@@ -30,6 +30,7 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     logger_mock.expects(:info).with('You can use this url to avoid uploading the same app more than once.').once
     logger_mock.expects(:info).with('Appium driver initialised for:').once
     logger_mock.expects(:info).with('    project : local').once
+    logger_mock.expects(:info).with(regexp_matches(/BrowserStack session/))
     logger_mock.expects(:info).with(regexp_matches(/^\s{4}build\s{3}:\s\S{36}$/))
     logger_mock.expects(:info).with(regexp_matches(/^\s{4}name\s{4}:\s.+$/))
     logger_mock
@@ -348,6 +349,7 @@ class AppAutomateDriverTest < Test::Unit::TestCase
     logger_mock.expects(:info).with('    project : TEST').once
     logger_mock.expects(:info).with('    build   : 156 TEST BRANCH')
     logger_mock.expects(:info).with("    name    : #{TARGET_DEVICE} tests-05 5")
+    logger_mock.expects(:info).with(regexp_matches(/BrowserStack session/))
 
     AppAutomateDriver.any_instance.stubs(:upload_app).returns(TEST_APP_URL)
     driver = AppAutomateDriver.new(USERNAME, ACCESS_KEY, LOCAL_ID, TARGET_DEVICE, APP_LOCATION)

--- a/test/fixtures/browserstack-app/dockerfile
+++ b/test/fixtures/browserstack-app/dockerfile
@@ -22,8 +22,6 @@ RUN ./gradlew app:assembleRelease
 
 FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci AS browserstack-app-automate
 
-RUN apk add bash curl
-
 COPY . /app
 WORKDIR /app
 

--- a/test/fixtures/comparison/Dockerfile
+++ b/test/fixtures/comparison/Dockerfile
@@ -1,7 +1,5 @@
 ARG BRANCH_NAME
 FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
-RUN apk add bash curl
-
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/payload-helpers/Dockerfile
+++ b/test/fixtures/payload-helpers/Dockerfile
@@ -1,7 +1,5 @@
 ARG BRANCH_NAME
 FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
-RUN apk add bash curl
-
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/proxy/Dockerfile
+++ b/test/fixtures/proxy/Dockerfile
@@ -1,7 +1,5 @@
 ARG BRANCH_NAME
 FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
-RUN apk add bash curl
-
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
## Goal

Back-ports some logging improvements to v2, in support of Android back-ports currently being made for Unity fixes.

## Changeset

Includes the move to a Ubuntu Docker image from Alpine, which we felt improved stability (it certainly leads to a cleaner log).  I've also taken the opportunity to trim the pipeline back from unnecessarily running tests on all Android versions, and brought the pushing of the Docker image for the branch closer to the start.

## Testing

Covered by CI and I have also been running a v4 Android branch against it.