### PR TITLE
Stop BrowserStackLocal binary at end of run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Produce app log for `local` farm test runs [#230](https://github.com/bugsnag/maze-runner/pull/230)
 - Add `--bind-address` and `--port` options [#231](https://github.com/bugsnag/maze-runner/pull/231)
 
+## Fixes
+- Stop BrowserStackLocal binary at end of run [#232](https://github.com/bugsnag/maze-runner/pull/232)
+
 # 4.10.1 - 2021/02/16
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
+# 4.11.1 - 2021/03/02
+
+## Fixes
+- Stop BrowserStackLocal binary at end of run [#232](https://github.com/bugsnag/maze-runner/pull/232)
+
 # 4.11.0 - 2021/03/02
 
 ## Enhancements
 
 - Produce app log for `local` farm test runs [#230](https://github.com/bugsnag/maze-runner/pull/230)
 - Add `--bind-address` and `--port` options [#231](https://github.com/bugsnag/maze-runner/pull/231)
-
-## Fixes
-- Stop BrowserStackLocal binary at end of run [#232](https://github.com/bugsnag/maze-runner/pull/232)
 
 # 4.10.1 - 2021/02/16
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.11.0)
+    bugsnag-maze-runner (4.11.1)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -30,29 +30,9 @@ class MazeRunnerEntry
 
   # Removes Maze Runner specific args from the array, as these will cause Cucumber to error.
   def remove_maze_runner_args
-    remove = [
-      Maze::Option::ACCESS_KEY,
-      Maze::Option::APPLE_TEAM_ID,
-      Maze::Option::APPIUM_SERVER,
-      Maze::Option::A11Y_LOCATOR,
-      Maze::Option::APP,
-      Maze::Option::BIND_ADDRESS,
-      Maze::Option::BS_APPIUM_VERSION,
-      Maze::Option::BS_BROWSER,
-      Maze::Option::BS_DEVICE,
-      Maze::Option::BS_LOCAL,
-      Maze::Option::CAPABILITIES,
-      Maze::Option::FARM,
-      Maze::Option::OS,
-      Maze::Option::OS_VERSION,
-      Maze::Option::PORT,
-      Maze::Option::RESILIENT,
-      Maze::Option::SEPARATE_SESSIONS,
-      Maze::Option::UDID,
-      Maze::Option::USERNAME
-    ]
-    remove.each do |opt|
-      @args.reject! { |arg| arg == "--#{opt}" || (arg.start_with? "--#{opt}=") }
+    Maze::Option.constants.each do |opt|
+      name = Maze::Option.const_get(opt)
+      @args.reject! { |arg| arg == "--#{name}" || (arg.start_with? "--#{name}=") }
     end
   end
 

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -214,5 +214,7 @@ at_exit do
   if Maze.config.farm == :local && Maze.config.os == 'macos'
     # Acquire and output the logs for the current session
     Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze.start_time}' > #{Maze.config.app}.log")
+  elsif Maze.config.farm == :bs
+    Maze::BrowserStackUtils.stop_local_tunnel Maze.config.bs_local
   end
 end

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.11.0'
+  VERSION = '4.11.1'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/browser_stack_utils.rb
+++ b/lib/maze/browser_stack_utils.rb
@@ -55,6 +55,13 @@ module Maze
         end
         status
       end
+
+      # Stops the local tunnel
+      # @param bs_local [String] path to the BrowserStackLocal binary
+      def stop_local_tunnel(bs_local)
+        $logger.info 'Stopping BrowserStack local tunnel'
+        Maze::Runner.run_command "#{bs_local} -d stop"
+      end
     end
   end
 end


### PR DESCRIPTION
## Goal

Prevent the BrowserStackLocal binary from loitering after a test run.

## Tests

Covered by CI and tested locally with Activity Monitor to verify that the spawned process is terminated.