### PR TITLE
Do not set explicit default for —bind-address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TDB
+
+## Fixes
+
+- Do not set explicit default for mock server bind address [#234](https://github.com/bugsnag/maze-runner/pull/234)
+
 # 4.11.3 - 2021/03/03
 
 ## Fixes

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -29,7 +29,7 @@ module Maze
             opt Option::BIND_ADDRESS,
                 'Mock server bind address',
                 short: :none,
-                default: '127.0.0.1'
+                type: :string
             opt Option::PORT,
                 'Mock server port',
                 short: :none,

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -117,13 +117,15 @@ module Maze
         $logger.info "Maze Runner v#{Maze::VERSION}"
         $logger.info 'Starting mock server'
         loop do
+
           @thread = Thread.new do
-            server = WEBrick::HTTPServer.new(
-              BindAddress: Maze.config.bind_address,
-              Port: Maze.config.port,
-              Logger: $logger,
-              AccessLog: []
-            )
+            options = {
+                Port: Maze.config.port,
+                Logger: $logger,
+                AccessLog: []
+            }
+            options[:BindAddress] = Maze.config.bind_address unless Maze.config.bind_address.nil?
+            server = WEBrick::HTTPServer.new(options)
 
             # Mount a block to respond to all requests with status:200
             server.mount_proc '/' do |_request, response|

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -61,4 +61,19 @@ class ProcessorTest < Test::Unit::TestCase
     assert_equal '1.2.3.4', config.bind_address
     assert_equal 1234, config.port
   end
+
+  def test_default_options
+    args = []
+    options = Maze::Option::Parser.parse args
+    config = Maze::Configuration.new
+    Maze::Option::Processor.populate config, options
+
+    assert_equal nil, config.bind_address
+    assert_equal 9339, config.port
+
+    assert_false config.appium_session_isolation
+    assert_equal :id, config.locator
+    assert_false config.resilient
+    assert_nil config.capabilities
+  end
 end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -15,11 +15,11 @@ module Maze
     def setup
       @logger_mock = mock('logger')
       $logger = @logger_mock
-      Maze.config.bind_address = BIND_ADDRESS
+      Maze.config.bind_address = nil
       Maze.config.port = PORT
     end
 
-    def test_start_cleanily
+    def test_start_cleanily_configured_bind_address
       # Expected logging calls
       @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
       @logger_mock.expects(:info).with('Starting mock server')
@@ -35,6 +35,7 @@ module Maze
       mock_http_server.expects(:shutdown)
 
       # Expected WEBrick instantiation
+      Maze.config.bind_address = BIND_ADDRESS
       WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
                                              Port: PORT,
                                              Logger: @logger_mock,
@@ -59,8 +60,7 @@ module Maze
       Thread.expects(:new).yields.twice
 
       # Fails to start first time
-      WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
-                                             Port: PORT,
+      WEBrick::HTTPServer.expects(:new).with(Port: PORT,
                                              Logger: @logger_mock,
                                              AccessLog: []).throws('Failed to start')
 
@@ -70,8 +70,7 @@ module Maze
       mock_http_server.expects(:mount).times(4)
       mock_http_server.expects(:start)
       mock_http_server.expects(:shutdown)
-      WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
-                                             Port: PORT,
+      WEBrick::HTTPServer.expects(:new).with(Port: PORT,
                                              Logger: @logger_mock,
                                              AccessLog: []).returns(mock_http_server)
 
@@ -98,16 +97,13 @@ module Maze
       Thread.expects(:new).yields.times(3)
 
       # Fails to start every time
-      WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
-                                             Port: PORT,
+      WEBrick::HTTPServer.expects(:new).with(Port: PORT,
                                              Logger: @logger_mock,
                                              AccessLog: []).throws('Failed to start')
-      WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
-                                             Port: PORT,
+      WEBrick::HTTPServer.expects(:new).with(Port: PORT,
                                              Logger: @logger_mock,
                                              AccessLog: []).throws('Failed to start')
-      WEBrick::HTTPServer.expects(:new).with(BindAddress: BIND_ADDRESS,
-                                             Port: PORT,
+      WEBrick::HTTPServer.expects(:new).with(Port: PORT,
                                              Logger: @logger_mock,
                                              AccessLog: []).throws('Failed to start')
 


### PR DESCRIPTION
## Goal

Do not set a default for the recently introduced `--bind-address` option, allowing `WEBrick::HTTPServer` to follow its default behaviour, which has generally served us well.

## Design

Setting a default of `127.0.0.1` when introducing the option caused some areas to regress (JS Browser and Node testing).  Making this change should remove the need to remedial configuration in those pipelines.

## Tests

Sufficiently covered by unit and e2e tests to merge to `master`.  Further testing against the JS repo will be performed before release.