### PR TITLE
Add support for ARM-based Macs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Enhancements
 
-- Add `--always-log` option [#257](https://github.com/bugsnag/maze-runner/pull/257)
+- Add `--always-log` option [#258](https://github.com/bugsnag/maze-runner/pull/258)
+
+## Fixes
+
+- Add support for macOS running on ARM [#259](https://github.com/bugsnag/maze-runner/pull/259)
 
 # 5.2.0 - 2021/05/19
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,11 +74,19 @@ GEM
       kramdown (>= 1.5.0)
       props (>= 1.1.2)
       textutils (>= 0.10.0)
+    mini_portile2 (2.5.3)
     minitest (5.14.3)
     mocha (1.12.0)
     multi_json (1.15.0)
     multi_test (0.1.2)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogiri (1.11.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.11.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.11.3-x86_64-linux)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -117,6 +125,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin
   ruby
   x86_64-darwin
   x86_64-linux
@@ -131,4 +140,4 @@ DEPENDENCIES
   yard-cucumber (~> 4.0.0)
 
 BUNDLED WITH
-   2.2.13
+   2.2.20


### PR DESCRIPTION
## Goal

Provide support for running on ARM based Macs.

## Changeset

Adds the `arm64-darwin` platform to the `Gemfile.lock`.

## Tests

On an ARM-based Mac before running this change, running `bundle exec maze-runner --help` results in an exception: `Cannot load such file -- nokogiri/nokogiri`.  This change resolves that exception and allows the Maze Runner tool to be used to run e2e tests.