### PR TITLE
Correct step failure message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fixes
 
 - Remove use of unlicensed Boring gem [#251](https://github.com/bugsnag/maze-runner/pull/251)
+- Correct wording of failure message for Cucumber step `I should receive no {word}` [#254](https://github.com/bugsnag/maze-runner/pull/254)
 
 # 5.0.1 - 2021/04/06
 

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -76,8 +76,8 @@ Then('I should receive no {word}') do |request_type|
     assert_equal(0, Maze::Server.errors.size, "#{Maze::Server.errors.size} errors received")
     assert_equal(0, Maze::Server.sessions.size, "#{Maze::Server.sessions.size} sessions received")
   else
-    list = Maze::Server.list_for(request_type).size
-    assert_equal(0, list, "#{list.size} #{request_type} received")
+    list = Maze::Server.list_for(request_type)
+    assert_equal(0, list.size, "#{list.size} #{request_type} received")
   end
 end
 


### PR DESCRIPTION
## Goal

Corrects the failure message to output the number of requests held in the list.  A double `.size` occurred before, meaning that 8 (bytes for an integer) was always output.

