### PR TITLE
Add a step asserting a minimum number of requests to have received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.13.0 - 2021/03/16
+
+- Add stress-test step asserting a minimum amount of requests received [#239](https://github.com/bugsnag/maze-runner/pull/239)
+
 # 4.12.1 - 2021/03/04
 
 - Loosen requirements on Lambda responses [#237](https://github.com/bugsnag/maze-runner/pull/237)

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -55,6 +55,16 @@ Then('I wait to receive {int} {word}') do |request_count, request_type|
   list.sort_by_sent_at! request_count
 end
 
+# Verify that at least a certain amount of requests have been received
+# This step is only intended for use in stress tests
+#
+# @step_input min_received [Integer] The minimum amount of requests required to pass
+# @step_input request_type [String] The type of request (error, session, build, etc)
+Then('I have received at least {int} {word} requests') do |min_received, request_type|
+  list = Maze::Server.list_for(request_type)
+  assert(list.size >= min_received, "Actually received #{list.size} #{request_type} requests")
+end
+
 # Assert that the test Server hasn't received any requests - of a specific, or any, type.
 #
 # @step_input request_type [String] The type of request ('error', 'session', build, etc), or 'requests' to assert on all

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -60,9 +60,9 @@ end
 #
 # @step_input min_received [Integer] The minimum amount of requests required to pass
 # @step_input request_type [String] The type of request (error, session, build, etc)
-Then('I have received at least {int} {word} requests') do |min_received, request_type|
+Then('I have received at least {int} {word}') do |min_received, request_type|
   list = Maze::Server.list_for(request_type)
-  assert(list.size >= min_received, "Actually received #{list.size} #{request_type} requests")
+  assert_operator(list.size, :>=, min_received, "Actually received #{list.size} #{request_type} requests")
 end
 
 # Assert that the test Server hasn't received any requests - of a specific, or any, type.


### PR DESCRIPTION
## Goal

This step should be used exclusively for stress-testing, as ensuring we don't receive excessive requests is an important criteria in our end-to-end testing.