### PR TITLE
Loosen requirements on Lambda responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.12.1 - 2021/03/04
+
+- Allow non-JSON bodies in Lambda responses [#237](https://github.com/bugsnag/maze-runner/pull/237)
+
 # 4.12.0 - 2021/03/04
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.12.1 - 2021/03/04
 
-- Allow non-JSON bodies in Lambda responses [#237](https://github.com/bugsnag/maze-runner/pull/237)
+- Loosen requirements on Lambda responses [#237](https://github.com/bugsnag/maze-runner/pull/237)
 
 # 4.12.0 - 2021/03/04
 

--- a/lib/features/steps/aws_sam_steps.rb
+++ b/lib/features/steps/aws_sam_steps.rb
@@ -29,6 +29,14 @@ Then('the SAM exit code equals {int}') do |expected|
   assert_equal(expected, Maze::Aws::Sam.last_exit_code)
 end
 
+# Test the Lambda response is empty but not-null. This indicates the Lambda did
+# not respond but did run successfully
+Then('the lambda response is empty') do
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  assert_equal({}, Maze::Aws::Sam.last_response)
+end
+
 # Test a Lambda response field equals the given string.
 #
 # @step_input key_path [String] The response element to test

--- a/lib/features/steps/aws_sam_steps.rb
+++ b/lib/features/steps/aws_sam_steps.rb
@@ -41,6 +41,18 @@ Then('the lambda response {string} equals {string}') do |key_path, expected|
   assert_equal(expected, actual)
 end
 
+# Test a Lambda response field contains the given string.
+#
+# @step_input key_path [String] The response element to test
+# @step_input expected [String] The string to test against
+Then('the lambda response {string} contains {string}') do |key_path, expected|
+  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+
+  actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
+
+  assert_includes(actual, expected)
+end
+
 # Test a Lambda response field equals the given integer.
 #
 # @step_input key_path [String] The response element to test

--- a/lib/maze/aws/sam.rb
+++ b/lib/maze/aws/sam.rb
@@ -91,6 +91,7 @@ module Maze
           begin
             parsed_output['body'] = JSON.parse(parsed_output['body'])
           rescue JSON::ParserError
+            # Ignore
           end
 
           parsed_output

--- a/test/fixtures/aws-sam/features/fixtures/node-app/process-exit/app.js
+++ b/test/fixtures/aws-sam/features/fixtures/node-app/process-exit/app.js
@@ -1,0 +1,3 @@
+exports.lambdaHandler = async (event, context) => {
+    process.exit(1)
+}

--- a/test/fixtures/aws-sam/features/fixtures/node-app/template.yaml
+++ b/test/fixtures/aws-sam/features/fixtures/node-app/template.yaml
@@ -4,7 +4,7 @@ Description: >
   node-app
 
   Sample SAM Template for node-app
-  
+
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
@@ -22,6 +22,19 @@ Resources:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
           Properties:
             Path: /hello
+            Method: get
+
+  ProcessExitFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: process-exit/
+      Handler: app.lambdaHandler
+      Runtime: nodejs14.x
+      Events:
+        ProcessExit:
+          Type: Api
+          Properties:
+            Path: /process-exit
             Method: get
 
 Outputs:

--- a/test/fixtures/aws-sam/features/fixtures/python-app/hello_world/app.py
+++ b/test/fixtures/aws-sam/features/fixtures/python-app/hello_world/app.py
@@ -1,0 +1,15 @@
+def lambda_handler(event, context):
+    return {
+        "statusCode": 200,
+        "body": """
+            <html>
+                <head><title>my cool page</title></head>
+
+                <body>
+                    <h1>my cool page</h1>
+
+                    <p>stuff and things</p>
+                </body>
+            </html>
+        """,
+    }

--- a/test/fixtures/aws-sam/features/fixtures/python-app/template.yaml
+++ b/test/fixtures/aws-sam/features/fixtures/python-app/template.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: python-app
+
+Globals:
+  Function:
+    Timeout: 3
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: hello_world/
+      Handler: app.lambda_handler
+      Runtime: python3.8
+      Events:
+        HelloWorld:
+          Type: Api
+          Properties:
+            Path: /hello
+            Method: get

--- a/test/fixtures/aws-sam/features/invoke.feature
+++ b/test/fixtures/aws-sam/features/invoke.feature
@@ -72,3 +72,9 @@ Scenario: Executing a lambda function that returns a HTML body
   And the lambda response "body" contains "<p>stuff and things</p>"
   And the lambda response "statusCode" equals 200
   And the SAM exit code equals 0
+
+Scenario: Executing a lambda function that does not respond
+  Given I invoke the "ProcessExitFunction" lambda in "features/fixtures/node-app"
+  Then the lambda response is empty
+  And the lambda response "body" is null
+  And the SAM exit code equals 0

--- a/test/fixtures/aws-sam/features/invoke.feature
+++ b/test/fixtures/aws-sam/features/invoke.feature
@@ -64,3 +64,11 @@ Scenario: Executing two lambda functions with 'sam invoke'
   And the lambda response "body.context.callbackWaitsForEmptyEventLoop" is true
   And the lambda response "statusCode" equals 201
   And the SAM exit code equals 0
+
+Scenario: Executing a lambda function that returns a HTML body
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/python-app"
+  Then the lambda response "body" contains "<title>my cool page</title>"
+  And the lambda response "body" contains "<h1>my cool page</h1>"
+  And the lambda response "body" contains "<p>stuff and things</p>"
+  And the lambda response "statusCode" equals 200
+  And the SAM exit code equals 0


### PR DESCRIPTION
## Goal

Currently it's impossible to test a Lambda function that returns no response or returns a response body which is not JSON

A Lambda can avoid responding by forcefully exiting; when this happens AWS return some generic JSON to the user. If we get a JSON error when parsing the last line of output, it's now assumed that there was no response. We now validate that there's an "END" marker in SAM's output so we can still provide a useful error message if something really goes wrong

The Lambda response body does not _have_ to be JSON, so we now allow non-JSON bodies without immediately failing the test. This allows testing against projects that return HTML, for example