### PR TITLE
Add Android 10 devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# TBA
+# 5.4.0 - 2021/06/24
 
 ## Enhancements
 
 - Add `--file-log` option to write received requests to files [#262](https://github.com/bugsnag/maze-runner/pull/262)
+- Add additional BrowserStack Android 10 devices [#264](https://github.com/bugsnag/maze-runner/pull/264)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (5.3.0)
+    bugsnag-maze-runner (5.4.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '5.3.0'
+  VERSION = '5.4.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -81,6 +81,12 @@ module Maze
 
         # Specific Android devices
         add_android 'Google Pixel 4', '11.0', hash                        # ANDROID_11_0_GOOGLE_PIXEL_4
+
+        add_android 'Xiaomi Redmi Note 9', '10.0', hash                   # ANDROID_10_0_XIAOMI_REDMI_NOTE_9
+        add_android 'Samsung Galaxy Note 20', '10.0', hash                # ANDROID_10_0_SAMSUNG_GALAXY_NOTE_20
+        add_android 'Motorola Moto G9 Play', '10.0', hash                 # ANDROID_10_0_MOTOROLA_MOTO_G9_PLAY
+        add_android 'OnePlus 8', '10.0', hash                             # ANDROID_10_0_ONEPLUS_8
+
         add_android 'Google Pixel 2', '9.0', hash                         # ANDROID_9_0_GOOGLE_PIXEL_2
         add_android 'Samsung Galaxy Note 9', '8.1', hash                  # ANDROID_8_1_SAMSUNG_GALAXY_NOTE_9
         add_android 'Samsung Galaxy J7 Prime', '8.1', hash                # ANDROID_8_1_SAMSUNG_GALAXY_J7_PRIME


### PR DESCRIPTION
## Goal

Adds a small variety of Android 10 devices available on BrowserStack.

## Tests

Use of all new devices tested locally.