### PR TITLE
Fix issue with os not being defined in local test runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 5.1.0 - TBD
+# 5.1.0 - 2021/05/10
 
 ## Enhnancements
 
@@ -10,6 +10,7 @@
 
 - Remove use of unlicensed Boring gem [#251](https://github.com/bugsnag/maze-runner/pull/251)
 - Correct wording of failure message for Cucumber step `I should receive no {word}` [#254](https://github.com/bugsnag/maze-runner/pull/254)
+- Fix `os` not being present for platform-dependent comparisons outside of device farms [#255](https://github.com/bugsnag/maze-runner/pull/255)
 
 # 5.0.1 - 2021/04/06
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (5.0.2)
+    bugsnag-maze-runner (5.1.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -74,17 +74,11 @@ GEM
       kramdown (>= 1.5.0)
       props (>= 1.1.2)
       textutils (>= 0.10.0)
-    mini_portile2 (2.5.0)
     minitest (5.14.3)
     mocha (1.12.0)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.3)
-      mini_portile2 (~> 2.5.0)
-      racc (~> 1.4)
     nokogiri (1.11.3-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.11.3-x86_64-linux)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/dockerfiles/Dockerfile.audit
+++ b/dockerfiles/Dockerfile.audit
@@ -1,6 +1,6 @@
 FROM licensefinder/license_finder
 
-RUN apt-get update && apt-get install \
+RUN apt-get update && apt-get install -y \
                       # Needed by curb (a dependency of Cucumber)
                       libcurl3 libcurl4-openssl-dev
 

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -174,6 +174,8 @@ def get_expected_platform_value(platform_values)
     os = Maze.config.capabilities['os']
   elsif Maze.config.farm == :sl
     os = Maze.driver.capabilities['platformName']
+  else
+    os = Maze.config.os
   end
   expected_value = Hash[platform_values.raw][os.downcase]
   raise("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '5.0.2'
+  VERSION = '5.1.0'
 
   class << self
     attr_accessor :driver


### PR DESCRIPTION
## Goal

When running local MacOS tests, the platform-dependent tables fail due to the OS not being correctly set. This resolves the issue by using the configuration option as a default.