### PR TITLE
Pin Rubyzip version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add document server (`--document-server-root` and associated options) [#274](https://github.com/bugsnag/maze-runner/pull/274)
 
+## Fixes
+
+- Pin RubyZip to avoid possible breakage under Ruby [#275](https://github.com/bugsnag/maze-runner/pull/275)
+
 # 5.6.0 - 2021/07/09
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Fixes
 
-- Pin RubyZip to avoid possible breakage under Ruby [#275](https://github.com/bugsnag/maze-runner/pull/275)
+- Pin RubyZip to avoid possible breakage from RubyZip 3.0 [#275](https://github.com/bugsnag/maze-runner/pull/275)
 
 # 5.6.0 - 2021/07/09
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
       optimist (~> 3.0.1)
       os (~> 1.0.0)
       rake (~> 12.3.3)
+      rubyzip (~> 2.3.2)
       selenium-webdriver (~> 3.11)
       test-unit (~> 3.3.0)
 

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -29,6 +29,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'optimist', '~> 3.0.1'
   spec.add_dependency 'rake', '~> 12.3.3'
   spec.add_dependency 'selenium-webdriver', '~> 3.11'
+
+  # Pin indirect dependencies
+  spec.add_runtime_dependency 'rubyzip', '~> 2.3.2'
+
   # TODO: Removed pending PLAT-6322
   # spec.add_dependency 'boring', '~> 0.1.0'
 


### PR DESCRIPTION
## Goal

Pin the version of RubyZip, an indirect dependency dependency, to avoid possible breakage in Ruby 3.