### PR TITLE
Remove deprecated device names and steps

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,6 +9,29 @@ The version of Cucumber used by Maze Runner has been updated from 3.1.2 to 7.1.0
       - move into a suitable hook such as `BeforeAll`
 * The `AfterAll` hook has also been added, which could prove used instead of `at_exit`
 
+The following deprecated BrowserStack device names been removed:
+* ANDROID_4
+* ANDROID_5
+* ANDROID_6
+* ANDROID_7
+* ANDROID_8
+* ANDROID_9
+
+The following deprecated Cucumber steps have been removed:
+
+Removed step | Replacement
+---|---|
+`the request is valid multipart form-data` | `the {word} request is valid multipart form-data`
+`all requests are valid multipart form-data` | `all {word} requests are valid multipart form-data`
+`the multipart request has {int} fields` | `the {word} multipart request has {int} fields`
+`the multipart request has a non-empty body` | `the {word} multipart request has a non-empty body`
+`the field {string} for multipart request is not null` | `the payload field {string} is not null`
+`the field {string} for multipart request equals {string}` | `the payload field {string} equals {string}`
+`the field {string} for multipart request is null` | `the payload field {string} is null`
+`the multipart body does not match the JSON file in {string}` | `the {word} multipart body does not match the JSON file in {string}`
+`the multipart body matches the JSON file in {string}` | `the {word} multipart body matches the JSON file in {string}`
+`the multipart field {string} matches the JSON file in {string}` | `the {word} multipart field {string} matches the JSON file in {string}`
+
 ## v4 to v5
 
 Maze Runner has beeb integrated with the Sauce Labs device farm, resulting in some environment variables and command

--- a/lib/features/steps/multipart_request_steps.rb
+++ b/lib/features/steps/multipart_request_steps.rb
@@ -26,28 +26,12 @@ Then('the {word} request is valid multipart form-data') do |request_type|
   valid_multipart_form_data?(list.current)
 end
 
-# @deprecated Use `the {word} request is valid multipart form-data`
-#
-# Verifies that the request contains multipart form-data
-Then('the request is valid multipart form-data') do
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  step 'the error request is valid multipart form-data'
-end
-
 # Verifies all requests of a given type contain multipart form-data
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 Then('all {word} requests are valid multipart form-data') do |request_type|
   list = Maze::Server.list_for request_type
   list.all.all? { |request| valid_multipart_form_data?(request) }
-end
-
-# @deprecated Use `all {word} requests are valid multipart form-data`
-#
-# Verifies all received requests contain multipart form-data
-Then('all requests are valid multipart form-data') do
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  step 'all error requests are valid multipart form-data'
 end
 
 # Tests the number of fields a given type of multipart request contains.
@@ -60,16 +44,6 @@ Then('the {word} multipart request has {int} fields') do |request_type, part_cou
   assert_equal(part_count, parts.size)
 end
 
-# @deprecated Use `the {word} multipart request has {int} fields`
-#
-# Tests the number of fields a multipart request contains.
-#
-# @step_input part_count [Integer] The number of expected fields
-Then('the multipart request has {int} fields') do |part_count|
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "the error multipart request has #{part_count} fields"
-end
-
 # Tests a given type of multipart request has at least one field.
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
@@ -77,48 +51,6 @@ Then('the {word} multipart request has a non-empty body') do |request_type|
   list = Maze::Server.list_for request_type
   parts = list.current[:body]
   assert(parts.size.positive?, "Multipart request payload contained #{parts.size} fields")
-end
-
-# @deprecated Use `the {word} multipart request has a non-empty body`
-#
-# Tests the multipart request has at least one field.
-Then('the multipart request has a non-empty body') do
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  step 'the error multipart request has a non-empty body'
-end
-
-# @deprecated Use `the payload field {string} is not null`
-#
-# Tests that a multipart request field exists and is not null.
-#
-# @step_input part_key [String] The key to the multipart element
-Then('the field {string} for multipart request is not null') do |part_key|
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  parts = Maze::Server.errors.current[:body]
-  assert_not_nil(parts[part_key], "The field '#{part_key}' should not be null")
-end
-
-# @deprecated Use `the payload field {string} equals {string}`
-#
-# Tests that a multipart request field equals a string.
-#
-# @step_input part_key [String] The key to the multipart element
-# @step_input expected_value [String] The string to match against
-Then('the field {string} for multipart request equals {string}') do |part_key, expected_value|
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  parts = Maze::Server.errors.current[:body]
-  assert_equal(parts[part_key], expected_value)
-end
-
-# @deprecated Use `the payload field {string} is null`
-#
-# Tests that a multipart request field is null.
-#
-# @step_input part_key [String] The key to the multipart element
-Then('the field {string} for multipart request is null') do |part_key|
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  parts = Maze::Server.errors.current[:body]
-  assert_nil(parts[part_key], "The field '#{part_key}' should be null")
 end
 
 # Takes a hashmap and parses all fields into strings or hashes depending on their format
@@ -150,17 +82,6 @@ Then('the {word} multipart body does not match the JSON file in {string}') do |r
   assert_false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
 end
 
-# @deprecated Use `the {word} multipart body does not match the JSON file in {string}`
-#
-# Tests that the multipart payload body does not match a JSON file.
-# JSON formatted multipart fields will be parsed into hashes.
-#
-# @step_input json_path [String] Path to a JSON file relative to maze-runner root
-Then('the multipart body does not match the JSON file in {string}') do |json_path|
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "the error multipart body does not match the JSON file in \"#{json_path}\""
-end
-
 # Tests that a given type of multipart payload body matches a JSON fixture.
 # JSON formatted multipart fields will be parsed into hashes.
 #
@@ -176,17 +97,6 @@ Then('the {word} multipart body matches the JSON file in {string}') do |request_
   assert_true(result.equal?, "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
 end
 
-# @deprecated Use `the {word} multipart body matches the JSON file in {string}`
-#
-# Tests that the multipart payload body matches a JSON fixture.
-# JSON formatted multipart fields will be parsed into hashes.
-#
-# @step_input json_path [String] Path to a JSON file relative to maze-runner root
-Then('the multipart body matches the JSON file in {string}') do |json_path|
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "the error multipart body matches the JSON file in \"#{json_path}\""
-end
-
 # Tests that a given type of multipart field matches a JSON fixture.
 # The field will be parsed into a hash.
 #
@@ -200,18 +110,6 @@ Then('the {word} multipart field {string} matches the JSON file in {string}') do
   expected_value = JSON.parse(open(json_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
   assert_true(result.equal?, "The multipart field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
-end
-
-# @deprecated Use `the {word} multipart field {string} matches the JSON file in {string}`
-#
-# Tests that a multipart field matches a JSON fixture.
-# The field will be parsed into a hash.
-#
-# @step_input field_path [String] Path to the tested element
-# @step_input json_path [String] Path to a JSON file relative to maze-runner root
-Then('the multipart field {string} matches the JSON file in {string}') do |field_path, json_path|
-  $logger.warn 'This step is deprecated and may be removed in a future release'
-  step "the error multipart field \"#{field_path}\" matches the JSON file in \"#{json_path}\""
 end
 
 # Tests that a multipart request field exists and is not null.

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -71,13 +71,6 @@ module Maze
           'IOS_11' => make_ios_hash('iPhone 8', '11'),
           'IOS_10' => make_ios_hash('iPhone 7', '10')
         }
-        # Deprecated entries
-        hash['ANDROID_9'] = hash['ANDROID_9_0']
-        hash['ANDROID_8'] = hash['ANDROID_8_0']
-        hash['ANDROID_7'] = hash['ANDROID_7_1']
-        hash['ANDROID_6'] = hash['ANDROID_6_0']
-        hash['ANDROID_5'] = hash['ANDROID_5_0']
-        hash['ANDROID_4'] = hash['ANDROID_4_4']
 
         # Specific Android devices
         add_android 'Google Pixel 4', '11.0', hash                        # ANDROID_11_0_GOOGLE_PIXEL_4


### PR DESCRIPTION
## Goal

Remove deprecations.

## Design

Although these are related to the upgrade to Cucumber 7 (for which we have an integration branch), I noticed the deprecated Cucumber steps whilst working on the Yard docs generation.  As the upgrade to Cucumber 7 will require a new major version, this seemed like a good time to remove the deprecations.

## Changeset

Deprecations removed with details added to `UPDGRADING.md`.

## Tests

Covered by CI.