### PR TITLE
Add an option to suppress request outputs when a failure occurs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -75,7 +75,7 @@ steps:
       cd test/fixtures/aws-sam &&
       bundle install &&
       bundle exec maze-runner
-      --no-request-output
+      --no-log-requests
 
   - label: 'Browserstack app-automate test - Android 6'
     depends_on: "test-images"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -75,6 +75,7 @@ steps:
       cd test/fixtures/aws-sam &&
       bundle install &&
       bundle exec maze-runner
+      --no-request-output
 
   - label: 'Browserstack app-automate test - Android 6'
     depends_on: "test-images"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.13.0 - 2021/03/16
 
 - Add stress-test step asserting a minimum amount of requests received [#239](https://github.com/bugsnag/maze-runner/pull/239)
+- Add option to not log received requests on a test failure [#238](https://github.com/bugsnag/maze-runner/pull/238)
 
 # 4.12.1 - 2021/03/04
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.12.0)
+    bugsnag-maze-runner (4.13.0)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -69,13 +69,11 @@ GEM
       kramdown (>= 1.5.0)
       props (>= 1.1.2)
       textutils (>= 0.10.0)
-    mini_portile2 (2.5.0)
     minitest (5.14.3)
     mocha (1.12.0)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.1)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.1-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -33,7 +33,7 @@ class MazeRunnerEntry
   def remove_maze_runner_args
     Maze::Option.constants.each do |opt|
       name = Maze::Option.const_get(opt)
-      @args.reject! { |arg| arg == "--#{name}" || (arg.start_with? "--#{name}=") }
+      @args.reject! { |arg| arg == "--#{name}" || (arg.start_with? "--#{name}=") || arg == "--no-#{name}" }
     end
   end
 

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -134,7 +134,7 @@ After do |scenario|
   Maze::Proxy.instance.stop
 
   # Log unprocessed requests if the scenario fails
-  if scenario.failed? && !Maze.config.suppress_request_output
+  if scenario.failed? && Maze.config.log_requests
     STDOUT.puts '^^^ +++'
     output_received_requests('errors')
     output_received_requests('sessions')

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -134,7 +134,7 @@ After do |scenario|
   Maze::Proxy.instance.stop
 
   # Log unprocessed requests if the scenario fails
-  if scenario.failed?
+  if scenario.failed? && !Maze.config.suppress_request_output
     STDOUT.puts '^^^ +++'
     output_received_requests('errors')
     output_received_requests('sessions')

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.12.0'
+  VERSION = '4.13.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -111,6 +111,6 @@ module Maze
     #
 
     # Suppress logging received requests during a test failure
-    attr_accessor :suppress_request_output
+    attr_accessor :log_requests
   end
 end

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -25,6 +25,19 @@ module Maze
     # Common configuration
     #
 
+    # Time in seconds to wait in the `I should receive no requests` step
+    attr_accessor :receive_no_requests_wait
+
+    # Maximum time in seconds to wait in the `I wait to receive {int} error(s)/session(s)/build(s)` steps
+    attr_accessor :receive_requests_wait
+
+    # Whether presence of the Bugsnag-Integrity header should be enforced
+    attr_accessor :enforce_bugsnag_integrity
+
+    #
+    # General appium configuration
+    #
+
     # Whether each scenario should have its own Appium session
     attr_accessor :appium_session_isolation
 
@@ -51,15 +64,6 @@ module Maze
     # :local (Using Appium Server with a local device)
     # :none (Cucumber-driven testing with no devices)
     attr_accessor :farm
-
-    # Time in seconds to wait in the `I should receive no requests` step
-    attr_accessor :receive_no_requests_wait
-
-    # Maximum time in seconds to wait in the `I wait to receive {int} error(s)/session(s)/build(s)` steps
-    attr_accessor :receive_requests_wait
-
-    # Whether presence of the Bugsnag-Integrity header should be enforced
-    attr_accessor :enforce_bugsnag_integrity
 
     #
     # BrowserStack specific configuration
@@ -101,5 +105,12 @@ module Maze
 
     # URL of the Appium server
     attr_accessor :appium_server_url
+
+    #
+    # Logging configuration
+    #
+
+    # Suppress logging received requests during a test failure
+    attr_accessor :suppress_request_output
   end
 end

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -31,6 +31,6 @@ module Maze
     UDID = 'udid'
 
     # Logging options
-    NO_REQUEST_OUTPUT = 'no-request-output'
+    LOG_REQUESTS = 'log-requests'
   end
 end

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -3,15 +3,17 @@
 # Provides the set of Maze Runner command line options
 module Maze
   module Option
-    # Common options
+    # Server options
+    BIND_ADDRESS = 'bind-address'
+    PORT = 'port'
+
+    # Appium options
     SEPARATE_SESSIONS = 'separate-sessions'
     FARM = 'farm'
     APP = 'app'
     A11Y_LOCATOR = 'a11y-locator'
     RESILIENT = 'resilient'
     CAPABILITIES = 'capabilities'
-    BIND_ADDRESS = 'bind-address'
-    PORT = 'port'
 
     # BrowserStack-only options
     BS_LOCAL = 'bs-local'
@@ -27,5 +29,8 @@ module Maze
     APPIUM_SERVER = 'appium-server'
     APPLE_TEAM_ID = 'apple-team-id'
     UDID = 'udid'
+
+    # Logging options
+    NO_REQUEST_OUTPUT = 'no-request-output'
   end
 end

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -117,6 +117,15 @@ module Maze
                 short: :none,
                 type: :string
 
+            text ''
+            text 'Logging options:'
+
+            opt Option::NO_REQUEST_OUTPUT,
+                "Don't log a list of received requests in the event of test failure",
+                short: :none,
+                type: :boolean,
+                default: false
+
             version "Maze Runner v#{Maze::VERSION} " \
                     "(Cucumber v#{Cucumber::VERSION.strip})"
             text ''

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -120,11 +120,11 @@ module Maze
             text ''
             text 'Logging options:'
 
-            opt Option::NO_REQUEST_OUTPUT,
-                "Don't log a list of received requests in the event of test failure",
+            opt Option::LOG_REQUESTS,
+                "Log a list of received requests in the event of test failure",
                 short: :none,
                 type: :boolean,
-                default: false
+                default: true
 
             version "Maze Runner v#{Maze::VERSION} " \
                     "(Cucumber v#{Cucumber::VERSION.strip})"

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -17,7 +17,7 @@ module Maze
           config.port = options[Maze::Option::PORT]
 
           # Logger options
-          config.suppress_request_output = options[Maze::Option::NO_REQUEST_OUTPUT]
+          config.log_requests = options[Maze::Option::LOG_REQUESTS]
 
           # General appium options
           config.appium_session_isolation = options[Maze::Option::SEPARATE_SESSIONS]

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -12,8 +12,14 @@ module Maze
         # @param config [Configuration] MazeRunner configuration to populate
         # @param options [Hash] Parsed command line options
         def populate(config, options)
+          # Server options
           config.bind_address = options[Maze::Option::BIND_ADDRESS]
           config.port = options[Maze::Option::PORT]
+
+          # Logger options
+          config.suppress_request_output = options[Maze::Option::NO_REQUEST_OUTPUT]
+
+          # General appium options
           config.appium_session_isolation = options[Maze::Option::SEPARATE_SESSIONS]
           config.app = options[Maze::Option::APP]
           config.resilient = options[Maze::Option::RESILIENT]

--- a/test/option/parser_test.rb
+++ b/test/option/parser_test.rb
@@ -43,7 +43,7 @@ class ParserTest < Test::Unit::TestCase
     assert_nil(options[Maze::Option::UDID])
 
     # Logging options
-    assert_false(options[Maze::Option::NO_REQUEST_OUTPUT])
+    assert_true(options[Maze::Option::LOG_REQUESTS])
   end
 
   def test_overwritten_values
@@ -65,7 +65,7 @@ class ParserTest < Test::Unit::TestCase
       --appium-server=ARG_APPIUM_SERVER
       --apple-team-id=ARG_APPLE_TEAM_ID
       --udid=ARG_UDID
-      --no-request-output
+      --no-log-requests
     ]
     options = Maze::Option::Parser.parse args
 
@@ -93,7 +93,7 @@ class ParserTest < Test::Unit::TestCase
     assert_equal('ARG_UDID', options[Maze::Option::UDID])
 
     # Logger options
-    assert_true(options[Maze::Option::NO_REQUEST_OUTPUT])
+    assert_false(options[Maze::Option::LOG_REQUESTS])
   end
 
   def test_short_flags

--- a/test/option/parser_test.rb
+++ b/test/option/parser_test.rb
@@ -41,6 +41,9 @@ class ParserTest < Test::Unit::TestCase
     assert_equal('http://localhost:4723/wd/hub', options[Maze::Option::APPIUM_SERVER])
     assert_nil(options[Maze::Option::APPLE_TEAM_ID])
     assert_nil(options[Maze::Option::UDID])
+
+    # Logging options
+    assert_false(options[Maze::Option::NO_REQUEST_OUTPUT])
   end
 
   def test_overwritten_values
@@ -62,6 +65,7 @@ class ParserTest < Test::Unit::TestCase
       --appium-server=ARG_APPIUM_SERVER
       --apple-team-id=ARG_APPLE_TEAM_ID
       --udid=ARG_UDID
+      --no-request-output
     ]
     options = Maze::Option::Parser.parse args
 
@@ -87,6 +91,9 @@ class ParserTest < Test::Unit::TestCase
     assert_equal('ARG_APPIUM_SERVER', options[Maze::Option::APPIUM_SERVER])
     assert_equal('ARG_APPLE_TEAM_ID', options[Maze::Option::APPLE_TEAM_ID])
     assert_equal('ARG_UDID', options[Maze::Option::UDID])
+
+    # Logger options
+    assert_true(options[Maze::Option::NO_REQUEST_OUTPUT])
   end
 
   def test_short_flags

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -62,6 +62,15 @@ class ProcessorTest < Test::Unit::TestCase
     assert_equal 1234, config.port
   end
 
+  def test_logger_options
+    args = %w[--no-log-requests]
+    options = Maze::Option::Parser.parse args
+    config = Maze::Configuration.new
+    Maze::Option::Processor.populate config, options
+
+    assert_false config.log_requests
+  end
+
   def test_default_options
     args = []
     options = Maze::Option::Parser.parse args
@@ -76,6 +85,6 @@ class ProcessorTest < Test::Unit::TestCase
     assert_false config.resilient
     assert_nil config.capabilities
 
-    assert_false config.suppress_request_output
+    assert_true config.log_requests
   end
 end

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -75,5 +75,7 @@ class ProcessorTest < Test::Unit::TestCase
     assert_equal :id, config.locator
     assert_false config.resilient
     assert_nil config.capabilities
+
+    assert_false config.suppress_request_output
   end
 end


### PR DESCRIPTION
## Goal

Adds the `--no-request-output` option, as well as tidying some of options into categories.
