### PR TITLE
Adds logging to a file for the appium server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 5.0.2 - TBD
+# 5.1.0 - TBD
+
+## Enhnancements
+
+- Enable locally running appium server to log to a file [#252](https://github.com/bugsnag/maze-runner/pull/252)
+  - Log file defaults to `appium_server.log`
+  - Can be overwritten using `--appium-logfile` option
 
 ## Fixes
 

--- a/lib/maze/appium_server.rb
+++ b/lib/maze/appium_server.rb
@@ -13,6 +13,9 @@ module Maze
       # @return [thread|nil] The thread running the appium process (if available)
       attr_reader :appium_thread
 
+      # @return [Logger|nil] The logger used for creating the log file
+      attr_reader :appium_logger
+
       # Starts a separate thread running the appium server so long as:
       #   - An instance of the appium server isn't already running
       #   - The port configured is available
@@ -41,7 +44,7 @@ module Maze
             @pid = pid
             $logger.debug("Appium:#{@pid}") { 'Appium server started' }
             stdout.each do |line|
-              $logger.debug("Appium:#{@pid}") { line }
+              log_line(line)
             end
           end
         end
@@ -78,6 +81,20 @@ module Maze
         true
       rescue Errno::ENOENT
         false
+      end
+
+      # Starts the logger targeting a file defined by the APPIUM_LOGFILE config option
+      def start_logger
+        @appium_logger = ::Logger.new(Maze.config.appium_logfile)
+        @appium_logger.datetime_format = '%Y-%m-%d %H:%M:%S'
+      end
+
+      # Logs to a known file, creating the outstream if it isn't already present
+      #
+      # @param line [String] The line to log
+      def log_line(line)
+        start_logger if @appium_logger.nil?
+        @appium_logger.info("Appium:#{@pid}") { line }
       end
 
       # Checks if the given port is already in use

--- a/lib/maze/appium_server.rb
+++ b/lib/maze/appium_server.rb
@@ -38,6 +38,8 @@ module Maze
           return
         end
 
+        start_logger
+
         command = "appium -a #{address} -p #{port}"
         @appium_thread = Thread.new do
           PTY.spawn(command) do |stdout, _stdin, pid|
@@ -93,7 +95,7 @@ module Maze
       #
       # @param line [String] The line to log
       def log_line(line)
-        start_logger if @appium_logger.nil?
+        return if @appium_logger.nil?
         @appium_logger.info("Appium:#{@pid}") { line }
       end
 

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -112,6 +112,9 @@ module Maze
     # Whether an appium server should be started
     attr_accessor :start_appium
 
+    # The location of the appium server logfile
+    attr_accessor :appium_logfile
+
     #
     # Logging configuration
     #

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -33,6 +33,7 @@ module Maze
     # Local-only options
     APPIUM_SERVER = 'appium-server'
     START_APPIUM = 'start-appium'
+    APPIUM_LOGFILE = 'appium-logfile'
     APPLE_TEAM_ID = 'apple-team-id'
     UDID = 'udid'
 

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -121,6 +121,10 @@ module Maze
                 'Whether a local Appium server should be start.  Only used for --farm=local.',
                 short: :none,
                 default: true
+            opt Option::APPIUM_LOGFILE,
+                'The file local appium server output is logged to, defaulting to "appium_server.log"',
+                short: :none,
+                default: 'appium_server.log'
             opt Option::APPLE_TEAM_ID,
                 'Apple Team Id, required for local iOS testing. MAZE_APPLE_TEAM_ID env var by default',
                 short: :none,

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -64,6 +64,7 @@ module Maze
             config.os_version = options[Maze::Option::OS_VERSION].to_f
             config.appium_server_url = options[Maze::Option::APPIUM_SERVER]
             config.start_appium = options[Maze::Option::START_APPIUM]
+            config.appium_logfile = options[Maze::Option::APPIUM_LOGFILE]
             if os == 'ios'
               config.apple_team_id = options[Maze::Option::APPLE_TEAM_ID]
               config.device_id = options[Maze::Option::UDID]


### PR DESCRIPTION
## Goal

Allows the appium server to output to a file which can be attached to the buildkite build when running in local mode.

Adds an `--appium-logfile` option denoting the file output, which defaults to `appium_server.log`

## Testing

- Tested manually and confirmed that the `appium_server.log` file is created by default and contains appium logs
- In addition, the `--appium-logfile` override successfully sets the file path of the logfile