### PR TITLE
Remove short command line options to avoid clashes with cucumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add `--file-log` option to write received requests to files [#262](https://github.com/bugsnag/maze-runner/pull/262)
 
+## Fixes
+
+- Remove short form from all command line options [#263](https://github.com/bugsnag/maze-runner/pull/263)
+
 # 5.3.0 - 2021/06/21
 
 ## Enhancements

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -28,11 +28,9 @@ module Maze
 
             opt Option::BIND_ADDRESS,
                 'Mock server bind address',
-                short: :none,
                 type: :string
             opt Option::PORT,
                 'Mock server port',
-                short: :none,
                 default: 9339
 
             text ''
@@ -40,29 +38,23 @@ module Maze
 
             opt Option::SEPARATE_SESSIONS,
                 'Start a new Appium session for each scenario',
-                short: :none,
                 type: :boolean,
                 default: false
             opt Option::FARM,
                 'Device farm to use: "bs" (BrowserStack) or "local"',
-                short: '-f',
                 type: :string
             opt Option::APP,
                 'The app to be installed and run against',
-                short: '-a',
                 type: :string
             opt Option::A11Y_LOCATOR,
                 'Locate elements by accessibility id rather than id',
-                short: :none,
                 type: :boolean,
                 default: false
             opt Option::RESILIENT,
                 'Use the resilient Appium driver',
-                short: '-r',
                 default: false
             opt Option::CAPABILITIES,
                 'Additional desired Appium capabilities as a JSON string',
-                short: '-c',
                 default: '{}'
 
             text ''
@@ -78,27 +70,22 @@ module Maze
                 type: :string
             opt Option::USERNAME,
                 'Device farm username. Consumes env var from environment based on farm set',
-                short: '-u',
                 type: :string
             opt Option::ACCESS_KEY,
                 'Device farm access key. Consumes env var from environment based on farm set',
-                short: '-p',
                 type: :string
             opt Option::APPIUM_VERSION,
                 'The Appium version to use with BrowserStack',
-                short: :none,
                 type: :string
 
             # BrowserStack-only options
             opt Option::BS_LOCAL,
                 '(BS only) Path to the BrowserStackLocal binary. MAZE_BS_LOCAL env var or "/BrowserStackLocal" by default',
-                short: :none,
                 type: :string
 
             # Sauce Labs-only options
             opt Option::SL_LOCAL,
                 '(SL only) Path to the Sauce Connect binary. MAZE_SL_LOCAL env var or "/sauce-connect/bin/sc" by default',
-                short: :none,
                 type: :string
 
             text ''
@@ -106,31 +93,24 @@ module Maze
 
             opt Option::OS,
                 'OS type to use ("ios", "android")',
-                short: :none,
                 type: :string
             opt Option::OS_VERSION,
                 'The intended OS version when running on a local device',
-                short: :none,
                 type: :string
             opt Option::APPIUM_SERVER,
                 'Appium server URL, only used for --farm=local. MAZE_APPIUM_SERVER env var or "http://localhost:4723/wd/hub" by default',
-                short: :none,
                 type: :string
             opt Option::START_APPIUM,
                 'Whether a local Appium server should be start.  Only used for --farm=local.',
-                short: :none,
                 default: true
             opt Option::APPIUM_LOGFILE,
                 'The file local appium server output is logged to, defaulting to "appium_server.log"',
-                short: :none,
                 default: 'appium_server.log'
             opt Option::APPLE_TEAM_ID,
                 'Apple Team Id, required for local iOS testing. MAZE_APPLE_TEAM_ID env var by default',
-                short: :none,
                 type: :string
             opt Option::UDID,
                 'Apple UDID, required for local iOS testing. MAZE_UDID env var by default',
-                short: :none,
                 type: :string
 
             text ''
@@ -138,19 +118,17 @@ module Maze
 
             opt Option::FILE_LOG,
                 "Writes lists of received requests to the maze_output folder for all scenarios",
-                short: :none,
                 type: :boolean,
                 default: true
 
             opt Option::LOG_REQUESTS,
                 "Log lists of received requests to the console in the event of scenario failure.  Defaults to true if the BUILDKITE environment variable is set",
-                short: :none,
                 type: :boolean,
                 default: false
 
             opt Option::ALWAYS_LOG,
-                "Always log all received requests to the console at the end of a scenario, whether is passes or fails",
-                short: :none,
+                "Always log all received requests at the end of a scenario, whether is passes or fails",
+                type: :boolean,
                 default: false
 
             version "Maze Runner v#{Maze::VERSION} " \

--- a/test/option/parser_test.rb
+++ b/test/option/parser_test.rb
@@ -114,28 +114,6 @@ class ParserTest < Test::Unit::TestCase
     assert_true(options[Maze::Option::LOG_REQUESTS])
   end
 
-  def test_short_flags
-    args = %w[
-      -f SHORT_FARM
-      -a SHORT_APP
-      -r
-      -c SHORT_CAPABILITIES
-      -u SHORT_USERNAME
-      -p SHORT_ACCESS_KEY
-    ]
-    options = Maze::Option::Parser.parse args
-
-    # Common options
-    assert_equal('SHORT_FARM', options[Maze::Option::FARM])
-    assert_equal('SHORT_APP', options[Maze::Option::APP])
-    assert_true(options[Maze::Option::RESILIENT])
-    assert_equal('SHORT_CAPABILITIES', options[Maze::Option::CAPABILITIES])
-
-    # BrowserStack-only options
-    assert_equal('SHORT_USERNAME', options[Maze::Option::USERNAME])
-    assert_equal('SHORT_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])
-  end
-
   def test_environment_values
     ENV['BROWSER_STACK_USERNAME'] = 'ENV_USERNAME'
     ENV['BROWSER_STACK_ACCESS_KEY'] = 'ENV_ACCESS_KEY'


### PR DESCRIPTION
## Goal

Slightly knee-jerk removal of short-form command line options to avoid an clashes with underlying Cucumber options.

## Design

Longer term, a wholesale reassessment of command line use is likely to take place, including the use of files for options and `--` separators in the CL (for instance).

## Tests

Covered by CI and existing unit tests.
