### PR TITLE
Prepare 5.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.2.0 - 2021/05/19
+
+## Enhancements
+
+- Add Android 9.0 Pixel 2 variant for unity testing [#256](https://github.com/bugsnag/maze-runner/pull/256)
+
 # 5.1.0 - 2021/05/10
 
 ## Enhnancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (5.1.0)
+    bugsnag-maze-runner (5.2.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '5.1.0'
+  VERSION = '5.2.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -81,6 +81,7 @@ module Maze
 
         # Specific Android devices
         add_android 'Google Pixel 4', '11.0', hash                        # ANDROID_11_0_GOOGLE_PIXEL_4
+        add_android 'Google Pixel 2', '9.0', hash                         # ANDROID_9_0_GOOGLE_PIXEL_2
         add_android 'Samsung Galaxy Note 9', '8.1', hash                  # ANDROID_8_1_SAMSUNG_GALAXY_NOTE_9
         add_android 'Samsung Galaxy J7 Prime', '8.1', hash                # ANDROID_8_1_SAMSUNG_GALAXY_J7_PRIME
         add_android 'Samsung Galaxy Tab S4', '8.1', hash                  # ANDROID_8_1_SAMSUNG_GALAXY_TAB_S4


### PR DESCRIPTION
## Goal

Adds a Pixel 2.0 running Android 9.0 accessible using `--device=ANDROID_9_0_GOOGLE_PIXEL_2`