### PR TITLE
Add iOS 15 device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.2.0 - 2021/10/22
+
+## Enhancements
+
+- Add entry for iOS 15 device on BrowaserStack [#304](https://github.com/bugsnag/maze-runner/pull/304)
+
 # 6.1.0 - 2021/10/20
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.1.0)
+    bugsnag-maze-runner (6.2.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.1.0'
+  VERSION = '6.2.0'
 
   class << self
     attr_accessor :driver, :internal_hooks, :mode, :start_time

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -65,6 +65,7 @@ module Maze
           'ANDROID_4_4' => make_android_hash('Google Nexus 5', '4.4', APPIUM_1_9_1),
 
           # iOS devices
+          'IOS_15' => make_ios_hash('iPhone 11 Pro', '15'),
           'IOS_14' => make_ios_hash('iPhone 11', '14'),
           'IOS_13' => make_ios_hash('iPhone 8', '13'),
           'IOS_12' => make_ios_hash('iPhone 8', '12'),


### PR DESCRIPTION
## Goal

Add an iOS 15 for use on BrowserStack.

## Tests

Used locally to run a scenario on an iOS 15 device.
