### PR TITLE
Remove blanket rescue for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # 5.9.2 - 2021/07/23
 
-## Fixes
-
 - Pin Docker images on Debian 10 (Buster) [#286](https://github.com/bugsnag/maze-runner/pull/286)
+- Remove blanket rescue for macOS in step `I click the element {string}` [#285](https://github.com/bugsnag/maze-runner/pull/285)
 
 # 5.9.1 - 2021/07/30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# 5.9.2 - 2021/07/23
+# 5.9.2 - 2021/08/23
+
+## Fixes
 
 - Pin Docker images on Debian 10 (Buster) [#286](https://github.com/bugsnag/maze-runner/pull/286)
 - Remove blanket rescue for macOS in step `I click the element {string}` [#285](https://github.com/bugsnag/maze-runner/pull/285)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (5.9.1)
+    bugsnag-maze-runner (5.9.2)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -80,7 +80,7 @@ GEM
     mocha (1.12.0)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.7-x86_64-darwin)
+    nokogiri (1.12.3-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -24,15 +24,7 @@ end
 #
 # @step_input element_id [String] The locator id
 When('I click the element {string}') do |element_id|
-  begin
-    Maze.driver.click_element(element_id)
-  rescue StandardError
-    # AppiumForMac raises an to run a scenario that crashes the app
-    raise unless Maze.config.os == 'macos'
-
-    $logger.warn 'Ignoring exception raised on click_element - this is normal for AppiumForMac if the button click ' \
-      'causes the app to crash.'
-  end
+  Maze.driver.click_element(element_id)
 end
 
 # Sends the app to the background for a number of seconds

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '5.9.1'
+  VERSION = '5.9.2'
 
   class << self
     attr_accessor :driver


### PR DESCRIPTION
## Goal

Remove the blanket rescue for macOS in step `I click the element {string}`.

## Design

A localized rescue, specific to only crashy button clicks will be added to `bugsnag-cocoa`.

## Tests

Covered by CI.