### PR TITLE
Make enable-retries consistent with other options

### DIFF
--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -48,6 +48,6 @@ module Maze
     ALWAYS_LOG = 'always-log'
 
     # Runtime options
-    ENABLE_RETRIES = 'enable_retries'
+    ENABLE_RETRIES = 'enable-retries'
   end
 end


### PR DESCRIPTION
## Goal

This was using an underscore, meaning it needed to be provided as `--enable_retries` instead of using hyphens like other options (`--enable-retries`)