### PR TITLE
add a generic send keys methods for unity as it can't access elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Enhancements
+
+- Add a generic send keys method so you can send keys without finding an element [#278](https://github.com/bugsnag/maze-runner/pull/278)
+
 # 5.7.0 - 2021/07/14
 
 ## Enhancements

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -119,10 +119,6 @@ module Maze
         @driver.send_keys(text)
       end
 
-      def hide_keyboard
-        @driver.hide_keyboard
-      end
-
       # Sends keys to a given element, clearing it first
       #
       # @param element_id [String] the element to clear and send text to

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -112,6 +112,17 @@ module Maze
         @driver.rotation = orientation
       end
 
+      # Send keys to the device without a specific element
+      #
+      # @param text [String] the text to send
+      def send_keys(text)
+        @driver.send_keys(text)
+      end
+
+      def hide_keyboard
+        @driver.hide_keyboard
+      end
+
       # Sends keys to a given element, clearing it first
       #
       # @param element_id [String] the element to clear and send text to


### PR DESCRIPTION
add a generic send keys methods for unity as it can't access elements