### PR TITLE
Output Application logs when running on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Enhancements
+
+- Produce app log for `local` farm test runs
+
 # 4.10.1 - 2021/02/16
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Produce app log for `local` farm test runs
+- Produce app log for `local` farm test runs [#230](https://github.com/bugsnag/maze-runner/pull/230)
 
 # 4.10.1 - 2021/02/16
 

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -209,6 +209,7 @@ at_exit do
     Maze::AppiumServer.stop if Maze::AppiumServer.running
   when :local
     # Acquire and output the logs for the current session
-    Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze::Logger.instance.start_time}' > #{Maze.config.app}Output.log")
+    pp "Running an exit command"
+    Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze::Logger.instance.start_time}' > #{Maze.config.app}.log")
   end
 end

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -201,9 +201,14 @@ at_exit do
   # future test runs are from a clean slate.
   Maze::Docker.down_all_services
 
-  next if Maze.config.farm == :none
-
-  # Stop the Appium session and server
-  Maze.driver.driver_quit unless Maze.config.appium_session_isolation
-  Maze::AppiumServer.stop if Maze::AppiumServer.running
+  # Specific shutdown when a device farm is configured
+  case Maze.config.farm
+  when :none
+    # Stop the Appium session and server
+    Maze.driver.driver_quit unless Maze.config.appium_session_isolation
+    Maze::AppiumServer.stop if Maze::AppiumServer.running
+  when :local
+    # Acquire and output the logs for the current session
+    Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze::Logger.start_time}' > #{Maze.config.app}Output.log")
+  end
 end

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -8,6 +8,9 @@ require 'uri'
 
 AfterConfiguration do |_cucumber_config|
 
+  # Record the local server starting time
+  Maze.start_time = Time.now.strftime('%Y-%m-%d %H:%M:%S')
+
   # Start mock server
   Maze::Server.start
   config = Maze.config
@@ -202,13 +205,14 @@ at_exit do
   Maze::Docker.down_all_services
 
   # Specific shutdown when a device farm is configured
-  case Maze.config.farm
-  when :none
-    # Stop the Appium session and server
-    Maze.driver.driver_quit unless Maze.config.appium_session_isolation
-    Maze::AppiumServer.stop if Maze::AppiumServer.running
-  when :local
+  next if Maze.config.farm == :none
+
+  # Stop the Appium session and server
+  Maze.driver.driver_quit unless Maze.config.appium_session_isolation
+  Maze::AppiumServer.stop if Maze::AppiumServer.running
+
+  if Maze.config.farm == :local && Maze.config.os == 'macos'
     # Acquire and output the logs for the current session
-    Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze::Logger.instance.start_time}' > #{Maze.config.app}.log")
+    Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze.start_time}' > #{Maze.config.app}.log")
   end
 end

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -209,6 +209,6 @@ at_exit do
     Maze::AppiumServer.stop if Maze::AppiumServer.running
   when :local
     # Acquire and output the logs for the current session
-    Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze::Logger.start_time}' > #{Maze.config.app}Output.log")
+    Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze::Logger.instance.start_time}' > #{Maze.config.app}Output.log")
   end
 end

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -209,7 +209,6 @@ at_exit do
     Maze::AppiumServer.stop if Maze::AppiumServer.running
   when :local
     # Acquire and output the logs for the current session
-    pp "Running an exit command"
     Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze::Logger.instance.start_time}' > #{Maze.config.app}.log")
   end
 end

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -10,6 +10,7 @@ module Maze
 
   class << self
     attr_accessor :driver
+    attr_accessor :start_time
     def config
       @config ||= Maze::Configuration.new
     end

--- a/lib/maze/logger.rb
+++ b/lib/maze/logger.rb
@@ -2,7 +2,6 @@
 
 require 'logger'
 require 'singleton'
-require 'time'
 
 # Logger classes
 module Maze

--- a/lib/maze/logger.rb
+++ b/lib/maze/logger.rb
@@ -8,8 +8,6 @@ require 'time'
 module Maze
   # A logger, with level configured according to the environment
   class Logger < Logger
-    # @return [String] A timestamp of when the test run started, using the Logger initialization as a basis
-    attr_reader :start_time
 
     include Singleton
     def initialize
@@ -21,7 +19,6 @@ module Maze
         super(STDOUT, level: Logger::INFO)
       end
       self.datetime_format = '%Y-%m-%d %H:%M:%S'
-      @start_time = Time.now.strftime(datetime_format)
     end
   end
 

--- a/lib/maze/logger.rb
+++ b/lib/maze/logger.rb
@@ -2,11 +2,15 @@
 
 require 'logger'
 require 'singleton'
+require 'time'
 
 # Logger classes
 module Maze
   # A logger, with level configured according to the environment
   class Logger < Logger
+    # @return [String] A timestamp of when the test run started, using the Logger initialization as a basis
+    attr_reader :start_time
+
     include Singleton
     def initialize
       if ENV['VERBOSE'] || ENV['DEBUG']
@@ -17,6 +21,7 @@ module Maze
         super(STDOUT, level: Logger::INFO)
       end
       self.datetime_format = '%Y-%m-%d %H:%M:%S'
+      @start_time = Time.now.strftime(datetime_format)
     end
   end
 


### PR DESCRIPTION
## Goal

Makes Maze output a log file when testing a MacOS app with the `--farm=local` option set.

## Testing

The file and resulting upload can be seen here: https://buildkite.com/bugsnag/bugsnag-cocoa/builds/2101#575036dc-e9db-4caa-856f-e748db2d2b16/307-308