### PR TITLE
Only start macOS apps when using Appium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.5.1 - 2021/07/06
+
+## Fixes
+
+- Only start macOS apps when using Appium [#269](https://github.com/bugsnag/maze-runner/pull/269)
+
 # 5.5.0 - 2021/07/06
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (5.5.0)
+    bugsnag-maze-runner (5.5.1)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/lib/features/support/hooks.rb
+++ b/lib/features/support/hooks.rb
@@ -137,8 +137,8 @@ Before do |scenario|
 
   Maze.driver.start_driver if Maze.config.farm != :none && Maze.config.appium_session_isolation
 
-  # Launch the app on macOS
-  Maze.driver.get(Maze.config.app) if Maze.config.os == 'macos'
+  # Launch the app on macOS, if Appium is being used
+  Maze.driver.get(Maze.config.app) if Maze.driver && Maze.config.os == 'macos'
 
   # Call any blocks registered by the client
   Maze.hooks.call_before scenario

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '5.5.0'
+  VERSION = '5.5.1'
 
   class << self
     attr_accessor :driver


### PR DESCRIPTION
## Goal

Prevent the dereference of `nil` with using `--os=macos` with a `--farm` (i.e. starting the macOS app on the command line and not using Appium.

## Design

v5.5.0 introduced the ability to specify an `--os` option without having to use Appium, to allow clients to make decisions based on the intended platform.  The existing code assumed that Appium would be used, leading to a `nil` `Maze.driver`.

## Changeset

Addition of a nil guard.

## Tests

Tested locally using the Unity e2e tests on macOS, where the problem was highlighted.  Longer term we should add some more macOS-based tests to our pipeline (with and without Appium).
