### PR TITLE
Ensure unhandled error tests can run correctly for iOS appium local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.9.3 - 2021/08/26
+
+## Fixes
+
+- Ensure 'noReset' capability is present when running iOS appium tests locally [#287](https://github.com/bugsnag/maze-runner/pull/287)
+
 # 5.9.2 - 2021/08/23
 
 ## Fixes

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '5.9.2'
+  VERSION = '5.9.3'
 
   class << self
     attr_accessor :driver

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -56,7 +56,8 @@ module Maze
                            'deviceName' => udid,
                            'xcodeOrgId' => team_id,
                            'xcodeSigningId' => 'iPhone Developer',
-                           'udid' => udid
+                           'udid' => udid,
+                           'noReset' => 'true'
                          }
                        elsif platform.downcase == 'macos'
                          {


### PR DESCRIPTION
## Goal

When re-launching an iOS app on a local device through an appium server the app is re-installed, wiping any cached requests.  This has been proven to work by adding `noReset=true` as an additional capability, which this change adds by default.