### PR TITLE
Use fork of yard-cucumber and resolve Yard warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem 'yard-cucumber', git: 'https://github.com/bugsnag/yard-cucumber'
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/bugsnag/yard-cucumber
+  revision: 679d8a834152b53df4700b7107a71d0753e5a2ba
+  specs:
+    yard-cucumber (4.0.0)
+      cucumber (>= 2.0, < 8.0)
+      yard (~> 0.8, >= 0.8.1)
+
 PATH
   remote: .
   specs:
@@ -144,6 +152,7 @@ DEPENDENCIES
   mocha (~> 1.12.0)
   redcarpet (~> 3.5)
   yard (~> 0.9.1)
+  yard-cucumber!
 
 BUNDLED WITH
    2.2.20

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -37,7 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha', '~> 1.12.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'yard', '~> 0.9.1'
-  # TODO Find an alternative for generating Cucumber step definition docs
-  # spec.add_development_dependency 'yard-cucumber', '~> 4.0.0'
   spec.add_development_dependency 'license_finder', '~> 6.12.0'
 end

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -143,8 +143,8 @@ end
 
 # See `the payload field {string} equals the platform-dependent string:`
 #
-# @step_input field_path [String] The field to test, prepended with "events.0.exceptions.0.stacktrace.#{num}"
-# @step_input field_path [String] The index of the stack frame to test
+# @step_input field_path [String] The field to test, prepended with "events.0.exceptions.0.stacktrace.#!{num}"
+# @step_input num [Integer] The index of the stack frame to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
 Then('the {string} of stack frame {int} equals the platform-dependent string:') do |field_path, num, platform_values|
   test_string_platform_values('error', "events.0.exceptions.0.stacktrace.#{num}.#{field_path}", platform_values)

--- a/lib/features/steps/multipart_request_steps.rb
+++ b/lib/features/steps/multipart_request_steps.rb
@@ -26,8 +26,7 @@ Then('the {word} request is valid multipart form-data') do |request_type|
   valid_multipart_form_data?(list.current)
 end
 
-# (Deprecated) Retained for backwards compatibility
-# Use "the {word} request is valid multipart form-data"
+# @deprecated Use `the {word} request is valid multipart form-data`
 #
 # Verifies that the request contains multipart form-data
 Then('the request is valid multipart form-data') do
@@ -43,8 +42,7 @@ Then('all {word} requests are valid multipart form-data') do |request_type|
   list.all.all? { |request| valid_multipart_form_data?(request) }
 end
 
-# (Deprecated) Retained for backwards compatibility
-# Use "all {word} requests are valid multipart form-data"
+# @deprecated Use `all {word} requests are valid multipart form-data`
 #
 # Verifies all received requests contain multipart form-data
 Then('all requests are valid multipart form-data') do
@@ -62,8 +60,7 @@ Then('the {word} multipart request has {int} fields') do |request_type, part_cou
   assert_equal(part_count, parts.size)
 end
 
-# (Deprecated) Retained for backwards compatibility
-# Use "the {word} multipart request has {int} fields"
+# @deprecated Use `the {word} multipart request has {int} fields`
 #
 # Tests the number of fields a multipart request contains.
 #
@@ -82,8 +79,7 @@ Then('the {word} multipart request has a non-empty body') do |request_type|
   assert(parts.size.positive?, "Multipart request payload contained #{parts.size} fields")
 end
 
-# (Deprecated) Retained for backwards compatibility
-# Use "the {word} multipart request has a non-empty body"
+# @deprecated Use `the {word} multipart request has a non-empty body`
 #
 # Tests the multipart request has at least one field.
 Then('the multipart request has a non-empty body') do
@@ -91,8 +87,7 @@ Then('the multipart request has a non-empty body') do
   step 'the error multipart request has a non-empty body'
 end
 
-# (Deprecated) Retained for backwards compatibility.
-# Use "the payload field {string} is not null"
+# @deprecated Use `the payload field {string} is not null`
 #
 # Tests that a multipart request field exists and is not null.
 #
@@ -103,8 +98,7 @@ Then('the field {string} for multipart request is not null') do |part_key|
   assert_not_nil(parts[part_key], "The field '#{part_key}' should not be null")
 end
 
-# (Deprecated) Retained for backwards compatibility
-# Use "the payload field {string} equals {string}"
+# @deprecated Use `the payload field {string} equals {string}`
 #
 # Tests that a multipart request field equals a string.
 #
@@ -116,8 +110,7 @@ Then('the field {string} for multipart request equals {string}') do |part_key, e
   assert_equal(parts[part_key], expected_value)
 end
 
-# (Deprecated) Retained for backwards compatibility
-# Use "the payload field {string} is null"
+# @deprecated Use `the payload field {string} is null`
 #
 # Tests that a multipart request field is null.
 #
@@ -157,8 +150,7 @@ Then('the {word} multipart body does not match the JSON file in {string}') do |r
   assert_false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
 end
 
-# (Deprecated) Retained for backwards compatibility
-# Use "the {word} multipart body does not match the JSON file in {string}"
+# @deprecated Use `the {word} multipart body does not match the JSON file in {string}`
 #
 # Tests that the multipart payload body does not match a JSON file.
 # JSON formatted multipart fields will be parsed into hashes.
@@ -184,8 +176,7 @@ Then('the {word} multipart body matches the JSON file in {string}') do |request_
   assert_true(result.equal?, "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
 end
 
-# (Deprecated) Retained for backwards compatibility
-# Use "the {word} multipart body matches the JSON file in {string}"
+# @deprecated Use `the {word} multipart body matches the JSON file in {string}`
 #
 # Tests that the multipart payload body matches a JSON fixture.
 # JSON formatted multipart fields will be parsed into hashes.
@@ -211,8 +202,7 @@ Then('the {word} multipart field {string} matches the JSON file in {string}') do
   assert_true(result.equal?, "The multipart field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
 end
 
-# (Deprecated) Retained for backwards compatibility
-# Use "the {word} multipart field {string} matches the JSON file in {string}"
+# @deprecated Use `the {word} multipart field {string} matches the JSON file in {string}`
 #
 # Tests that a multipart field matches a JSON fixture.
 # The field will be parsed into a hash.

--- a/lib/features/steps/value_steps.rb
+++ b/lib/features/steps/value_steps.rb
@@ -104,7 +104,7 @@ Then('the {word} payload field {string} is a date') do |request_type, field|
   assert_kind_of Date, date
 end
 
-# Tests whether a payload field (loosely) matches a UUID regex (/[a-fA-F0-9-]{36}/)
+# Tests whether a payload field (loosely) matches a UUID regex (/[a-fA-F0-9-]!{36}/)
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test


### PR DESCRIPTION
## Goal

Re-enable use of (forked) yard-cucumber.

## Design

The [yard-cucumber](https://github.com/burtlo/yard-cucumber) that we were using is no longer being maintained and is tied to Cucumber 3.  To support Cucumber 7, I've forked the repo, updating just its Gemspec.

## Tests

I've manually run Yard locally and verified that the generated docs contain the Step Definition docs.  This highlighted a few warnings, which I've now resolved.