### PR TITLE
Correct guard for “platform-dependent” steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Fixes
+
+- Correct guard for platform-dependent value steps [#270](https://github.com/bugsnag/maze-runner/pull/270)
+
 # 5.5.1 - 2021/07/06
 
 ## Fixes

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -168,8 +168,6 @@ When('I clear and send the keys {string} to the element {string}') do |keys, ele
 end
 
 def get_expected_platform_value(platform_values)
-  raise('This step should only be used when running tests with Appium') if Maze.driver.nil?
-
   if Maze.config.farm == :bs
     os = Maze.config.capabilities['os']
   elsif Maze.config.farm == :sl
@@ -177,6 +175,9 @@ def get_expected_platform_value(platform_values)
   else
     os = Maze.config.os
   end
+
+  raise('Unable to determine the current platform') if os.nil?
+
   expected_value = Hash[platform_values.raw][os.downcase]
   raise("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
 


### PR DESCRIPTION
## Goal

Corrects the guard on "platform-dependent value" steps that was using a now false assumption that Appium must be in use for the `--os` option to be set.

## Tests

Verified locally that Unity steps that were failing due to this now pass.