### PR TITLE
Remove now unnecessary libcurl3 from license_finder docker image

### DIFF
--- a/dockerfiles/Dockerfile.audit
+++ b/dockerfiles/Dockerfile.audit
@@ -2,7 +2,7 @@ FROM licensefinder/license_finder
 
 RUN apt-get update && apt-get install -y \
                       # Needed by curb (a dependency of Cucumber)
-                      libcurl3 libcurl4-openssl-dev
+                      libcurl4-openssl-dev
 
 WORKDIR /scan
 


### PR DESCRIPTION
## Goal

libcurl3 and libcurl4-openssl-dev conflict on the latest version of the license-audit base image, causing the build to fail.  As only libcurl4-openssl-dev is required we can remove libcurl3 completely.