### PR TITLE
Add multipart steps usable against any request queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBA
+
+## Enhancements
+
+- Add multipart parsing steps usable for any payload types [#261](https://github.com/bugsnag/maze-runner/pull/261)
+
 # 5.4.0 - 2021/06/24
 
 ## Enhancements

--- a/lib/features/steps/multipart_request_steps.rb
+++ b/lib/features/steps/multipart_request_steps.rb
@@ -20,7 +20,7 @@ end
 
 # Verifies that the request contains multipart form-data
 Then('the request is valid multipart form-data') do
-  valid_multipart_form_data?(Maze::Server.errors.current)
+  step 'Then the error request is valid multipart form-data'
 end
 
 # Verifies that any type of request contains multipart form-data
@@ -33,7 +33,7 @@ end
 
 # Verifies all received requests contain multipart form-data
 Then('all requests are valid multipart form-data') do
-  Maze::Server.errors.all.all? { |request| valid_multipart_form_data?(request) }
+  step 'Then all error requests are valid multipart form-data'
 end
 
 # Verifies all requests of a given type contain multipart form-data
@@ -48,8 +48,7 @@ end
 #
 # @step_input part_count [Integer] The number of expected fields
 Then('the multipart request has {int} fields') do |part_count|
-  parts = Maze::Server.errors.current[:body]
-  assert_equal(part_count, parts.size)
+  step "Then the error multipart request has #{part_count} fields"
 end
 
 # Tests the number of fields a given type of multipart request contains.
@@ -64,8 +63,7 @@ end
 
 # Tests the multipart request has at least one field.
 Then('the multipart request has a non-empty body') do
-  parts = Maze::Server.errors.current[:body]
-  assert(parts.size.positive?, "Multipart request payload contained #{parts.size} fields")
+  step 'Then the error multipart request has a non-empty body'
 end
 
 # Tests a given type of multipart request has at least one field.
@@ -130,12 +128,7 @@ end
 #
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart body does not match the JSON file in {string}') do |json_path|
-  assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
-  raw_payload_value = Maze::Server.errors.current[:body]
-  payload_value = parse_multipart_body(raw_payload_value)
-  expected_value = JSON.parse(open(json_path, &:read))
-  result = Maze::Compare.value(expected_value, payload_value)
-  assert_false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
+  step "Then the error multipart body does not match the JSON file in \"#{json_path}\""
 end
 
 # Tests that a given type of multipart payload body does not match a JSON file.
@@ -158,12 +151,7 @@ end
 #
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart body matches the JSON file in {string}') do |json_path|
-  assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
-  raw_payload_value = Maze::Server.errors.current[:body]
-  payload_value = parse_multipart_body(raw_payload_value)
-  expected_value = JSON.parse(open(json_path, &:read))
-  result = Maze::Compare.value(expected_value, payload_value)
-  assert_true(result.equal?, "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
+  step "Then the error multipart body matches the JSON file in \"#{json_path}\""
 end
 
 # Tests that a given type of multipart payload body matches a JSON fixture.
@@ -187,11 +175,7 @@ end
 # @step_input field_path [String] Path to the tested element
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart field {string} matches the JSON file in {string}') do |field_path, json_path|
-  assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
-  payload_value = JSON.parse(Maze::Server.errors.current[:body][field_path].to_s)
-  expected_value = JSON.parse(open(json_path, &:read))
-  result = Maze::Compare.value(expected_value, payload_value)
-  assert_true(result.equal?, "The multipart field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
+  step "Then the error multipart field \"#{field_path}\" matches the JSON file in \"#{json_path}\""
 end
 
 # Tests that a given type of multipart field matches a JSON fixture.

--- a/lib/features/steps/multipart_request_steps.rb
+++ b/lib/features/steps/multipart_request_steps.rb
@@ -23,9 +23,25 @@ Then('the request is valid multipart form-data') do
   valid_multipart_form_data?(Maze::Server.errors.current)
 end
 
+# Verifies that any type of request contains multipart form-data
+#
+# @step_input request_type [String] The type of request (error, session, build, etc)
+Then('the {word} request is valid multipart form-data') do |request_type|
+  list = Maze::Server.list_for request_type
+  valid_multipart_form_data?(list.current)
+end
+
 # Verifies all received requests contain multipart form-data
 Then('all requests are valid multipart form-data') do
   Maze::Server.errors.all.all? { |request| valid_multipart_form_data?(request) }
+end
+
+# Verifies all requests of a given type contain multipart form-data
+#
+# @step_input request_type [String] The type of request (error, session, build, etc)
+Then('all {word} requests are valid multipart form-data') do |request_type|
+  list = Maze::Server.list_for request_type
+  list.all.all? { |request| valid_multipart_form_data?(request) }
 end
 
 # Tests the number of fields a multipart request contains.
@@ -36,9 +52,28 @@ Then('the multipart request has {int} fields') do |part_count|
   assert_equal(part_count, parts.size)
 end
 
+# Tests the number of fields a given type of multipart request contains.
+#
+# @step_input request_type [String] The type of request (error, session, build, etc)
+# @step_input part_count [Integer] The number of expected fields
+Then('the {word} multipart request has {int} fields') do |request_type, part_count|
+  list = Maze::Server.list_for request_type
+  parts = list.current[:body]
+  assert_equal(part_count, parts.size)
+end
+
 # Tests the multipart request has at least one field.
 Then('the multipart request has a non-empty body') do
   parts = Maze::Server.errors.current[:body]
+  assert(parts.size.positive?, "Multipart request payload contained #{parts.size} fields")
+end
+
+# Tests a given type of multipart request has at least one field.
+#
+# @step_input request_type [String] The type of request (error, session, build, etc)
+Then('the {word} multipart request has a non-empty body') do |request_type|
+  list = Maze::Server.list_for request_type
+  parts = list.current[:body]
   assert(parts.size.positive?, "Multipart request payload contained #{parts.size} fields")
 end
 
@@ -103,6 +138,21 @@ Then('the multipart body does not match the JSON file in {string}') do |json_pat
   assert_false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
 end
 
+# Tests that a given type of multipart payload body does not match a JSON file.
+# JSON formatted multipart fields will be parsed into hashes.
+#
+# @step_input request_type [String] The type of request (error, session, build, etc)
+# @step_input json_path [String] Path to a JSON file relative to maze-runner root
+Then('the {word} multipart body does not match the JSON file in {string}') do |request_type, json_path|
+  assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
+  payload_list = Maze::Server.list_for request_type
+  raw_payload_value = payload_list.current[:body]
+  payload_value = parse_multipart_body(raw_payload_value)
+  expected_value = JSON.parse(open(json_path, &:read))
+  result = Maze::Compare.value(expected_value, payload_value)
+  assert_false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
+end
+
 # Tests that the multipart payload body matches a JSON fixture.
 # JSON formatted multipart fields will be parsed into hashes.
 #
@@ -110,6 +160,21 @@ end
 Then('the multipart body matches the JSON file in {string}') do |json_path|
   assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
   raw_payload_value = Maze::Server.errors.current[:body]
+  payload_value = parse_multipart_body(raw_payload_value)
+  expected_value = JSON.parse(open(json_path, &:read))
+  result = Maze::Compare.value(expected_value, payload_value)
+  assert_true(result.equal?, "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
+end
+
+# Tests that a given type of multipart payload body matches a JSON fixture.
+# JSON formatted multipart fields will be parsed into hashes.
+#
+# @step_input request_type [String] The type of request (error, session, build, etc)
+# @step_input json_path [String] Path to a JSON file relative to maze-runner root
+Then('the {word} multipart body matches the JSON file in {string}') do |request_type, json_path|
+  assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
+  payload_list = Maze::Server.list_for request_type
+  raw_payload_value = payload_list.current[:body]
   payload_value = parse_multipart_body(raw_payload_value)
   expected_value = JSON.parse(open(json_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
@@ -124,6 +189,21 @@ end
 Then('the multipart field {string} matches the JSON file in {string}') do |field_path, json_path|
   assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
   payload_value = JSON.parse(Maze::Server.errors.current[:body][field_path].to_s)
+  expected_value = JSON.parse(open(json_path, &:read))
+  result = Maze::Compare.value(expected_value, payload_value)
+  assert_true(result.equal?, "The multipart field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
+end
+
+# Tests that a given type of multipart field matches a JSON fixture.
+# The field will be parsed into a hash.
+#
+# @step_input request_type [String] The type of request (error, session, build, etc)
+# @step_input field_path [String] Path to the tested element
+# @step_input json_path [String] Path to a JSON file relative to maze-runner root
+Then('the {word} multipart field {string} matches the JSON file in {string}') do |request_type, field_path, json_path|
+  assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
+  payload_list = Maze::Server.list_for request_type
+  payload_value = JSON.parse(payload_list.current[:body][field_path].to_s)
   expected_value = JSON.parse(open(json_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
   assert_true(result.equal?, "The multipart field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")

--- a/lib/features/steps/multipart_request_steps.rb
+++ b/lib/features/steps/multipart_request_steps.rb
@@ -18,8 +18,12 @@ def valid_multipart_form_data?(request)
   assert(request[:body].size.positive?, "Multipart request payload contained #{request[:body].size} fields")
 end
 
+# (Deprecated) Retained for backwards compatibility
+# Use "the {word} request is valid multipart form-data"
+#
 # Verifies that the request contains multipart form-data
 Then('the request is valid multipart form-data') do
+  $logger.warn 'This step is deprecated and may be removed in a future release'
   step 'Then the error request is valid multipart form-data'
 end
 
@@ -31,8 +35,12 @@ Then('the {word} request is valid multipart form-data') do |request_type|
   valid_multipart_form_data?(list.current)
 end
 
+# (Deprecated) Retained for backwards compatibility
+# Use "all {word} requests are valid multipart form-data"
+#
 # Verifies all received requests contain multipart form-data
 Then('all requests are valid multipart form-data') do
+  $logger.warn 'This step is deprecated and may be removed in a future release'
   step 'Then all error requests are valid multipart form-data'
 end
 
@@ -44,10 +52,14 @@ Then('all {word} requests are valid multipart form-data') do |request_type|
   list.all.all? { |request| valid_multipart_form_data?(request) }
 end
 
+# (Deprecated) Retained for backwards compatibility
+# Use "the {word} multipart request has {int} fields"
+#
 # Tests the number of fields a multipart request contains.
 #
 # @step_input part_count [Integer] The number of expected fields
 Then('the multipart request has {int} fields') do |part_count|
+  $logger.warn 'This step is deprecated and may be removed in a future release'
   step "Then the error multipart request has #{part_count} fields"
 end
 
@@ -61,8 +73,12 @@ Then('the {word} multipart request has {int} fields') do |request_type, part_cou
   assert_equal(part_count, parts.size)
 end
 
+# (Deprecated) Retained for backwards compatibility
+# Use "the {word} multipart request has a non-empty body"
+#
 # Tests the multipart request has at least one field.
 Then('the multipart request has a non-empty body') do
+  $logger.warn 'This step is deprecated and may be removed in a future release'
   step 'Then the error multipart request has a non-empty body'
 end
 
@@ -82,6 +98,7 @@ end
 #
 # @step_input part_key [String] The key to the multipart element
 Then('the field {string} for multipart request is not null') do |part_key|
+  $logger.warn 'This step is deprecated and may be removed in a future release'
   parts = Maze::Server.errors.current[:body]
   assert_not_nil(parts[part_key], "The field '#{part_key}' should not be null")
 end
@@ -94,6 +111,7 @@ end
 # @step_input part_key [String] The key to the multipart element
 # @step_input expected_value [String] The string to match against
 Then('the field {string} for multipart request equals {string}') do |part_key, expected_value|
+  $logger.warn 'This step is deprecated and may be removed in a future release'
   parts = Maze::Server.errors.current[:body]
   assert_equal(parts[part_key], expected_value)
 end
@@ -105,6 +123,7 @@ end
 #
 # @step_input part_key [String] The key to the multipart element
 Then('the field {string} for multipart request is null') do |part_key|
+  $logger.warn 'This step is deprecated and may be removed in a future release'
   parts = Maze::Server.errors.current[:body]
   assert_nil(parts[part_key], "The field '#{part_key}' should be null")
 end
@@ -123,11 +142,15 @@ def parse_multipart_body(body)
   end
 end
 
+# (Deprecated) Retained for backwards compatibility
+# Use "the {word} multipart body does not match the JSON file in {string}"
+#
 # Tests that the multipart payload body does not match a JSON file.
 # JSON formatted multipart fields will be parsed into hashes.
 #
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart body does not match the JSON file in {string}') do |json_path|
+  $logger.warn 'This step is deprecated and may be removed in a future release'
   step "Then the error multipart body does not match the JSON file in \"#{json_path}\""
 end
 
@@ -146,11 +169,15 @@ Then('the {word} multipart body does not match the JSON file in {string}') do |r
   assert_false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
 end
 
+# (Deprecated) Retained for backwards compatibility
+# Use "the {word} multipart body matches the JSON file in {string}"
+#
 # Tests that the multipart payload body matches a JSON fixture.
 # JSON formatted multipart fields will be parsed into hashes.
 #
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart body matches the JSON file in {string}') do |json_path|
+  $logger.warn 'This step is deprecated and may be removed in a future release'
   step "Then the error multipart body matches the JSON file in \"#{json_path}\""
 end
 
@@ -169,12 +196,16 @@ Then('the {word} multipart body matches the JSON file in {string}') do |request_
   assert_true(result.equal?, "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
 end
 
+# (Deprecated) Retained for backwards compatibility
+# Use "the {word} multipart field {string} matches the JSON file in {string}"
+#
 # Tests that a multipart field matches a JSON fixture.
 # The field will be parsed into a hash.
 #
 # @step_input field_path [String] Path to the tested element
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart field {string} matches the JSON file in {string}') do |field_path, json_path|
+  $logger.warn 'This step is deprecated and may be removed in a future release'
   step "Then the error multipart field \"#{field_path}\" matches the JSON file in \"#{json_path}\""
 end
 

--- a/lib/features/steps/multipart_request_steps.rb
+++ b/lib/features/steps/multipart_request_steps.rb
@@ -18,15 +18,6 @@ def valid_multipart_form_data?(request)
   assert(request[:body].size.positive?, "Multipart request payload contained #{request[:body].size} fields")
 end
 
-# (Deprecated) Retained for backwards compatibility
-# Use "the {word} request is valid multipart form-data"
-#
-# Verifies that the request contains multipart form-data
-Then('the request is valid multipart form-data') do
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  step 'Then the error request is valid multipart form-data'
-end
-
 # Verifies that any type of request contains multipart form-data
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
@@ -36,12 +27,12 @@ Then('the {word} request is valid multipart form-data') do |request_type|
 end
 
 # (Deprecated) Retained for backwards compatibility
-# Use "all {word} requests are valid multipart form-data"
+# Use "the {word} request is valid multipart form-data"
 #
-# Verifies all received requests contain multipart form-data
-Then('all requests are valid multipart form-data') do
+# Verifies that the request contains multipart form-data
+Then('the request is valid multipart form-data') do
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step 'Then all error requests are valid multipart form-data'
+  step 'Then the error request is valid multipart form-data'
 end
 
 # Verifies all requests of a given type contain multipart form-data
@@ -53,14 +44,12 @@ Then('all {word} requests are valid multipart form-data') do |request_type|
 end
 
 # (Deprecated) Retained for backwards compatibility
-# Use "the {word} multipart request has {int} fields"
+# Use "all {word} requests are valid multipart form-data"
 #
-# Tests the number of fields a multipart request contains.
-#
-# @step_input part_count [Integer] The number of expected fields
-Then('the multipart request has {int} fields') do |part_count|
+# Verifies all received requests contain multipart form-data
+Then('all requests are valid multipart form-data') do
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "Then the error multipart request has #{part_count} fields"
+  step 'Then all error requests are valid multipart form-data'
 end
 
 # Tests the number of fields a given type of multipart request contains.
@@ -74,12 +63,14 @@ Then('the {word} multipart request has {int} fields') do |request_type, part_cou
 end
 
 # (Deprecated) Retained for backwards compatibility
-# Use "the {word} multipart request has a non-empty body"
+# Use "the {word} multipart request has {int} fields"
 #
-# Tests the multipart request has at least one field.
-Then('the multipart request has a non-empty body') do
+# Tests the number of fields a multipart request contains.
+#
+# @step_input part_count [Integer] The number of expected fields
+Then('the multipart request has {int} fields') do |part_count|
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step 'Then the error multipart request has a non-empty body'
+  step "Then the error multipart request has #{part_count} fields"
 end
 
 # Tests a given type of multipart request has at least one field.
@@ -89,6 +80,15 @@ Then('the {word} multipart request has a non-empty body') do |request_type|
   list = Maze::Server.list_for request_type
   parts = list.current[:body]
   assert(parts.size.positive?, "Multipart request payload contained #{parts.size} fields")
+end
+
+# (Deprecated) Retained for backwards compatibility
+# Use "the {word} multipart request has a non-empty body"
+#
+# Tests the multipart request has at least one field.
+Then('the multipart request has a non-empty body') do
+  $logger.warn 'This step is deprecated and may be removed in a future release'
+  step 'Then the error multipart request has a non-empty body'
 end
 
 # (Deprecated) Retained for backwards compatibility.
@@ -142,18 +142,6 @@ def parse_multipart_body(body)
   end
 end
 
-# (Deprecated) Retained for backwards compatibility
-# Use "the {word} multipart body does not match the JSON file in {string}"
-#
-# Tests that the multipart payload body does not match a JSON file.
-# JSON formatted multipart fields will be parsed into hashes.
-#
-# @step_input json_path [String] Path to a JSON file relative to maze-runner root
-Then('the multipart body does not match the JSON file in {string}') do |json_path|
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "Then the error multipart body does not match the JSON file in \"#{json_path}\""
-end
-
 # Tests that a given type of multipart payload body does not match a JSON file.
 # JSON formatted multipart fields will be parsed into hashes.
 #
@@ -170,15 +158,15 @@ Then('the {word} multipart body does not match the JSON file in {string}') do |r
 end
 
 # (Deprecated) Retained for backwards compatibility
-# Use "the {word} multipart body matches the JSON file in {string}"
+# Use "the {word} multipart body does not match the JSON file in {string}"
 #
-# Tests that the multipart payload body matches a JSON fixture.
+# Tests that the multipart payload body does not match a JSON file.
 # JSON formatted multipart fields will be parsed into hashes.
 #
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
-Then('the multipart body matches the JSON file in {string}') do |json_path|
+Then('the multipart body does not match the JSON file in {string}') do |json_path|
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "Then the error multipart body matches the JSON file in \"#{json_path}\""
+  step "Then the error multipart body does not match the JSON file in \"#{json_path}\""
 end
 
 # Tests that a given type of multipart payload body matches a JSON fixture.
@@ -197,16 +185,15 @@ Then('the {word} multipart body matches the JSON file in {string}') do |request_
 end
 
 # (Deprecated) Retained for backwards compatibility
-# Use "the {word} multipart field {string} matches the JSON file in {string}"
+# Use "the {word} multipart body matches the JSON file in {string}"
 #
-# Tests that a multipart field matches a JSON fixture.
-# The field will be parsed into a hash.
+# Tests that the multipart payload body matches a JSON fixture.
+# JSON formatted multipart fields will be parsed into hashes.
 #
-# @step_input field_path [String] Path to the tested element
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
-Then('the multipart field {string} matches the JSON file in {string}') do |field_path, json_path|
+Then('the multipart body matches the JSON file in {string}') do |json_path|
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "Then the error multipart field \"#{field_path}\" matches the JSON file in \"#{json_path}\""
+  step "Then the error multipart body matches the JSON file in \"#{json_path}\""
 end
 
 # Tests that a given type of multipart field matches a JSON fixture.
@@ -222,4 +209,17 @@ Then('the {word} multipart field {string} matches the JSON file in {string}') do
   expected_value = JSON.parse(open(json_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
   assert_true(result.equal?, "The multipart field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
+end
+
+# (Deprecated) Retained for backwards compatibility
+# Use "the {word} multipart field {string} matches the JSON file in {string}"
+#
+# Tests that a multipart field matches a JSON fixture.
+# The field will be parsed into a hash.
+#
+# @step_input field_path [String] Path to the tested element
+# @step_input json_path [String] Path to a JSON file relative to maze-runner root
+Then('the multipart field {string} matches the JSON file in {string}') do |field_path, json_path|
+  $logger.warn 'This step is deprecated and may be removed in a future release'
+  step "Then the error multipart field \"#{field_path}\" matches the JSON file in \"#{json_path}\""
 end

--- a/lib/features/steps/multipart_request_steps.rb
+++ b/lib/features/steps/multipart_request_steps.rb
@@ -32,7 +32,7 @@ end
 # Verifies that the request contains multipart form-data
 Then('the request is valid multipart form-data') do
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step 'Then the error request is valid multipart form-data'
+  step 'the error request is valid multipart form-data'
 end
 
 # Verifies all requests of a given type contain multipart form-data
@@ -49,7 +49,7 @@ end
 # Verifies all received requests contain multipart form-data
 Then('all requests are valid multipart form-data') do
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step 'Then all error requests are valid multipart form-data'
+  step 'all error requests are valid multipart form-data'
 end
 
 # Tests the number of fields a given type of multipart request contains.
@@ -70,7 +70,7 @@ end
 # @step_input part_count [Integer] The number of expected fields
 Then('the multipart request has {int} fields') do |part_count|
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "Then the error multipart request has #{part_count} fields"
+  step "the error multipart request has #{part_count} fields"
 end
 
 # Tests a given type of multipart request has at least one field.
@@ -88,7 +88,7 @@ end
 # Tests the multipart request has at least one field.
 Then('the multipart request has a non-empty body') do
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step 'Then the error multipart request has a non-empty body'
+  step 'the error multipart request has a non-empty body'
 end
 
 # (Deprecated) Retained for backwards compatibility.
@@ -166,7 +166,7 @@ end
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart body does not match the JSON file in {string}') do |json_path|
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "Then the error multipart body does not match the JSON file in \"#{json_path}\""
+  step "the error multipart body does not match the JSON file in \"#{json_path}\""
 end
 
 # Tests that a given type of multipart payload body matches a JSON fixture.
@@ -193,7 +193,7 @@ end
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart body matches the JSON file in {string}') do |json_path|
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "Then the error multipart body matches the JSON file in \"#{json_path}\""
+  step "the error multipart body matches the JSON file in \"#{json_path}\""
 end
 
 # Tests that a given type of multipart field matches a JSON fixture.
@@ -221,5 +221,5 @@ end
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the multipart field {string} matches the JSON file in {string}') do |field_path, json_path|
   $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "Then the error multipart field \"#{field_path}\" matches the JSON file in \"#{json_path}\""
+  step "the error multipart field \"#{field_path}\" matches the JSON file in \"#{json_path}\""
 end


### PR DESCRIPTION
Adds new multipart request steps that allow multipart field checking on any received requests.

Deprecated steps have not been updated (as there are up to date replacements that should be used instead).

To keep backwards compatibility the original steps call into the new steps using the `error` queue by default.