### PR TITLE
Add environment variable for Sauce Connect binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0 - TDB
+
+- Integration with Sauce Labs device farm [#TDB](https://github.com/bugsnag/maze-runner/pull/TDB)
+
 # 4.13.0 - 2021/03/16
 
 - Add stress-test step asserting a minimum amount of requests received [#239](https://github.com/bugsnag/maze-runner/pull/239)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.13.0)
+    bugsnag-maze-runner (5.0.0)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -28,7 +28,7 @@ GEM
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (4.4.1)
+    appium_lib_core (4.5.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.20.2)
@@ -69,11 +69,13 @@ GEM
       kramdown (>= 1.5.0)
       props (>= 1.1.2)
       textutils (>= 0.10.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.3)
     mocha (1.12.0)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.2)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -120,4 +122,4 @@ DEPENDENCIES
   yard-cucumber (~> 4.0.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.13

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -51,7 +51,7 @@ AfterConfiguration do |_cucumber_config|
                                                    config.access_key,
                                                    config.app
       # Capabilities
-      Maze::SauceLabsUtils.start_sauce_connect '/sauce-connect/bin/sc',
+      Maze::SauceLabsUtils.start_sauce_connect config.sl_local,
                                                tunnel_id,
                                                config.username,
                                                config.access_key
@@ -67,9 +67,6 @@ AfterConfiguration do |_cucumber_config|
       #                                                                    tunnel_id,
       #                                                                    config.capabilities_option
     end
-    # Maze::BrowserStackUtils.start_local_tunnel config.bs_local,
-    #                                            tunnel_id,
-    #                                            config.access_key
   elsif config.farm == :local
     # Local device
     config.capabilities = Maze::Capabilities.for_local config.os,

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -15,9 +15,6 @@ AfterConfiguration do |_cucumber_config|
   Maze::Server.start
   config = Maze.config
 
-
-  puts "Farm is #{config.farm}"
-
   next if config.farm == :none
 
   # Setup Appium capabilities.  Note that the 'app' capability is

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.13.0'
+  VERSION = '5.0.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -72,6 +72,9 @@ module Maze
     # Location of the BrowserStackLocal binary (if used)
     attr_accessor :bs_local
 
+    # Location of the Sauce Connect binary (if used)
+    attr_accessor :sl_local
+
     # Farm username
     attr_accessor :username
 

--- a/lib/maze/devices.rb
+++ b/lib/maze/devices.rb
@@ -54,7 +54,8 @@ module Maze
 
       def add_sc_android_test(hash)
         hash['sl_android'] = {
-          'platformName' => 'android'
+          'platformName' => 'android',
+          'platformVersion' => '10'
         }
       end
 

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -21,7 +21,11 @@ module Maze
     BS_LOCAL = 'bs-local'
     USERNAME = 'username'
     ACCESS_KEY = 'access-key'
+    # TODO: Rename to be farm agnostic
     BS_APPIUM_VERSION = 'appium-version'
+
+    # Sauce Labs-only options
+    SL_LOCAL = 'sl-local'
 
     # Local-only options
     OS = 'os'

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -96,6 +96,12 @@ module Maze
                 short: :none,
                 type: :string
 
+            # Sauce Labs-only options
+            opt Option::SL_LOCAL,
+                '(SL only) Path to the Sauce Connect binary. MAZE_SL_LOCAL env var or "/sauce-connect/bin/sc" by default',
+                short: :none,
+                type: :string
+
             text ''
             text 'Local device options:'
 
@@ -169,6 +175,7 @@ module Maze
             options[Option::ACCESS_KEY] ||= ENV['SAUCE_LABS_ACCESS_KEY']
           end
           options[Option::BS_LOCAL] ||= ENV['MAZE_BS_LOCAL'] || '/BrowserStackLocal'
+          options[Option::SL_LOCAL] ||= ENV['MAZE_SL_LOCAL'] || '/sauce-connect/bin/sc'
           options[Option::USERNAME] ||= ENV['MAZE_DEVICE_FARM_USERNAME']
           options[Option::ACCESS_KEY] ||= ENV['MAZE_DEVICE_FARM_ACCESS_KEY']
           options[Option::APPIUM_SERVER] ||= ENV['MAZE_APPIUM_SERVER'] || 'http://localhost:4723/wd/hub'

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -57,7 +57,7 @@ module Maze
             else
               config.test_browser = options[Maze::Option::TEST_BROWSER]
             end
-            # config.bs_local = Maze::Helper.expand_path(options[Maze::Option::BS_LOCAL])
+            config.sl_local = Maze::Helper.expand_path(options[Maze::Option::SL_LOCAL])
             # config.appium_version = options[Maze::Option::BS_APPIUM_VERSION]
             username = config.username = options[Maze::Option::USERNAME]
             access_key = config.access_key = options[Maze::Option::ACCESS_KEY]

--- a/lib/maze/sauce_labs_utils.rb
+++ b/lib/maze/sauce_labs_utils.rb
@@ -64,10 +64,15 @@ module Maze
         success = wait.until { connect_shell.running? }
         raise 'Shell session did not start in time!' unless success
         command = "#{sc_local} -u #{username} -k #{access_key} -x #{endpoint} -i #{tunnel_id} -d #{SC_PID_FILE}"
+
+        # TODO Handle the case where the command fails, providing suitable diagnostics
         connect_shell.run_command command
         ready_regex = /Sauce Connect is up, you may start your tests\.$/
-        Maze::Wait.new(timeout: 30).until do
+        success = Maze::Wait.new(timeout: 30).until do
           connect_shell.stdout_lines.any? { |line| line.match?(ready_regex) }
+        end
+        unless success
+          $logger.info "Failed: #{connect_shell.stdout_lines}"
         end
       end
 

--- a/test/option/parser_test.rb
+++ b/test/option/parser_test.rb
@@ -10,6 +10,7 @@ class ParserTest < Test::Unit::TestCase
     ENV.delete('MAZE_DEVICE_FARM_USERNAME')
     ENV.delete('MAZE_DEVICE_FARM_ACCESS_KEY')
     ENV.delete('MAZE_BS_LOCAL')
+    ENV.delete('MAZE_SL_LOCAL')
     ENV.delete('MAZE_APPIUM_SERVER')
     ENV.delete('MAZE_APPLE_TEAM_ID')
     ENV.delete('MAZE_UDID')
@@ -122,6 +123,7 @@ class ParserTest < Test::Unit::TestCase
     ENV['MAZE_DEVICE_FARM_USERNAME'] = 'ENV_USERNAME'
     ENV['MAZE_DEVICE_FARM_ACCESS_KEY'] = 'ENV_ACCESS_KEY'
     ENV['MAZE_BS_LOCAL'] = 'ENV_BS_LOCAL'
+    ENV['MAZE_SL_LOCAL'] = 'ENV_SL_LOCAL'
     ENV['MAZE_APPIUM_SERVER'] = 'ENV_APPIUM_SERVER'
     ENV['MAZE_APPLE_TEAM_ID'] = 'ENV_TEAM_ID'
     ENV['MAZE_UDID'] = 'ENV_UDID'

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -10,6 +10,7 @@ require_relative '../../lib/maze/helper'
 class ProcessorTest < Test::Unit::TestCase
   def setup
     ENV.delete('MAZE_BS_LOCAL')
+    ENV.delete('MAZE_SL_LOCAL')
     ENV.delete('MAZE_DEVICE_FARM_USERNAME')
     ENV.delete('MAZE_DEVICE_FARM_ACCESS_KEY')
 

--- a/test/option/validator_test.rb
+++ b/test/option/validator_test.rb
@@ -12,6 +12,7 @@ class ValidatorTest < Test::Unit::TestCase
     @validator = Maze::Option::Validator.new
     # Prevent environment confusing tests
     ENV.delete('MAZE_BS_LOCAL')
+    ENV.delete('MAZE_SL_LOCAL')
     ENV.delete('MAZE_DEVICE_FARM_USERNAME')
     ENV.delete('MAZE_DEVICE_FARM_ACCESS_KEY')
     ENV.delete('MAZE_APPLE_TEAM_ID')

--- a/test/option/validator_test.rb
+++ b/test/option/validator_test.rb
@@ -49,7 +49,6 @@ class ValidatorTest < Test::Unit::TestCase
     options = Maze::Option::Parser.parse args
     errors = @validator.validate options
 
-    puts errors
     assert_equal 1, errors.length
     assert_match 'Device type \'MADE_UP\' unknown on BrowserStack.  Must be one of', errors[0]
   end
@@ -62,7 +61,6 @@ class ValidatorTest < Test::Unit::TestCase
     options = Maze::Option::Parser.parse args
     errors = @validator.validate options
 
-    puts errors
     assert_equal 1, errors.length
     assert_match 'Browser type \'MADE_UP\' unknown on BrowserStack.  Must be one of', errors[0]
   end


### PR DESCRIPTION
## Goal

Adds an environment variable for the Sauce Connect binary, following the established pattern for `BrowserStackLocal`.

## Changeset

Also a few minor tidy-ups and TODOs added for later implementation.

## Tests

Covered by CI and with these changes in place I am able to successfully run the handled smoke test scenarios in bugsnag-android locally.