### PR TITLE
Add AWS SAM CLI tests to the pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,6 +68,14 @@ steps:
           run: docker-tests
     command: 'bundle exec maze-runner'
 
+  - label: 'AWS - SAM tests'
+    agents:
+      queue: 'opensource-mac-aws-sam'
+    command: >-
+      cd test/fixtures/aws-sam &&
+      bundle install &&
+      bundle exec maze-runner
+
   - label: 'Browserstack app-automate test - Android 6'
     depends_on: "test-images"
     plugins:


### PR DESCRIPTION
## Goal

Adds tests for the SAM CLI functionality to the pipeline.

## Design

These tests failed at first due to a permission error resulting from the Buildkite agent being configured to check files out beneath `/usr/local`, which is owned by `root`.  The agent has now been reconfigured to work beneath `/Users/admin`, avoiding the problem.

## Tests

Covered by CI.