### PR TITLE
Pin Docker image base to Debian 10 (Buster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.9.2 - 2021/07/23
+
+## Fixes
+
+- Pin Docker images on Debian 10 (Buster) [#286](https://github.com/bugsnag/maze-runner/pull/286)
+
 # 5.9.1 - 2021/07/30
 
 ## Fixes

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,6 +1,6 @@
 # Ruby image are based on Debian
 ARG RUBY_VERSION
-FROM ruby:$RUBY_VERSION as ci
+FROM ruby:${RUBY_VERSION}-buster as ci
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     apt-get install -y apt-utils docker-compose wget unzip bash bundler \


### PR DESCRIPTION
## Goal

Pin the Docker image base to Debian 10 (Buster) to avoid us having to continually port our subsequent Docker build steps to new Debian versions.

## Tests

Covered by CI.