### PR TITLE
Add --bind-address and --port options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# TBD
+# 4.11.0 - 2021/03/02
 
 ## Enhancements
 
 - Produce app log for `local` farm test runs [#230](https://github.com/bugsnag/maze-runner/pull/230)
+- Add `--bind-address` and `--port` options [#231](https://github.com/bugsnag/maze-runner/pull/231)
 
 # 4.10.1 - 2021/02/16
 
@@ -432,7 +433,7 @@ Addition of HTTP version steps.
 # 1.1.0
 
 Various changes have been made since the 1.0.0 release, but no specific versioning strategy
-was employed.  This minor release encapsulates those changes and no further significant 
+was employed.  This minor release encapsulates those changes and no further significant
 changes to the v1 series is expected (v2 already exists and should be used in preference).
 
 # 1.0.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.10.1)
+    bugsnag-maze-runner (4.11.0)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -31,23 +31,25 @@ class MazeRunnerEntry
   # Removes Maze Runner specific args from the array, as these will cause Cucumber to error.
   def remove_maze_runner_args
     remove = [
-      Maze::Option::SEPARATE_SESSIONS,
-      Maze::Option::APP,
-      Maze::Option::BS_LOCAL,
-      Maze::Option::BS_DEVICE,
-      Maze::Option::BS_BROWSER,
-      Maze::Option::OS,
-      Maze::Option::OS_VERSION,
-      Maze::Option::FARM,
-      Maze::Option::USERNAME,
       Maze::Option::ACCESS_KEY,
+      Maze::Option::APPLE_TEAM_ID,
       Maze::Option::APPIUM_SERVER,
       Maze::Option::A11Y_LOCATOR,
-      Maze::Option::UDID,
-      Maze::Option::APPLE_TEAM_ID,
+      Maze::Option::APP,
+      Maze::Option::BIND_ADDRESS,
       Maze::Option::BS_APPIUM_VERSION,
+      Maze::Option::BS_BROWSER,
+      Maze::Option::BS_DEVICE,
+      Maze::Option::BS_LOCAL,
+      Maze::Option::CAPABILITIES,
+      Maze::Option::FARM,
+      Maze::Option::OS,
+      Maze::Option::OS_VERSION,
+      Maze::Option::PORT,
       Maze::Option::RESILIENT,
-      Maze::Option::CAPABILITIES
+      Maze::Option::SEPARATE_SESSIONS,
+      Maze::Option::UDID,
+      Maze::Option::USERNAME
     ]
     remove.each do |opt|
       @args.reject! { |arg| arg == "--#{opt}" || (arg.start_with? "--#{opt}=") }

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.10.1'
+  VERSION = '4.11.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -12,6 +12,16 @@ module Maze
     end
 
     #
+    # Server configuration
+    #
+
+    # Mock server bind address
+    attr_accessor :bind_address
+
+    # Mock server port
+    attr_accessor :port
+
+    #
     # Common configuration
     #
 

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -10,6 +10,8 @@ module Maze
     A11Y_LOCATOR = 'a11y-locator'
     RESILIENT = 'resilient'
     CAPABILITIES = 'capabilities'
+    BIND_ADDRESS = 'bind-address'
+    PORT = 'port'
 
     # BrowserStack-only options
     BS_LOCAL = 'bs-local'

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -23,7 +23,21 @@ module Maze
             opt :version,
                 'Display Maze Runner and Cucumber versions'
 
-            # Common options
+            text ''
+            text 'Server options:'
+
+            opt Option::BIND_ADDRESS,
+                'Mock server bind address',
+                short: :none,
+                default: '127.0.0.1'
+            opt Option::PORT,
+                'Mock server port',
+                short: :none,
+                default: 9339
+
+            text ''
+            text 'Appium options:'
+
             opt Option::SEPARATE_SESSIONS,
                 'Start a new Appium session for each scenario',
                 short: :none,
@@ -51,7 +65,9 @@ module Maze
                 short: '-c',
                 default: '{}'
 
-            # BrowserStack-only options
+            text ''
+            text 'Device farm options:'
+
             opt Option::BS_LOCAL,
                 '(BS only) Path to the BrowserStackLocal binary. MAZE_BS_LOCAL env var or "/BrowserStackLocal" by default',
                 short: :none,
@@ -77,7 +93,9 @@ module Maze
                 short: :none,
                 type: :string
 
-            # Local-only options
+            text ''
+            text 'Local device options:'
+
             opt Option::OS,
                 'OS type to use ("ios", "android")',
                 short: :none,

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -12,6 +12,8 @@ module Maze
         # @param config [Configuration] MazeRunner configuration to populate
         # @param options [Hash] Parsed command line options
         def populate(config, options)
+          config.bind_address = options[Maze::Option::BIND_ADDRESS]
+          config.port = options[Maze::Option::PORT]
           config.appium_session_isolation = options[Maze::Option::SEPARATE_SESSIONS]
           config.app = options[Maze::Option::APP]
           config.resilient = options[Maze::Option::RESILIENT]

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -11,11 +11,6 @@ module Maze
   # Receives and stores requests through a WEBrick HTTPServer
   class Server
 
-    # There are some constraints on the port from driving remote browsers on BrowserStack.
-    # E.g. the ports/ranges that Safari will access on "localhost" urls are restricted to the following:
-    #   80, 3000, 4000, 5000, 8000, 8080 or 9000-9999 [ from https://stackoverflow.com/a/28678652 ]
-    PORT = 9339
-
     class << self
       # Allows overwriting of the server status code
       attr_writer :status_code
@@ -124,7 +119,8 @@ module Maze
         loop do
           @thread = Thread.new do
             server = WEBrick::HTTPServer.new(
-              Port: PORT,
+              BindAddress: Maze.config.bind_address,
+              Port: Maze.config.port,
               Logger: $logger,
               AccessLog: []
             )

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -47,7 +47,7 @@ class ProcessorTest < Test::Unit::TestCase
   end
 
   def test_populate_local_config
-    args = %w[--farm=local --app=my_app.apk --os=ios --os-version=7.1 --apple-team-id=ABC --udid=123]
+    args = %w[--farm=local --app=my_app.apk --os=ios --os-version=7.1 --apple-team-id=ABC --udid=123 --bind-address=1.2.3.4 --port=1234]
     options = Maze::Option::Parser.parse args
     config = Maze::Configuration.new
     Maze::Option::Processor.populate config, options
@@ -58,5 +58,7 @@ class ProcessorTest < Test::Unit::TestCase
     assert_equal 7.1, config.os_version
     assert_equal 'ABC', config.apple_team_id
     assert_equal '123', config.device_id
+    assert_equal '1.2.3.4', config.bind_address
+    assert_equal 1234, config.port
   end
 end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -9,9 +9,14 @@ require_relative '../lib/maze/server'
 module Maze
   class ServerTest < Test::Unit::TestCase
 
+    BIND_ADDRESS = '1.2.3.4'
+    PORT = 1234
+
     def setup
       @logger_mock = mock('logger')
       $logger = @logger_mock
+      Maze.config.bind_address = BIND_ADDRESS
+      Maze.config.port = PORT
     end
 
     def test_start_cleanily
@@ -30,7 +35,8 @@ module Maze
       mock_http_server.expects(:shutdown)
 
       # Expected WEBrick instantiation
-      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+      WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
+                                             Port: PORT,
                                              Logger: @logger_mock,
                                              AccessLog: []).returns(mock_http_server)
 
@@ -53,7 +59,8 @@ module Maze
       Thread.expects(:new).yields.twice
 
       # Fails to start first time
-      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+      WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
+                                             Port: PORT,
                                              Logger: @logger_mock,
                                              AccessLog: []).throws('Failed to start')
 
@@ -63,7 +70,8 @@ module Maze
       mock_http_server.expects(:mount).times(4)
       mock_http_server.expects(:start)
       mock_http_server.expects(:shutdown)
-      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+      WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
+                                             Port: PORT,
                                              Logger: @logger_mock,
                                              AccessLog: []).returns(mock_http_server)
 
@@ -90,13 +98,16 @@ module Maze
       Thread.expects(:new).yields.times(3)
 
       # Fails to start every time
-      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+      WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
+                                             Port: PORT,
                                              Logger: @logger_mock,
                                              AccessLog: []).throws('Failed to start')
-      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+      WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
+                                             Port: PORT,
                                              Logger: @logger_mock,
                                              AccessLog: []).throws('Failed to start')
-      WEBrick::HTTPServer.expects(:new).with(Port: Server::PORT,
+      WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
+                                             Port: PORT,
                                              Logger: @logger_mock,
                                              AccessLog: []).throws('Failed to start')
 


### PR DESCRIPTION
## Goal

Adds options to control the bind address and port of the mock server.

## Tests

Covered by unit tests combined with manual testing to confirm that the bind address and port options take effect correctly, accessing the mock server from a separate machine.