### PR TITLE
Remove use of unlicensed Boring gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.0.2 - TBD
+
+## Fixes
+
+- Remove use of unlicensed Boring gem [#251](https://github.com/bugsnag/maze-runner/pull/251)
+
 # 5.0.1 - 2021/04/06
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     bugsnag-maze-runner (5.0.1)
       appium_lib (~> 11.2.0)
-      boring (~> 0.1.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
@@ -32,7 +31,6 @@ GEM
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.20.2)
-    boring (0.1.0)
     builder (3.2.4)
     childprocess (3.0.0)
     concurrent-ruby (1.1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (5.0.1)
+    bugsnag-maze-runner (5.0.2)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -72,7 +72,7 @@ GEM
     mocha (1.12.0)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.2)
+    nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     optimist (3.0.1)

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'optimist', '~> 3.0.1'
   spec.add_dependency 'rake', '~> 12.3.3'
   spec.add_dependency 'selenium-webdriver', '~> 3.11'
-  spec.add_dependency 'boring', '~> 0.1.0'
+  # Removed pending PLAT-6322
+  # spec.add_dependency 'boring', '~> 0.1.0'
 
   spec.add_development_dependency 'markdown', '~> 1.2'
   spec.add_development_dependency 'mocha', '~> 1.12.0'

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'optimist', '~> 3.0.1'
   spec.add_dependency 'rake', '~> 12.3.3'
   spec.add_dependency 'selenium-webdriver', '~> 3.11'
-  # Removed pending PLAT-6322
+  # TODO: Removed pending PLAT-6322
   # spec.add_dependency 'boring', '~> 0.1.0'
 
   spec.add_development_dependency 'markdown', '~> 1.2'

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '5.0.1'
+  VERSION = '5.0.2'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/interactive_cli.rb
+++ b/lib/maze/interactive_cli.rb
@@ -1,5 +1,5 @@
 require 'pty'
-# Removed pending PLAT-6322
+# TODO: Removed pending PLAT-6322
 # require 'boring'
 
 module Maze
@@ -32,7 +32,7 @@ module Maze
       @stderr_lines = []
       @on_exit_blocks = []
       @current_buffer = ''
-      # Removed pending PLAT-6322
+      # TODO: Removed pending PLAT-6322
       # @boring = Boring.new
 
       start_threaded_shell(shell)
@@ -165,7 +165,7 @@ module Maze
     end
 
     def format_line(line)
-      # Removed pending PLAT-6322
+      # TODO: Removed pending PLAT-6322
       # @boring.scrub(line.strip)
       line.strip
     end

--- a/lib/maze/interactive_cli.rb
+++ b/lib/maze/interactive_cli.rb
@@ -1,5 +1,6 @@
 require 'pty'
-require 'boring'
+# Removed pending PLAT-6322
+# require 'boring'
 
 module Maze
   # Encapsulates a shell session, retaining state and input streams for interactive tests
@@ -31,7 +32,8 @@ module Maze
       @stderr_lines = []
       @on_exit_blocks = []
       @current_buffer = ''
-      @boring = Boring.new
+      # Removed pending PLAT-6322
+      # @boring = Boring.new
 
       start_threaded_shell(shell)
     end
@@ -163,7 +165,9 @@ module Maze
     end
 
     def format_line(line)
-      @boring.scrub(line.strip)
+      # Removed pending PLAT-6322
+      # @boring.scrub(line.strip)
+      line.strip
     end
   end
 end

--- a/test/fixtures/docker-app/features/fixtures/interactive/guessing-game
+++ b/test/fixtures/docker-app/features/fixtures/interactive/guessing-game
@@ -12,9 +12,13 @@ loop do
   guess.chomp!
 
   if guess.to_i == number
-    puts "\e[0;32;1mYeah\e[0m, it's \e[0;1m#{number}\e[0m!"
+    # TODO: Pending PLAT-6322
+    # puts "\e[0;32;1mYeah\e[0m, it's \e[0;1m#{number}\e[0m!"
+    puts "Yeah, it's #{number}!"
     break
   end
 
-  puts "\e[0;31;1mNope\e[0m, it's not \e[0;1m#{guess}\e[0m. Try again!"
+  # TODO: Pending PLAT-6322
+  # puts "\e[0;31;1mNope\e[0m, it's not \e[0;1m#{guess}\e[0m. Try again!"
+  puts "Nope, it's not #{guess}. Try again!"
 end


### PR DESCRIPTION
Stop using the Boring gem, which was introduced to resolve flaking React Native CLI e2e tests.

An internal ticket has been raised to find an alternative to `Boring`, or write our own implementation.  I have also contact its author in the hope that they may be willing to add a `LICENSE`.