### PR TITLE
Updates for Appium 1.20 with Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # 5.0.0 - TDB
 
 - Integration with Sauce Labs device farm [#TDB](https://github.com/bugsnag/maze-runner/pull/TDB)
+- Enhances for running Android tests with Appium 1.20.2 [#244](https://github.com/bugsnag/maze-runner/pull/244)
+  - Use Appium 1.20.2 for BrowserStack devices where possible 
+  - Add `--start-appium` option for running with local devices, defaulting to true
+  - Add `Maze::Driver::Appium.set_rotation`
 
 # 4.13.0 - 2021/03/16
 

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -77,7 +77,7 @@ AfterConfiguration do |_cucumber_config|
 
     # Attempt to start the local appium server
     appium_uri = URI(config.appium_server_url)
-    Maze::AppiumServer.start(address: appium_uri.host, port: appium_uri.port)
+    Maze::AppiumServer.start(address: appium_uri.host, port: appium_uri.port) if config.start_appium
   end
 
   # Create and start the relevant driver
@@ -172,7 +172,7 @@ After do |scenario|
   elsif Maze.config.os == 'macos'
     # Close the app - without the sleep, launching the app for the next scenario intermittently fails
     system("killall #{Maze.config.app} && sleep 1")
-  elsif Maze.config.test_device
+  elsif [:bs, :sl, :local].include? Maze.config.farm
     Maze.driver.reset
   end
 ensure

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -45,7 +45,9 @@ module Maze
                          {
                            'platformName' => 'Android',
                            'automationName' => 'UiAutomator2',
-                           'autoGrantPermissions' => 'true'
+                           'autoGrantPermissions' => 'true',
+                           # 'skipDeviceInitialization' => 'true',
+                           'noReset' => 'true'
                          }
                        elsif platform.downcase == 'ios'
                          {

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -12,7 +12,8 @@ module Maze
           'browserstack.console' => 'errors',
           'browserstack.localIdentifier' => local_id,
           'browserstack.local' => 'true',
-          'disabledAnimations' => 'true'
+          'disabledAnimations' => 'true',
+          'noReset' => 'true'
         }
         capabilities.merge! Devices::DEVICE_HASH[device_type]
         capabilities.merge! JSON.parse(capabilities_option)

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -47,7 +47,6 @@ module Maze
                            'platformName' => 'Android',
                            'automationName' => 'UiAutomator2',
                            'autoGrantPermissions' => 'true',
-                           # 'skipDeviceInitialization' => 'true',
                            'noReset' => 'true'
                          }
                        elsif platform.downcase == 'ios'

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -109,6 +109,9 @@ module Maze
     # URL of the Appium server
     attr_accessor :appium_server_url
 
+    # Whether an appium server should be started
+    attr_accessor :start_appium
+
     #
     # Logging configuration
     #

--- a/lib/maze/devices.rb
+++ b/lib/maze/devices.rb
@@ -4,14 +4,12 @@ module Maze
   # Provides a source of capabilities used to run tests against specific BrowserStack devices
   # noinspection RubyStringKeysInHashInspection
   class Devices
-    APPIUM_1_9_1 = '1.9.1' # 4
-    APPIUM_1_15_0 = '1.15.0' # 6
-    APPIUM_1_17_0 = '1.17.0' # 6
-    APPIUM_1_18_0 = '1.18.0' # 7
-    APPIUM_1_20_2 = '1.20.2' # 8 +
+    APPIUM_1_9_1 = '1.9.1'
+    APPIUM_1_15_0 = '1.15.0'
+    APPIUM_1_20_2 = '1.20.2'
 
     class << self
-      def make_android_hash(device, version, appium_version)
+      def make_android_hash(device, version, appium_version = APPIUM_1_20_2)
         {
           'device' => device,
           'os_version' => version,
@@ -22,7 +20,7 @@ module Maze
         }.freeze
       end
 
-      def add_android(device, version, appium_version, hash)
+      def add_android(device, version, hash, appium_version = APPIUM_1_20_2)
         # Key format is "ANDROID_<version>_<device>", with:
         # - dots in versions and all spaces replaced with underscores
         # - device made upper case
@@ -69,14 +67,14 @@ module Maze
       def create_hash
         hash = {
           # Classic, non-specific devices for each Android version
-          'ANDROID_11_0' => make_android_hash('Google Pixel 4', '11.0', APPIUM_1_17_0),
-          'ANDROID_10_0' => make_android_hash('Google Pixel 4', '10.0', APPIUM_1_17_0),
-          'ANDROID_9_0' => make_android_hash('Google Pixel 3', '9.0', APPIUM_1_17_0),
-          'ANDROID_8_1' => make_android_hash('Samsung Galaxy Note 9', '8.1', APPIUM_1_17_0),
-          'ANDROID_8_0' => make_android_hash('Google Pixel 2', '8.0', APPIUM_1_17_0),
-          'ANDROID_7_1' => make_android_hash('Google Pixel', '7.1', APPIUM_1_17_0),
-          'ANDROID_6_0' => make_android_hash('Google Nexus 6', '6.0', APPIUM_1_17_0),
-          'ANDROID_5_0' => make_android_hash('Google Nexus 6', '5.0', APPIUM_1_17_0),
+          'ANDROID_11_0' => make_android_hash('Google Pixel 4', '11.0'),
+          'ANDROID_10_0' => make_android_hash('Google Pixel 4', '10.0'),
+          'ANDROID_9_0' => make_android_hash('Google Pixel 3', '9.0'),
+          'ANDROID_8_1' => make_android_hash('Samsung Galaxy Note 9', '8.1'),
+          'ANDROID_8_0' => make_android_hash('Google Pixel 2', '8.0'),
+          'ANDROID_7_1' => make_android_hash('Google Pixel', '7.1'),
+          'ANDROID_6_0' => make_android_hash('Google Nexus 6', '6.0'),
+          'ANDROID_5_0' => make_android_hash('Google Nexus 6', '5.0'),
           'ANDROID_4_4' => make_android_hash('Google Nexus 5', '4.4', APPIUM_1_9_1),
 
           # iOS devices
@@ -95,22 +93,22 @@ module Maze
         hash['ANDROID_4'] = hash['ANDROID_4_4']
 
         # Specific Android devices
-        add_android 'Google Pixel 4', '11.0', APPIUM_1_17_0, hash          # ANDROID_11_0_GOOGLE_PIXEL_4
-        add_android 'Samsung Galaxy Note 9', '8.1', APPIUM_1_17_0, hash    # ANDROID_8_1_SAMSUNG_GALAXY_NOTE_9
-        add_android 'Samsung Galaxy J7 Prime', '8.1', APPIUM_1_17_0, hash  # ANDROID_8_1_SAMSUNG_GALAXY_J7_PRIME
-        add_android 'Samsung Galaxy Tab S4', '8.1', APPIUM_1_17_0, hash    # ANDROID_8_1_SAMSUNG_GALAXY_TAB_S4
-        add_android 'Google Pixel', '8.0', APPIUM_1_17_0, hash             # ANDROID_8_0_GOOGLE_PIXEL
-        add_android 'Google Pixel 2', '8.0', APPIUM_1_17_0, hash           # ANDROID_8_0_GOOGLE_PIXEL_2
-        add_android 'Samsung Galaxy S9', '8.0', APPIUM_1_17_0, hash        # ANDROID_8_0_SAMSUNG_GALAXY_S9
-        add_android 'Samsung Galaxy S9 Plus', '8.0', APPIUM_1_17_0, hash   # ANDROID_8_0_SAMSUNG_GALAXY_S9_PLUS
-        add_android 'Samsung Galaxy Tab S3', '7.0', APPIUM_1_17_0, hash    # ANDROID_7_0_SAMSUNG_GALAXY_TAB_S3
-        add_android 'Motorola Moto X 2nd Gen', '6.0', APPIUM_1_17_0, hash  # ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN
-        add_android 'Google Nexus 6', '6.0', APPIUM_1_17_0, hash           # ANDROID_6_0_GOOGLE_NEXUS_6
-        add_android 'Samsung Galaxy S7', '6.0', APPIUM_1_17_0, hash        # ANDROID_6_0_SAMSUNG_GALAXY_S7
-        add_android 'Google Nexus 6', '5.0', APPIUM_1_17_0, hash           # ANDROID_5_0_GOOGLE_NEXUS_6
-        add_android 'Samsung Galaxy S6', '5.0', APPIUM_1_17_0, hash        # ANDROID_5_0_SAMSUNG_GALAXY_S6
-        add_android 'Samsung Galaxy Note 4', '4.4', APPIUM_1_9_1, hash     # ANDROID_4_4_SAMSUNG_GALAXY_NOTE_4
-        add_android 'Samsung Galaxy Tab 4', '4.4', APPIUM_1_9_1, hash      # ANDROID_4_4_SAMSUNG_GALAXY_TAB_4
+        add_android 'Google Pixel 4', '11.0', hash                        # ANDROID_11_0_GOOGLE_PIXEL_4
+        add_android 'Samsung Galaxy Note 9', '8.1', hash                  # ANDROID_8_1_SAMSUNG_GALAXY_NOTE_9
+        add_android 'Samsung Galaxy J7 Prime', '8.1', hash                # ANDROID_8_1_SAMSUNG_GALAXY_J7_PRIME
+        add_android 'Samsung Galaxy Tab S4', '8.1', hash                  # ANDROID_8_1_SAMSUNG_GALAXY_TAB_S4
+        add_android 'Google Pixel', '8.0', hash                           # ANDROID_8_0_GOOGLE_PIXEL
+        add_android 'Google Pixel 2', '8.0', hash                         # ANDROID_8_0_GOOGLE_PIXEL_2
+        add_android 'Samsung Galaxy S9', '8.0', hash                      # ANDROID_8_0_SAMSUNG_GALAXY_S9
+        add_android 'Samsung Galaxy S9 Plus', '8.0', hash                 # ANDROID_8_0_SAMSUNG_GALAXY_S9_PLUS
+        add_android 'Samsung Galaxy Tab S3', '7.0', hash                  # ANDROID_7_0_SAMSUNG_GALAXY_TAB_S3
+        add_android 'Motorola Moto X 2nd Gen', '6.0', hash                # ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN
+        add_android 'Google Nexus 6', '6.0', hash                         # ANDROID_6_0_GOOGLE_NEXUS_6
+        add_android 'Samsung Galaxy S7', '6.0', hash                      # ANDROID_6_0_SAMSUNG_GALAXY_S7
+        add_android 'Google Nexus 6', '5.0', hash                         # ANDROID_5_0_GOOGLE_NEXUS_6
+        add_android 'Samsung Galaxy S6', '5.0', hash                      # ANDROID_5_0_SAMSUNG_GALAXY_S6
+        add_android 'Samsung Galaxy Note 4', '4.4', hash, APPIUM_1_9_1    # ANDROID_4_4_SAMSUNG_GALAXY_NOTE_4
+        add_android 'Samsung Galaxy Tab 4', '4.4', hash, APPIUM_1_9_1     # ANDROID_4_4_SAMSUNG_GALAXY_TAB_4
 
         # Specific iOS devices
         add_ios 'iPhone 8 Plus', '11.0', hash                             # IOS_11_0_IPHONE_8_PLUS

--- a/lib/maze/devices.rb
+++ b/lib/maze/devices.rb
@@ -4,10 +4,11 @@ module Maze
   # Provides a source of capabilities used to run tests against specific BrowserStack devices
   # noinspection RubyStringKeysInHashInspection
   class Devices
-    APPIUM_1_6_5 = '1.6.5'
-    APPIUM_1_7_2 = '1.7.2'
-    APPIUM_1_8_0 = '1.8.0'
-    APPIUM_1_15_0 = '1.15.0'
+    APPIUM_1_9_1 = '1.9.1' # 4
+    APPIUM_1_15_0 = '1.15.0' # 6
+    APPIUM_1_17_0 = '1.17.0' # 6
+    APPIUM_1_18_0 = '1.18.0' # 7
+    APPIUM_1_20_2 = '1.20.2' # 8 +
 
     class << self
       def make_android_hash(device, version, appium_version)
@@ -68,15 +69,15 @@ module Maze
       def create_hash
         hash = {
           # Classic, non-specific devices for each Android version
-          'ANDROID_11_0' => make_android_hash('Google Pixel 4', '11.0', APPIUM_1_8_0),
-          'ANDROID_10_0' => make_android_hash('Google Pixel 4', '10.0', APPIUM_1_8_0),
-          'ANDROID_9_0' => make_android_hash('Google Pixel 3', '9.0', APPIUM_1_8_0),
-          'ANDROID_8_1' => make_android_hash('Samsung Galaxy Note 9', '8.1', APPIUM_1_7_2),
-          'ANDROID_8_0' => make_android_hash('Google Pixel 2', '8.0', APPIUM_1_7_2),
-          'ANDROID_7_1' => make_android_hash('Google Pixel', '7.1', APPIUM_1_6_5),
-          'ANDROID_6_0' => make_android_hash('Google Nexus 6', '6.0', APPIUM_1_6_5),
-          'ANDROID_5_0' => make_android_hash('Google Nexus 6', '5.0', APPIUM_1_6_5),
-          'ANDROID_4_4' => make_android_hash('Google Nexus 5', '4.4', APPIUM_1_6_5),
+          'ANDROID_11_0' => make_android_hash('Google Pixel 4', '11.0', APPIUM_1_17_0),
+          'ANDROID_10_0' => make_android_hash('Google Pixel 4', '10.0', APPIUM_1_17_0),
+          'ANDROID_9_0' => make_android_hash('Google Pixel 3', '9.0', APPIUM_1_17_0),
+          'ANDROID_8_1' => make_android_hash('Samsung Galaxy Note 9', '8.1', APPIUM_1_17_0),
+          'ANDROID_8_0' => make_android_hash('Google Pixel 2', '8.0', APPIUM_1_17_0),
+          'ANDROID_7_1' => make_android_hash('Google Pixel', '7.1', APPIUM_1_17_0),
+          'ANDROID_6_0' => make_android_hash('Google Nexus 6', '6.0', APPIUM_1_17_0),
+          'ANDROID_5_0' => make_android_hash('Google Nexus 6', '5.0', APPIUM_1_17_0),
+          'ANDROID_4_4' => make_android_hash('Google Nexus 5', '4.4', APPIUM_1_9_1),
 
           # iOS devices
           'IOS_14' => make_ios_hash('iPhone 11', '14'),
@@ -94,22 +95,22 @@ module Maze
         hash['ANDROID_4'] = hash['ANDROID_4_4']
 
         # Specific Android devices
-        add_android 'Google Pixel 4', '11.0', APPIUM_1_8_0, hash          # ANDROID_11_0_GOOGLE_PIXEL_4
-        add_android 'Samsung Galaxy Note 9', '8.1', APPIUM_1_7_2, hash    # ANDROID_8_1_SAMSUNG_GALAXY_NOTE_9
-        add_android 'Samsung Galaxy J7 Prime', '8.1', APPIUM_1_7_2, hash  # ANDROID_8_1_SAMSUNG_GALAXY_J7_PRIME
-        add_android 'Samsung Galaxy Tab S4', '8.1', APPIUM_1_7_2, hash    # ANDROID_8_1_SAMSUNG_GALAXY_TAB_S4
-        add_android 'Google Pixel', '8.0', APPIUM_1_7_2, hash             # ANDROID_8_0_GOOGLE_PIXEL
-        add_android 'Google Pixel 2', '8.0', APPIUM_1_7_2, hash           # ANDROID_8_0_GOOGLE_PIXEL_2
-        add_android 'Samsung Galaxy S9', '8.0', APPIUM_1_7_2, hash        # ANDROID_8_0_SAMSUNG_GALAXY_S9
-        add_android 'Samsung Galaxy S9 Plus', '8.0', APPIUM_1_7_2, hash   # ANDROID_8_0_SAMSUNG_GALAXY_S9_PLUS
-        add_android 'Samsung Galaxy Tab S3', '7.0', APPIUM_1_6_5, hash    # ANDROID_7_0_SAMSUNG_GALAXY_TAB_S3
-        add_android 'Motorola Moto X 2nd Gen', '6.0', APPIUM_1_6_5, hash  # ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN
-        add_android 'Google Nexus 6', '6.0', APPIUM_1_6_5, hash           # ANDROID_6_0_GOOGLE_NEXUS_6
-        add_android 'Samsung Galaxy S7', '6.0', APPIUM_1_6_5, hash        # ANDROID_6_0_SAMSUNG_GALAXY_S7
-        add_android 'Google Nexus 6', '5.0', APPIUM_1_6_5, hash           # ANDROID_5_0_GOOGLE_NEXUS_6
-        add_android 'Samsung Galaxy S6', '5.0', APPIUM_1_6_5, hash        # ANDROID_5_0_SAMSUNG_GALAXY_S6
-        add_android 'Samsung Galaxy Note 4', '4.4', APPIUM_1_6_5, hash    # ANDROID_4_4_SAMSUNG_GALAXY_NOTE_4
-        add_android 'Samsung Galaxy Tab 4', '4.4', APPIUM_1_6_5, hash     # ANDROID_4_4_SAMSUNG_GALAXY_TAB_4
+        add_android 'Google Pixel 4', '11.0', APPIUM_1_17_0, hash          # ANDROID_11_0_GOOGLE_PIXEL_4
+        add_android 'Samsung Galaxy Note 9', '8.1', APPIUM_1_17_0, hash    # ANDROID_8_1_SAMSUNG_GALAXY_NOTE_9
+        add_android 'Samsung Galaxy J7 Prime', '8.1', APPIUM_1_17_0, hash  # ANDROID_8_1_SAMSUNG_GALAXY_J7_PRIME
+        add_android 'Samsung Galaxy Tab S4', '8.1', APPIUM_1_17_0, hash    # ANDROID_8_1_SAMSUNG_GALAXY_TAB_S4
+        add_android 'Google Pixel', '8.0', APPIUM_1_17_0, hash             # ANDROID_8_0_GOOGLE_PIXEL
+        add_android 'Google Pixel 2', '8.0', APPIUM_1_17_0, hash           # ANDROID_8_0_GOOGLE_PIXEL_2
+        add_android 'Samsung Galaxy S9', '8.0', APPIUM_1_17_0, hash        # ANDROID_8_0_SAMSUNG_GALAXY_S9
+        add_android 'Samsung Galaxy S9 Plus', '8.0', APPIUM_1_17_0, hash   # ANDROID_8_0_SAMSUNG_GALAXY_S9_PLUS
+        add_android 'Samsung Galaxy Tab S3', '7.0', APPIUM_1_17_0, hash    # ANDROID_7_0_SAMSUNG_GALAXY_TAB_S3
+        add_android 'Motorola Moto X 2nd Gen', '6.0', APPIUM_1_17_0, hash  # ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN
+        add_android 'Google Nexus 6', '6.0', APPIUM_1_17_0, hash           # ANDROID_6_0_GOOGLE_NEXUS_6
+        add_android 'Samsung Galaxy S7', '6.0', APPIUM_1_17_0, hash        # ANDROID_6_0_SAMSUNG_GALAXY_S7
+        add_android 'Google Nexus 6', '5.0', APPIUM_1_17_0, hash           # ANDROID_5_0_GOOGLE_NEXUS_6
+        add_android 'Samsung Galaxy S6', '5.0', APPIUM_1_17_0, hash        # ANDROID_5_0_SAMSUNG_GALAXY_S6
+        add_android 'Samsung Galaxy Note 4', '4.4', APPIUM_1_9_1, hash     # ANDROID_4_4_SAMSUNG_GALAXY_NOTE_4
+        add_android 'Samsung Galaxy Tab 4', '4.4', APPIUM_1_9_1, hash      # ANDROID_4_4_SAMSUNG_GALAXY_TAB_4
 
         # Specific iOS devices
         add_ios 'iPhone 8 Plus', '11.0', hash                             # IOS_11_0_IPHONE_8_PLUS

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -105,6 +105,13 @@ module Maze
         find_element(@element_locator, element_id).send_keys(text)
       end
 
+      # Sets the rotation of the device
+      #
+      # @param orientation [Symbol] :portrait or :landscape
+      def set_rotation(orientation)
+        @driver.rotation = orientation
+      end
+
       # Sends keys to a given element, clearing it first
       #
       # @param element_id [String] the element to clear and send text to

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -31,6 +31,7 @@ module Maze
     OS = 'os'
     OS_VERSION = 'os-version'
     APPIUM_SERVER = 'appium-server'
+    START_APPIUM = 'start-appium'
     APPLE_TEAM_ID = 'apple-team-id'
     UDID = 'udid'
 

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -117,6 +117,10 @@ module Maze
                 'Appium server URL, only used for --farm=local. MAZE_APPIUM_SERVER env var or "http://localhost:4723/wd/hub" by default',
                 short: :none,
                 type: :string
+            opt Option::START_APPIUM,
+                'Whether a local Appium server should be start.  Only used for --farm=local.',
+                short: :none,
+                default: true
             opt Option::APPLE_TEAM_ID,
                 'Apple Team Id, required for local iOS testing. MAZE_APPLE_TEAM_ID env var by default',
                 short: :none,

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -66,6 +66,7 @@ module Maze
             os = config.os = options[Maze::Option::OS].downcase
             config.os_version = options[Maze::Option::OS_VERSION].to_f
             config.appium_server_url = options[Maze::Option::APPIUM_SERVER]
+            config.start_appium = options[Maze::Option::START_APPIUM]
             if os == 'ios'
               config.apple_team_id = options[Maze::Option::APPLE_TEAM_ID]
               config.device_id = options[Maze::Option::UDID]

--- a/test/option/parser_test.rb
+++ b/test/option/parser_test.rb
@@ -64,6 +64,7 @@ class ParserTest < Test::Unit::TestCase
       --os=ARG_OS
       --os-version=ARG_OS_VERSION
       --appium-server=ARG_APPIUM_SERVER
+      --no-start-appium
       --apple-team-id=ARG_APPLE_TEAM_ID
       --udid=ARG_UDID
       --no-log-requests
@@ -90,6 +91,7 @@ class ParserTest < Test::Unit::TestCase
     assert_equal('ARG_OS', options[Maze::Option::OS])
     assert_equal('ARG_OS_VERSION', options[Maze::Option::OS_VERSION])
     assert_equal('ARG_APPIUM_SERVER', options[Maze::Option::APPIUM_SERVER])
+    assert_false(options[Maze::Option::START_APPIUM])
     assert_equal('ARG_APPLE_TEAM_ID', options[Maze::Option::APPLE_TEAM_ID])
     assert_equal('ARG_UDID', options[Maze::Option::UDID])
 

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -48,7 +48,7 @@ class ProcessorTest < Test::Unit::TestCase
   end
 
   def test_populate_local_config
-    args = %w[--farm=local --app=my_app.apk --os=ios --os-version=7.1 --apple-team-id=ABC --udid=123 --bind-address=1.2.3.4 --port=1234]
+    args = %w[--farm=local --app=my_app.apk --os=ios --os-version=7.1 --apple-team-id=ABC --udid=123 --bind-address=1.2.3.4 --port=1234 --no-start-appium]
     options = Maze::Option::Parser.parse args
     config = Maze::Configuration.new
     Maze::Option::Processor.populate config, options
@@ -61,6 +61,7 @@ class ProcessorTest < Test::Unit::TestCase
     assert_equal '123', config.device_id
     assert_equal '1.2.3.4', config.bind_address
     assert_equal 1234, config.port
+    assert_false config.start_appium
   end
 
   def test_logger_options


### PR DESCRIPTION
## Goal

Get all of our Android e2e tests working with Appium 1.20 using BrowserStack devices.  Also makes significant improvements for running the tests on locally held devices.

## Design

Our Android e2e tests do not currently work properly with Appium versions 1.9.1+.  This change set fixes that (with a small change to the Android pipeline).  Whilst this is not directly related to the Sauce Labs integration, it's an important building block when considering that Sauce Labs do not support <1.15.  It can also be viewed as a breaking change, so I opted to target this integration branch and a major version bump.

## Changeset

- The `noReset` capability is now specified to prevent the app from being reset when `driver.launch_app` is called, which was breaking all of our test scenarios involving unhandled errors.  The app is still reset between scenarios.
- Appium 1.20.2 is used for all Android BrowserStack devices where possible (1.9.1 is the latests they support for Android 4.4).
- Added `--start-appium` option defaulting to `true` (with `--no-start-appium` to disable it) for users like myself that are using Appium Desktop rather than the NPM version.  This was added to assist the initial debugging of scenarios on local test devices.
- `driver.set_rotation` added to allow test scenarios to explicitly set the rotation/orientation.

## Tests

Unit tests added for the new command line option and I have a branch of `bugsnag-android` that successfully runs a "full" build with it. 