### PR TITLE
Terminate BrowserStackLocal without hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.11.2 - 2021/03/03
+
+## Fixes
+- Stop BrowserStackLocal binary at end of run without hanging [#233](https://github.com/bugsnag/maze-runner/pull/233)
+
 # 4.11.1 - 2021/03/02
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.11.1)
+    bugsnag-maze-runner (4.11.2)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -215,6 +215,6 @@ at_exit do
     # Acquire and output the logs for the current session
     Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze.start_time}' > #{Maze.config.app}.log")
   elsif Maze.config.farm == :bs
-    Maze::BrowserStackUtils.stop_local_tunnel Maze.config.bs_local
+    Maze::BrowserStackUtils.stop_local_tunnel
   end
 end

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.11.1'
+  VERSION = '4.11.2'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/browser_stack_utils.rb
+++ b/lib/maze/browser_stack_utils.rb
@@ -56,14 +56,17 @@ module Maze
           @pid = JSON.parse(output)['pid']
           $logger.info "BrowserStackLocal daemon running under pid #{@pid}"
         rescue JSON::ParserError
-          $logger.warn 'Unable to parse pid from output, BrowserStackLocal will not be killed'
+          $logger.warn 'Unable to parse pid from output, BrowserStackLocal will be left to die its own death'
         end
       end
 
       # Stops the local tunnel
       def stop_local_tunnel
-        $logger.info "Stopping BrowserStack local tunnel"
-        Process.kill('TERM', @pid) if @pid
+        if @pid
+          $logger.info "Stopping BrowserStack local tunnel"
+          Process.kill('TERM', @pid)
+          @pid = nil
+        end
       rescue Errno::ESRCH
         # ignored
       end

--- a/lib/maze/browser_stack_utils.rb
+++ b/lib/maze/browser_stack_utils.rb
@@ -52,7 +52,6 @@ module Maze
 
         # Extract the pid from the output so it gets killed at the end of the run
         output = Runner.run_command(command)[0][0]
-        puts output
         begin
           @pid = JSON.parse(output)['pid']
           $logger.info "BrowserStackLocal daemon running under pid #{@pid}"

--- a/test/browser_stack_utils_test.rb
+++ b/test/browser_stack_utils_test.rb
@@ -6,6 +6,7 @@ require 'open3'
 require 'test_helper'
 require_relative '../lib/maze/browser_stack_utils'
 require_relative '../lib/maze/helper'
+require_relative '../lib/maze/runner'
 
 class BrowserStackUtilsTest < Test::Unit::TestCase
 
@@ -106,8 +107,8 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
     $logger.expects(:info).with('Starting BrowserStack local tunnel').once
 
     command_options = "-d start --key #{ACCESS_KEY} --local-identifier #{LOCAL_ID} --force-local --only-automate --force"
-    waiter = mock('Process::Waiter', value: mock('Process::Status'))
-    Open3.expects(:popen2)&.with("#{BS_LOCAL} #{command_options}")&.yields(mock('stdin'), mock('stdout'), waiter)
+    Maze::Runner.expects(:run_command)&.with("#{BS_LOCAL} #{command_options}")&.returns([['{"pid":123}']])
+    $logger.expects(:info).with('BrowserStackLocal daemon running under pid 123').once
 
     Maze::BrowserStackUtils.start_local_tunnel BS_LOCAL, LOCAL_ID, ACCESS_KEY
   end


### PR DESCRIPTION
## Goal

Terminate the BrowserStackLocal process(es) at the end of a run in a way that doesn't lead to it hanging.

## Design

Despite the `BrowserStackLocal -d stop` option being intended for CI use and testing prior to its introduction, it appears that the command can hang, causing build steps to time out.  This change takes a different approach to terminating the processes that a launched, by extracting the parent process id from the output of the `-d start` command.  Sending this the `TERM` signal also closes any children that are created.

## Tests

Tested locally to verify that the `BrowserStackLocal` processes are terminated upon exit.  This new approach should be "CI safe", in the sense that even if the processes are not terminated, the Buildkite agent will perform the clean-up admirably.  The important thing is that a hang does not occur.