### PR TITLE
Support Ruby 3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,21 +6,6 @@ steps:
         run: license_finder
     command: /bin/bash -lc '/scan/scripts/license_finder.sh'
 
-  - label: ':docker: Build CI image for Ruby 2.5'
-    key: "ci-image-ruby-2-5"
-    plugins:
-      - docker-compose#v3.7.0:
-          build:
-            - ci-ruby-2.5
-          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
-          cache-from:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.5
-      - docker-compose#v3.7.0:
-          push:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.5
-    env:
-      RUBY_VERSION: "2.5"
-
   - label: ':docker: Build CI image for Ruby 2.7'
     key: "ci-image-ruby-2-7"
     plugins:
@@ -51,16 +36,16 @@ steps:
     env:
       RUBY_VERSION: "3"
 
-  - label: 'Unit tests with Ruby 2.5'
-    depends_on: 'ci-image-ruby-2-5'
+  - label: 'Unit tests with Ruby 2.7'
+    depends_on: 'ci-image-ruby-2-7'
     plugins:
       docker-compose#v3.7.0:
         run: unit-test
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:
-          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.5
+          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
     env:
-      RUBY_VERSION: "2.5"
+      RUBY_VERSION: "2.7"
     command: 'bundle exec rake'
 
   - label: 'Unit tests with Ruby 3'
@@ -89,8 +74,8 @@ steps:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
 
-  - label: 'No-device tests with Ruby 2.5'
-    depends_on: "ci-image-ruby-2-5"
+  - label: 'No-device tests with Ruby 2.7'
+    depends_on: "ci-image-ruby-2-7"
     plugins:
       - docker-compose#v3.7.0:
           run: framework-tests
@@ -107,7 +92,7 @@ steps:
       - docker-compose#v3.7.0:
           run: docker-tests
     env:
-      RUBY_VERSION: "2.5"
+      RUBY_VERSION: "2.7"
     command: 'bundle exec maze-runner'
 
   - label: 'No-device tests with Ruby 3'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -125,7 +125,7 @@ steps:
       bundle exec maze-runner
       --no-log-requests
 
-  - label: 'Browserstack app-automate test - Android 6 using Ruby 2.7'
+  - label: 'Browserstack app-automate test - Android 6'
     depends_on: "ci-image-ruby-2-7"
     plugins:
       docker-compose#v3.7.0:
@@ -142,7 +142,7 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: 'Browserstack app-automate test - Android 11 using Ruby 3'
+  - label: 'Browserstack app-automate test - Android 11'
     depends_on: "ci-image-ruby-3"
     plugins:
       docker-compose#v3.7.0:
@@ -150,7 +150,7 @@ steps:
       artifacts#v1.3.0:
         upload: test/fixtures/android-appium-test/maze_output/**/*
     env:
-      RUBY_VERSION: "3"
+      RUBY_VERSION: "2.7"
     command: >-
       bundle exec maze-runner
       --app=app/build/outputs/apk/release/app-release.apk

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,12 +6,6 @@ steps:
         run: license_finder
     command: /bin/bash -lc '/scan/scripts/license_finder.sh'
 
-  - label: 'Unit tests'
-    plugins:
-      docker-compose#v3.7.0:
-        run: unit-test
-    command: 'bundle exec rake'
-
   - label: ':docker: Build CI image'
     key: "ci-image"
     plugins:
@@ -24,6 +18,16 @@ steps:
       - docker-compose#v3.7.0:
           push:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+
+  - label: 'Unit tests'
+    depends_on: 'ci-image'
+    plugins:
+      docker-compose#v3.7.0:
+        run: unit-test
+        image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+        cache-from:
+          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+    command: 'bundle exec rake'
 
   - label: ':docker: Push Docker image for branch'
     key: "cli-image"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -62,7 +62,7 @@ steps:
 
   - label: ':docker: Push Docker image for branch'
     key: "cli-image"
-    depends_on: "ci-image-2-7"
+    depends_on: "ci-image-ruby-2-7"
     plugins:
       - docker-compose#v3.7.0:
           build: cli

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -125,11 +125,14 @@ steps:
       bundle exec maze-runner
       --no-log-requests
 
-  - label: 'Browserstack app-automate test - Android 6'
+  - label: 'Browserstack app-automate test - Android 6 using Ruby 2.7'
     depends_on: "ci-image-ruby-2-7"
     plugins:
       docker-compose#v3.7.0:
         run: android-appium-test
+        image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+        cache-from:
+          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
       artifacts#v1.3.0:
         upload: test/fixtures/android-appium-test/maze_output/**/*
     env:
@@ -142,15 +145,18 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: 'Browserstack app-automate test - Android 11'
-    depends_on: "ci-image-ruby-2-7"
+  - label: 'Browserstack app-automate test - Android 11 using Ruby 3'
+    depends_on: "ci-image-ruby-3"
     plugins:
       docker-compose#v3.7.0:
         run: android-appium-test
+        image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+        cache-from:
+          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
       artifacts#v1.3.0:
         upload: test/fixtures/android-appium-test/maze_output/**/*
     env:
-      RUBY_VERSION: "2.7"
+      RUBY_VERSION: "3"
     command: >-
       bundle exec maze-runner
       --app=app/build/outputs/apk/release/app-release.apk

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,63 +6,91 @@ steps:
         run: license_finder
     command: /bin/bash -lc '/scan/scripts/license_finder.sh'
 
-  - label: ':docker: Build CI image'
-    key: "ci-image"
+  - label: ':docker: Build CI image for Ruby 2.5'
+    key: "ci-image-ruby-2-5"
     plugins:
       - docker-compose#v3.7.0:
           build:
-            - ci
+            - ci-ruby-2.5
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
           cache-from:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.5
       - docker-compose#v3.7.0:
           push:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.5
+    env:
+      RUBY_VERSION: "2.5"
 
-  - label: 'Unit tests'
-    depends_on: 'ci-image'
+  - label: ':docker: Build CI image for Ruby 2.7'
+    key: "ci-image-ruby-2-7"
+    plugins:
+      - docker-compose#v3.7.0:
+          build:
+            - ci-ruby-2.7
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+          cache-from:
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
+      - docker-compose#v3.7.0:
+          push:
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
+    env:
+      RUBY_VERSION: "2.7"
+
+  - label: ':docker: Build CI image for Ruby 3'
+    key: "ci-image-ruby-3"
+    plugins:
+      - docker-compose#v3.7.0:
+          build:
+            - ci-ruby-3
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+          cache-from:
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
+      - docker-compose#v3.7.0:
+          push:
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
+    env:
+      RUBY_VERSION: "3"
+
+  - label: 'Unit tests with Ruby 2.5'
+    depends_on: 'ci-image-ruby-2-5'
     plugins:
       docker-compose#v3.7.0:
         run: unit-test
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:
-          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.5
+    env:
+      RUBY_VERSION: "2.5"
+    command: 'bundle exec rake'
+
+  - label: 'Unit tests with Ruby 3'
+    depends_on: 'ci-image-ruby-3'
+    plugins:
+      docker-compose#v3.7.0:
+        run: unit-test
+        image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+        cache-from:
+          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
+    env:
+      RUBY_VERSION: "3"
     command: 'bundle exec rake'
 
   - label: ':docker: Push Docker image for branch'
     key: "cli-image"
-    depends_on: "ci-image"
+    depends_on: "ci-image-2-7"
     plugins:
       - docker-compose#v3.7.0:
           build: cli
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
           cache-from:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
       - docker-compose#v3.7.0:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
 
-  - label: ':docker: Build test images'
-    key: "test-images"
-    depends_on: "ci-image"
-    plugins:
-      - docker-compose#v3.7.0:
-          build:
-            - comparison-tests
-            - android-appium-test
-            - ios-appium-test
-            - payload-helper-tests
-            - http-response-tests
-            - unit-test
-            - docker-tests
-          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
-          cache-from:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
-          build-parallel: true
-
-  - label: 'No-device tests'
-    depends_on: "test-images"
+  - label: 'No-device tests with Ruby 2.5'
+    depends_on: "ci-image-ruby-2-5"
     plugins:
       - docker-compose#v3.7.0:
           run: framework-tests
@@ -78,6 +106,29 @@ steps:
           run: payload-helper-tests
       - docker-compose#v3.7.0:
           run: docker-tests
+    env:
+      RUBY_VERSION: "2.5"
+    command: 'bundle exec maze-runner'
+
+  - label: 'No-device tests with Ruby 3'
+    depends_on: "ci-image-ruby-3"
+    plugins:
+      - docker-compose#v3.7.0:
+          run: framework-tests
+      - docker-compose#v3.7.0:
+          run: comparison-tests
+      - docker-compose#v3.7.0:
+          run: proxy-tests
+      - docker-compose#v3.7.0:
+          run: cli-tests
+      - docker-compose#v3.7.0:
+          run: http-response-tests
+      - docker-compose#v3.7.0:
+          run: payload-helper-tests
+      - docker-compose#v3.7.0:
+          run: docker-tests
+    env:
+      RUBY_VERSION: "3"
     command: 'bundle exec maze-runner'
 
   - label: 'AWS - SAM tests'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -143,7 +143,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'Browserstack app-automate test - Android 11'
-    depends_on: "ci-image-ruby-3"
+    depends_on: "ci-image-ruby-2-7"
     plugins:
       docker-compose#v3.7.0:
         run: android-appium-test

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -125,8 +125,8 @@ steps:
       bundle exec maze-runner
       --no-log-requests
 
-  - label: 'Browserstack app-automate test - Android 6'
-    depends_on: "test-images"
+  - label: 'Browserstack app-automate test - Android 6 using Ruby 2.7'
+    depends_on: "ci-image-ruby-2-7"
     plugins:
       docker-compose#v3.7.0:
         run: android-appium-test
@@ -140,8 +140,8 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: 'Browserstack app-automate test - Android 11'
-    depends_on: "test-images"
+  - label: 'Browserstack app-automate test - Android 11 using Ruby 3'
+    depends_on: "ci-image-ruby-3"
     plugins:
       docker-compose#v3.7.0:
         run: android-appium-test

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -132,6 +132,8 @@ steps:
         run: android-appium-test
       artifacts#v1.3.0:
         upload: test/fixtures/android-appium-test/maze_output/**/*
+    env:
+      RUBY_VERSION: "2.7"
     command: >-
       bundle exec maze-runner
       --app=app/build/outputs/apk/release/app-release.apk
@@ -147,6 +149,8 @@ steps:
         run: android-appium-test
       artifacts#v1.3.0:
         upload: test/fixtures/android-appium-test/maze_output/**/*
+    env:
+      RUBY_VERSION: "3"
     command: >-
       bundle exec maze-runner
       --app=app/build/outputs/apk/release/app-release.apk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.9.1 - 2021/07/30
+
+## Fixes
+
+- Support running with Ruby 3 [#284](https://github.com/bugsnag/maze-runner/pull/284)
+
 # 5.9.0 - 2021/07/28
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (5.9.0)
+    bugsnag-maze-runner (5.9.1)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ PATH
       rubyzip (~> 2.3.2)
       selenium-webdriver (~> 3.11)
       test-unit (~> 3.3.0)
+      webrick (~> 1.7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -105,6 +106,7 @@ GEM
     tomlrb (1.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'minitest', '~> 5.0'
   spec.add_dependency 'os', '~> 1.0.0'
   spec.add_dependency 'test-unit', '~> 3.3.0'
+  spec.add_dependency 'webrick', '~> 1.7.0'
 
   spec.add_dependency 'appium_lib', '~> 11.2.0'
   spec.add_dependency 'cucumber-expressions', '~> 6.0.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       context: test/fixtures/android-appium-test
       args:
         BRANCH_NAME:
+        RUBY_VERSION:
     extra_hosts:
       - "maze-local:127.0.0.1"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       dockerfile: dockerfiles/Dockerfile.ci
       context: .
       target: ci
+      args:
+        - RUBY_VERSION
 
   cli:
     build:
@@ -80,24 +82,28 @@ services:
       context: test/fixtures/comparison
       args:
         BRANCH_NAME:
+        RUBY_VERSION:
 
   doc-server-tests:
     build:
       context: test/fixtures/doc-server
       args:
         BRANCH_NAME:
+        RUBY_VERSION:
 
   framework-tests:
     build:
       context: test/fixtures/framework
       args:
         BRANCH_NAME:
+        RUBY_VERSION:
 
   docker-tests:
     build:
       context: test/fixtures/docker-app
       args:
         BRANCH_NAME:
+        RUBY_VERSION:
     environment:
       NETWORK_NAME: "${BUILDKITE_JOB_ID:-core-maze-runner}"
     volumes:
@@ -108,24 +114,29 @@ services:
       context: test/fixtures/proxy
       args:
         BRANCH_NAME:
+        RUBY_VERSION:
 
   payload-helper-tests:
     build:
       context: test/fixtures/payload-helpers
       args:
         BRANCH_NAME:
+        RUBY_VERSION:
 
   http-response-tests:
     build:
       context: test/fixtures/http-response
       args:
         BRANCH_NAME:
+        RUBY_VERSION:
 
   unit-test:
     build:
       dockerfile: dockerfiles/Dockerfile.ci
       context: .
       target: unit-test
+      args:
+        RUBY_VERSION:
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       dockerfile: dockerfiles/Dockerfile.ci
       context: .
       target: cli
+      args:
+        - RUBY_VERSION=2.7
 
   docs:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       context: test/fixtures/cli
       args:
         BRANCH_NAME:
+        RUBY_VERSION:
 
   comparison-tests:
     build:

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,10 +1,11 @@
 FROM ubuntu:20.04 as ci
 
-RUN apt-get update && apt-get install -y rbenv apt-utils docker-compose wget unzip bash bundler \
-                                        # Needed by nokogiri (a dependency of appium_lib)
-                                        zlib1g libpng-dev zlibc zlib1g zlib1g-dev curl \
-                                        # Needed by curb (a dependency of Cucumber)
-                                        libcurl4 libcurl4-openssl-dev
+RUN DEBIAN_FRONTEND=noninteractive \
+        apt-get update && apt-get install -y rbenv apt-utils docker-compose wget unzip bash bundler \
+                                             # Needed by nokogiri (a dependency of appium_lib)
+                                             zlib1g libpng-dev zlibc zlib1g zlib1g-dev curl \
+                                             # Needed by curb (a dependency of Cucumber)
+                                             libcurl4 libcurl4-openssl-dev
 
 RUN rbenv install 2.7.0
 RUN rbenv install 3.0.1

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,16 +1,13 @@
-FROM ubuntu:20.04 as ci
+# Ruby image are based on Debian
+ARG RUBY_VERSION
+FROM ruby:$RUBY_VERSION as ci
 
-RUN DEBIAN_FRONTEND=noninteractive \
-        apt-get update && apt-get install -y rbenv apt-utils docker-compose wget unzip bash bundler \
-                                             # Needed by nokogiri (a dependency of appium_lib)
-                                             zlib1g libpng-dev zlibc zlib1g zlib1g-dev curl \
-                                             # Needed by curb (a dependency of Cucumber)
-                                             libcurl4 libcurl4-openssl-dev
-
-RUN rbenv install 2.7.0
-RUN rbenv install 3.0.1
-
-RUN rbenv local 2.7.0
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y apt-utils docker-compose wget unzip bash bundler \
+                       # Needed by nokogiri (a dependency of appium_lib)
+                       zlib1g libpng-dev zlibc zlib1g zlib1g-dev curl \
+                       # Needed by curb (a dependency of Cucumber)
+                       libcurl4 libcurl4-openssl-dev
 
 RUN ruby -v
 

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,10 +1,16 @@
 FROM ubuntu:20.04 as ci
 
-RUN apt-get update && apt-get install -y ruby-full apt-utils docker-compose wget unzip bash bundler \
+RUN apt-get update && apt-get install -y rbenv apt-utils docker-compose wget unzip bash bundler \
                                         # Needed by nokogiri (a dependency of appium_lib)
                                         zlib1g libpng-dev zlibc zlib1g zlib1g-dev curl \
                                         # Needed by curb (a dependency of Cucumber)
                                         libcurl4 libcurl4-openssl-dev
+
+RUN rbenv install 2.7.0
+RUN rbenv install 3.0.1
+
+RUN rbenv local 2.7.0
+
 RUN ruby -v
 
 RUN wget -q https://storage.googleapis.com/bugsnag-public-test-dependencies/BrowserStackLocal-linux-x64.zip \

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '5.9.0'
+  VERSION = '5.9.1'
 
   class << self
     attr_accessor :driver

--- a/test/fixtures/android-appium-test/app/build.gradle
+++ b/test/fixtures/android-appium-test/app/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         applicationId "com.bugsnag.android.mazerunner"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/test/fixtures/android-appium-test/app/build.gradle
+++ b/test/fixtures/android-appium-test/app/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation "com.bugsnag:bugsnag-android:5.9.4"
+    implementation "com.bugsnag:bugsnag-android:5.10.1"
     implementation "com.android.support:appcompat-v7:26.1.0"
     implementation "com.android.support.constraint:constraint-layout:1.0.2"
     testImplementation "junit:junit:4.12"

--- a/test/fixtures/android-appium-test/app/build.gradle
+++ b/test/fixtures/android-appium-test/app/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         applicationId "com.bugsnag.android.mazerunner"
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/test/fixtures/android-appium-test/dockerfile
+++ b/test/fixtures/android-appium-test/dockerfile
@@ -1,4 +1,5 @@
 ARG BRANCH_NAME
+ARG RUBY_VERSION
 FROM openjdk:8-jdk-stretch AS browserstack-app-automate-builder
 
 RUN apt-get update
@@ -20,7 +21,7 @@ COPY . .
 
 RUN ./gradlew app:assembleRelease
 
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci AS browserstack-app-automate
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION} AS browserstack-app-automate
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/cli/Dockerfile
+++ b/test/fixtures/cli/Dockerfile
@@ -1,5 +1,6 @@
 ARG BRANCH_NAME
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
+ARG RUBY_VERSION
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 RUN sudo apt-get install -y nodejs

--- a/test/fixtures/cli/Dockerfile
+++ b/test/fixtures/cli/Dockerfile
@@ -1,5 +1,5 @@
 ARG BRANCH_NAME
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 RUN sudo apt-get install -y nodejs

--- a/test/fixtures/comparison/Dockerfile
+++ b/test/fixtures/comparison/Dockerfile
@@ -1,5 +1,6 @@
 ARG BRANCH_NAME
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+ARG RUBY_VERSION
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/doc-server/Dockerfile
+++ b/test/fixtures/doc-server/Dockerfile
@@ -1,5 +1,6 @@
 ARG BRANCH_NAME
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+ARG RUBY_VERSION
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/docker-app/Dockerfile
+++ b/test/fixtures/docker-app/Dockerfile
@@ -1,5 +1,6 @@
 ARG BRANCH_NAME
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+ARG RUBY_VERSION
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/framework/Dockerfile
+++ b/test/fixtures/framework/Dockerfile
@@ -1,5 +1,6 @@
 ARG BRANCH_NAME
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+ARG RUBY_VERSION
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/http-response/Dockerfile
+++ b/test/fixtures/http-response/Dockerfile
@@ -1,5 +1,6 @@
 ARG BRANCH_NAME
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+ARG RUBY_VERSION
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/ios-app/dockerfile
+++ b/test/fixtures/ios-app/dockerfile
@@ -1,6 +1,6 @@
 ARG BRANCH_NAME
-
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+ARG RUBY_VERSION
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
 
 WORKDIR /app
 COPY features features

--- a/test/fixtures/payload-helpers/Dockerfile
+++ b/test/fixtures/payload-helpers/Dockerfile
@@ -1,5 +1,6 @@
 ARG BRANCH_NAME
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+ARG RUBY_VERSION
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/proxy/Dockerfile
+++ b/test/fixtures/proxy/Dockerfile
@@ -1,5 +1,6 @@
 ARG BRANCH_NAME
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
+ARG RUBY_VERSION
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
## Goal

Allow Maze Runner to be used with Ruby 3.

## Changeset

The only identified change needed is to add a dependency on `webrick`.  The remaining changes enhance the pipeline to run tests with both Ruby 2.7 and 3.

The addition of tests against Ruby 2.5 (the minimum support version) was also considered, but the additional work needed to the base image and pipeline steps did not seem worthwhile.

## Tests

Covered by updated CI pipeline and I've also verified that the Docker image pushed for the branch can be successfully used in another pipeline (Android).