### PR TITLE
Add license finder to pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,10 +2,9 @@ steps:
 
   - name: ':copyright: License Audit'
     plugins:
-      - docker-compose#v3.7.0:
-          build: license-audit
-      - docker-compose#v3.7.0:
-          run: license-audit
+      docker-compose#v3.7.0:
+        run: license_finder
+    command: /bin/bash -lc '/scan/scripts/license_finder.sh'
 
   - label: 'Unit tests'
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,12 @@
 steps:
+
+  - name: ':copyright: License Audit'
+    plugins:
+      - docker-compose#v3.7.0:
+          build: license-audit
+      - docker-compose#v3.7.0:
+          run: license-audit
+
   - label: 'Unit tests'
     plugins:
       docker-compose#v3.7.0:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,13 @@ GEM
     iniparser (1.0.1)
     kramdown (2.3.0)
       rexml
+    license_finder (6.12.0)
+      bundler
+      rubyzip (>= 1, < 3)
+      thor (~> 1.0.1)
+      tomlrb (>= 1.3, < 2.1)
+      with_env (= 1.1.0)
+      xml-simple (~> 1.1.5)
     logutils (0.6.1)
     markdown (1.2.0)
       kramdown (>= 1.5.0)
@@ -74,6 +81,10 @@ GEM
     multi_test (0.1.2)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogiri (1.11.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.11.3-x86_64-linux)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -95,12 +106,15 @@ GEM
       logutils (>= 0.6.1)
       props (>= 1.1.2)
       rubyzip (>= 1.0.0)
+    thor (1.0.1)
     tomlrb (1.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    with_env (1.1.0)
+    xml-simple (1.1.8)
     yard (0.9.26)
     yard-cucumber (4.0.0)
       cucumber (>= 2.0, < 4.0)
@@ -110,9 +124,12 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   bugsnag-maze-runner!
+  license_finder (~> 6.12.0)
   markdown (~> 1.2)
   mocha (~> 1.12.0)
   redcarpet (~> 3.5)

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'yard', '~> 0.9.1'
   spec.add_development_dependency 'yard-cucumber', '~> 4.0.0'
+  spec.add_development_dependency 'license_finder', '~> 6.12.0'
 end

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+global.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '3.6'
 services:
 
-  license-audit:
+  license_finder:
     build:
       dockerfile: dockerfiles/Dockerfile.audit
       context: .
     volumes:
-      - ./:/app
+      - ./:/scan
 
   ci:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,13 @@
 version: '3.6'
 services:
+
+  license-audit:
+    build:
+      dockerfile: dockerfiles/Dockerfile.audit
+      context: .
+    volumes:
+      - ./:/app
+
   ci:
     build:
       dockerfile: dockerfiles/Dockerfile.ci

--- a/dockerfiles/Dockerfile.audit
+++ b/dockerfiles/Dockerfile.audit
@@ -1,11 +1,9 @@
-FROM ubuntu:20.04 as ci
+FROM licensefinder/license_finder
 
-RUN apt-get update && apt-get install -y ruby-full apt-utils docker-compose wget unzip bash bundler \
-                                        # Needed by nokogiri (a dependency of appium_lib)
-                                        zlib1g libpng-dev zlibc zlib1g zlib1g-dev curl \
-                                        # Needed by curb (a dependency of Cucumber)
-                                        libcurl4 libcurl4-openssl-dev
+RUN apt-get update && apt-get install \
+                      # Needed by curb (a dependency of Cucumber)
+                      libcurl3 libcurl4-openssl-dev
 
-WORKDIR /app
+WORKDIR /scan
 
-CMD /app/scripts/license_finder.sh
+CMD /scan/scripts/license_finder.sh

--- a/dockerfiles/Dockerfile.audit
+++ b/dockerfiles/Dockerfile.audit
@@ -1,0 +1,11 @@
+FROM ubuntu:20.04 as ci
+
+RUN apt-get update && apt-get install -y ruby-full apt-utils docker-compose wget unzip bash bundler \
+                                        # Needed by nokogiri (a dependency of appium_lib)
+                                        zlib1g libpng-dev zlibc zlib1g zlib1g-dev curl \
+                                        # Needed by curb (a dependency of Cucumber)
+                                        libcurl4 libcurl4-openssl-dev
+
+WORKDIR /app
+
+CMD /app/scripts/license_finder.sh

--- a/scripts/license_finder.sh
+++ b/scripts/license_finder.sh
@@ -1,0 +1,3 @@
+curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o config/global.yml
+bundle install
+bundle exec license_finder --decisions-file=config/global.yml

--- a/scripts/license_finder.sh
+++ b/scripts/license_finder.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o config/global.yml
 bundle install
-bundle exec license_finder --decisions-file=config/global.yml
+license_finder --decisions-file=config/global.yml


### PR DESCRIPTION
## Goal

Add a check to the pipeline to ensure that any added dependencies comply with company policy.

## Design

A script is provided to run the license checks locally.  Decision files for the [LicenseFinder](https://github.com/pivotal/LicenseFinder) tool are held centrally with our [license-audit tool](https://github.com/bugsnag/license-audit) for process control and to avoid duplication.

## Changeset

New pipeline step to perform license auditing.

## Tests

Covered by CI and by running the script locally.  I've confirmed that a dependency not covered by an approved license would cause CI to fail.