### PR TITLE
Correct docker tag for v5 releases

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -148,5 +148,5 @@ steps:
       - docker-compose#v3.7.0:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:${BUILDKITE_TAG}-cli
-            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v4-cli
+            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v5-cli
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 5.0.0 - 2021/03/30
 
+## Enhancements
+
 - Integration with Sauce Labs device farm [#246](https://github.com/bugsnag/maze-runner/pull/246)
 - Enhances for running Android tests with Appium 1.20.2 [#244](https://github.com/bugsnag/maze-runner/pull/244)
   - Use Appium 1.20.2 for BrowserStack devices where possible 
@@ -8,14 +10,20 @@
 
 # 4.13.1 - 2021/03/31
 
+## Fixes
+
 - Always log version number [#247](https://github.com/bugsnag/maze-runner/pull/247)
 
 # 4.13.0 - 2021/03/16
+
+## Enhancements
 
 - Add stress-test step asserting a minimum amount of requests received [#239](https://github.com/bugsnag/maze-runner/pull/239)
 - Add option to not log received requests on a test failure [#238](https://github.com/bugsnag/maze-runner/pull/238)
 
 # 4.12.1 - 2021/03/04
+
+## Fixes
 
 - Loosen requirements on Lambda responses [#237](https://github.com/bugsnag/maze-runner/pull/237)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,17 +12,12 @@ Ensure that:
 If the release will create a new major version, also ensure that:
 1. The `Push Docker image for tag` step in `.buildkite/pipeline.yml`
    1. Will recognise the new tag in the `if` condition.
-   1. Pushes the built release image with the correct tag for the major release stream (e.g. `latest-v4-cli`)
-
-As branches are merged to `master` we automatically trigger builds in out major notifiers against the new `master` 
-version, which is useful for assessing the possible impact of a release on our notifiers.  Some judgement should be 
-applied here on whther the triggered builds need to run to completion (typically they don't) and whether the 
-`maze-runner-master` branches that are built for each notifier pipeline are sufficiently up-to-date.
+   1. Pushes the built release image with the correct tag for the major release stream (e.g. `latest-v6-cli`)
 
 #### Performing the release
 
 1. On Github, 'Draft a new release':
-   1. Tag version - of the form v3.6.0
+   1. Tag version - of the form v5.0.1
    1. Target - generally `master` unless the release is a minor/patch for a previous major version for which we have a branch.
    1. Release title - as the Tag version
    1. Description - copy directly from `CHANGLEOG.md`, ensuring that the formatting looks correct in the preview.


### PR DESCRIPTION
## Goal

Ensure Docker images for v5 releases are tagged with `latest-v5-cli` and not overwrite the last v4 release.