### PR TITLE
Add —always-log option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.3.0 - TBD
+
+## Enhancements
+
+- Add `--always-log` option [#257](https://github.com/bugsnag/maze-runner/pull/257)
+
 # 5.2.0 - 2021/05/19
 
 ## Enhancements

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -164,7 +164,7 @@ After do |scenario|
   Maze::Proxy.instance.stop
 
   # Log unprocessed requests if the scenario fails
-  if scenario.failed? && Maze.config.log_requests
+  if (scenario.failed? && Maze.config.log_requests) || Maze.config.always_log
     STDOUT.puts '^^^ +++'
     output_received_requests('errors')
     output_received_requests('sessions')

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -121,5 +121,8 @@ module Maze
 
     # Suppress logging received requests during a test failure
     attr_accessor :log_requests
+
+    # Always log all received requests at the end of a scenario
+    attr_accessor :always_log
   end
 end

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -39,5 +39,6 @@ module Maze
 
     # Logging options
     LOG_REQUESTS = 'log-requests'
+    ALWAYS_LOG = 'always-log'
   end
 end

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -143,6 +143,11 @@ module Maze
                 type: :boolean,
                 default: true
 
+            opt Option::ALWAYS_LOG,
+                "Always log all received requests at the end of a scenario, whether is passes or fails",
+                short: :none,
+                default: false
+
             version "Maze Runner v#{Maze::VERSION} " \
                     "(Cucumber v#{Cucumber::VERSION.strip})"
             text ''

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -18,6 +18,7 @@ module Maze
 
           # Logger options
           config.log_requests = options[Maze::Option::LOG_REQUESTS]
+          config.always_log = options[Maze::Option::ALWAYS_LOG]
 
           # General appium options
           config.appium_session_isolation = options[Maze::Option::SEPARATE_SESSIONS]

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -67,12 +67,13 @@ class ProcessorTest < Test::Unit::TestCase
   end
 
   def test_logger_options
-    args = %w[--no-log-requests]
+    args = %w[--no-log-requests --always-log]
     options = Maze::Option::Parser.parse args
     config = Maze::Configuration.new
     Maze::Option::Processor.populate config, options
 
     assert_false config.log_requests
+    assert_true config.always_log
   end
 
   def test_default_options
@@ -90,5 +91,6 @@ class ProcessorTest < Test::Unit::TestCase
     assert_nil config.capabilities
 
     assert_true config.log_requests
+    assert_false config.always_log
   end
 end


### PR DESCRIPTION
## Goal

Adds an `--always-log` option, defaulting to `false`, to allow all received requests to be logged at the end of a scenario, whether it passes or fails.

## Tests

Tested locally and unit test updated.
