### PR TITLE
Eager concurrency

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -148,6 +148,7 @@ steps:
       --device=ANDROID_6_0
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: 'Browserstack app-automate test - Android 11 using Ruby 3'
     depends_on: "ci-image-ruby-3"
@@ -168,6 +169,7 @@ steps:
       --device=ANDROID_11_0
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - wait
 


### PR DESCRIPTION
## Goal

Implement eager concurrency for the CI browserstack-app concurrency group.

## Design

By default, Buildkite processes jobs in the order in which they were created, which is often very inefficient for our needs.  Jobs that are ready to be processed can be held behind those that are still waiting for other steps to complete.  

## Changeset

Setting `concurrency_method` to `eager` is Buildkite's mechanism to avoid this situation and is perfect for our needs.

## Testing

Covered by CI.