### PR TITLE
Only do logging for Buildkite on Buildkite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.1.1 - TBD
+
+## Fixes
+
+- Only log collapsable headings when running on Buildkite [#303](https://github.com/bugsnag/maze-runner/pull/303)
+
 # 6.1.0 - 2021/10/20
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.1.0)
+    bugsnag-maze-runner (6.1.1)
       appium_lib (~> 11.2.0)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -57,7 +57,7 @@ end
 
 # Before each scenario
 Before do |scenario|
-  STDOUT.puts "--- Scenario: #{scenario.name}"
+  STDOUT.puts "--- Scenario: #{scenario.name}" if ENV['BUILDKITE']
 
   # Invoke the internal hook for the mode of operation
   Maze.internal_hooks.before
@@ -98,7 +98,7 @@ After do |scenario|
 
   # Log unprocessed requests on Buildkite if the scenario fails
   if (scenario.failed? && Maze.config.log_requests) || Maze.config.always_log
-    STDOUT.puts '^^^ +++'
+    STDOUT.puts '^^^ +++' if ENV['BUILDKITE']
     output_received_requests('errors')
     output_received_requests('sessions')
     output_received_requests('builds')
@@ -134,7 +134,7 @@ def output_received_requests(request_type)
     count = request_queue.size_all
     $logger.info "#{count} #{request_type} were received:"
     request_queue.all.each.with_index(1) do |request, number|
-      STDOUT.puts "--- #{request_type} #{number} of #{count}"
+      STDOUT.puts "--- #{request_type} #{number} of #{count}" if ENV['BUILDKITE']
       Maze::LogUtil.log_hash(Logger::Severity::INFO, request)
     end
   end
@@ -200,7 +200,7 @@ end
 # After all tests
 AfterAll do
 
-  STDOUT.puts '+++ All scenarios complete'
+  STDOUT.puts '+++ All scenarios complete' if ENV['BUILDKITE']
 
   # Stop the mock server
   Maze::Server.stop

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.1.0'
+  VERSION = '6.1.1'
 
   class << self
     attr_accessor :driver, :internal_hooks, :mode, :start_time


### PR DESCRIPTION
## Goal

Only output the expand/collapsable logging section headings supported by Buildkite when running on Buildkite.

## Tests

Checked logs locally and on Buildkite.