### PR TITLE
feat: add ability to specify dockerhub credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0
+
+Added `DOCKER_USER` and `DOCKER_PASSWORD` environment variables to avoid Dockerhub rate
+limits when run on CI.
 # 1.2.0
 
 Addition of HTTP version steps.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (1.1.0)
+    bugsnag-maze-runner (1.3.0)
       cucumber (~> 3.1.0)
       cucumber-expressions (= 5.0.15)
       minitest (~> 5.0)
@@ -13,7 +13,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.17.0)
+    backports (3.21.0)
     builder (3.2.4)
     cucumber (3.1.0)
       builder (>= 2.1.2)
@@ -31,13 +31,13 @@ GEM
     cucumber-expressions (5.0.15)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    diff-lcs (1.3)
+    diff-lcs (1.4.4)
     gherkin (5.1.0)
-    minitest (5.14.0)
-    multi_json (1.14.1)
+    minitest (5.14.4)
+    multi_json (1.15.0)
     multi_test (0.1.2)
     os (1.0.1)
-    power_assert (1.1.6)
+    power_assert (2.0.1)
     rack (2.0.9)
     rake (12.3.3)
     test-unit (3.2.9)
@@ -50,4 +50,4 @@ DEPENDENCIES
   bugsnag-maze-runner!
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/lib/features/support/docker.rb
+++ b/lib/features/support/docker.rb
@@ -88,6 +88,12 @@ def run_service_with_command(service, command, compose_file=$docker_compose_file
 end
 
 def run_docker_compose_command(file, command, must_pass=true)
+  if ENV['DOCKER_USER'] or ENV['DOCKER_PASSWORD']
+    run_command(@script_env || {},
+                "echo #{ENV['DOCKER_PASSWORD']} | docker login --username #{ENV['DOCKER_USER']} --password-stdin",
+                must_pass: true,
+                hide_input: true)
+  end
   command = "docker-compose -f #{file} #{command}"
   run_command(@script_env || {}, command, must_pass: must_pass)
 end

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -128,8 +128,8 @@ def encode_query_params hash
   URI.encode_www_form hash
 end
 
-def run_command(*cmd, must_pass: true)
-  STDOUT.puts cmd if ENV['VERBOSE']
+def run_command(*cmd, must_pass: true, hide_input: false)
+  STDOUT.puts cmd if ENV['VERBOSE'] and not hide_input
   stdout, stderr, status = Open3.capture3(*cmd)
   STDOUT.puts stdout if ENV['VERBOSE']
   STDOUT.puts stderr if ENV['VERBOSE']

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module BugsnagMazeRunner
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.3.0'.freeze
 end


### PR DESCRIPTION
## Goal

To avoid rate limiting for the Dockerhub access in our Travis builds (specifically bugsnag-java), added environment variables to allow us to use a non-anonymous user.

## Design

Added a `docker login` command before `docker-compose` is run - this is only done if the environment variables are present.

Also added a param to the `run_command` method so that the password is not printed when verbose is on.
