### PR TITLE
Allow Windows to be set as --os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# TBA
+# 5.5.0 - 2021/07/06
 
 ## Enhancements
 
@@ -7,6 +7,7 @@
 ## Fixes
 
 - Correct logging of received requests [#267](https://github.com/bugsnag/maze-runner/pull/267)
+- Allow Windows to be specified as `--os` option [#268](https://github.com/bugsnag/maze-runner/pull/268)
 
 # 5.4.0 - 2021/06/24
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (5.4.0)
+    bugsnag-maze-runner (5.5.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '5.4.0'
+  VERSION = '5.5.0'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -72,8 +72,12 @@ module Maze
               config.device_id = options[Maze::Option::UDID]
             end
           when :none
-            config.os = options[Maze::Option::OS].downcase
-            config.os_version = options[Maze::Option::OS_VERSION].to_f
+            if options[Maze::Option::OS]
+              config.os = options[Maze::Option::OS].downcase
+            end
+            if options[Maze::Option::OS_VERSION]
+              config.os_version = options[Maze::Option::OS_VERSION].to_f
+            end
           else
             raise "Unexpected farm option #{config.farm}"
           end

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -72,7 +72,8 @@ module Maze
               config.device_id = options[Maze::Option::UDID]
             end
           when :none
-            nil
+            config.os = options[Maze::Option::OS].downcase
+            config.os_version = options[Maze::Option::OS_VERSION].to_f
           else
             raise "Unexpected farm option #{config.farm}"
           end

--- a/lib/maze/option/validator.rb
+++ b/lib/maze/option/validator.rb
@@ -117,7 +117,7 @@ module Maze
           errors << "--#{Option::OS} must be specified"
         else
           os = options[Option::OS].downcase
-          errors << 'os must be android, ios or macos' unless %w[android ios macos].include? os
+          errors << 'os must be android, ios, macos or windows' unless %w[android ios macos windows].include? os
           if os == 'ios'
             errors << "--#{Option::APPLE_TEAM_ID} must be specified for iOS" if options[Option::APPLE_TEAM_ID].nil?
             errors << "--#{Option::UDID} must be specified for iOS" if options[Option::UDID].nil?

--- a/test/option/validator_test.rb
+++ b/test/option/validator_test.rb
@@ -105,7 +105,7 @@ class ValidatorTest < Test::Unit::TestCase
     errors = @validator.validate options
 
     assert_equal 1, errors.length
-    assert_equal 'os must be android, ios or macos', errors[0]
+    assert_equal 'os must be android, ios, macos or windows', errors[0]
   end
 
   def test_local_missing_os


### PR DESCRIPTION
## Goal

Allow `windows` to be specified as the `--os`.  Also allow the `--os-version` to be set when running with no farm (i.e. not Appium).

## Design

The approach to running Unity tests on Windows has been to employ WSL.  This means that MazeRunner can run on Ubuntu, on Windows, avoiding the need to port the codebase (noting that many dependencies have native extensions).  However, it also means that the MazeRunner test setups cannot meaningfully detect the current operating system (Ruby will report Linux).  Adding this option allows the developer to explicitly configure where the tests are being run.

## Changeset

Command line option processing and validation updated.

## Tests

Tested locally as part of setting up MR testing on Windows for our Unity notifier.