### PR TITLE
Move logging of version to the start

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,7 +87,7 @@ steps:
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
       --device=ANDROID_6_0
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: 'Browserstack app-automate test - Android 11'
@@ -101,7 +101,7 @@ steps:
       --farm=bs
       --device=ANDROID_11_0
       --appium-version=1.17.0
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - wait

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.13.1 - 2021/03/31
+
+- Always log version number [#247](https://github.com/bugsnag/maze-runner/pull/247)
+
 # 4.13.0 - 2021/03/16
 
 - Add stress-test step asserting a minimum amount of requests received [#239](https://github.com/bugsnag/maze-runner/pull/239)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (4.13.0)
+    bugsnag-maze-runner (4.13.1)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -28,7 +28,7 @@ GEM
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (4.4.1)
+    appium_lib_core (4.5.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.20.2)
@@ -69,11 +69,13 @@ GEM
       kramdown (>= 1.5.0)
       props (>= 1.1.2)
       textutils (>= 0.10.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.3)
     mocha (1.12.0)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.2)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -120,4 +122,4 @@ DEPENDENCIES
   yard-cucumber (~> 4.0.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.13

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -62,6 +62,8 @@ class MazeRunnerEntry
   end
 
   def start(args)
+    $logger.info "Maze Runner v#{Maze::VERSION}"
+
     # Parse args, processing any Maze Runner specific options
     @args = args.dup
     options = Maze::Option::Parser.parse args

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '4.13.0'
+  VERSION = '4.13.1'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -114,7 +114,6 @@ module Maze
       # Starts the WEBrick server in a separate thread
       def start
         attempts = 0
-        $logger.info "Maze Runner v#{Maze::VERSION}"
         $logger.info 'Starting mock server'
         loop do
 

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -21,7 +21,6 @@ module Maze
 
     def test_start_cleanily_configured_bind_address
       # Expected logging calls
-      @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
       @logger_mock.expects(:info).with('Starting mock server')
 
       # Force synchronous execution
@@ -51,7 +50,6 @@ module Maze
 
     def test_start_on_retry
       # Expected logging calls
-      @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
       @logger_mock.expects(:info).with('Starting mock server')
       @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
       @logger_mock.expects(:info).with('Retrying in 5 seconds')
@@ -85,7 +83,6 @@ module Maze
 
     def test_start_fails
       # Expected logging calls
-      @logger_mock.expects(:info).with("Maze Runner v#{Maze::VERSION}")
       @logger_mock.expects(:info).with('Starting mock server')
       @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
       @logger_mock.expects(:info).with('Retrying in 5 seconds')


### PR DESCRIPTION
## Goal

Move logging of the Maze Runner version right to the start, so that it's alway clear which version we have, even if command line option validation errors are raised.
