### PR TITLE
Add Android 7 and 12 devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.3.0 - 2021/11/03
+
+## Enhancements
+
+- Add Android 12 and addition Android 7 devices [#304](https://github.com/bugsnag/maze-runner/pull/304)
+
 # 6.2.1 - 2021/10/26
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add Android 12 and addition Android 7 devices [#304](https://github.com/bugsnag/maze-runner/pull/304)
 
+## Fixes
+
+- Correct command line option for `--enable-retries` [#307](https://github.com/bugsnag/maze-runner/pull/307)
+
 # 6.2.1 - 2021/10/26
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Add Android 12 and addition Android 7 devices [#304](https://github.com/bugsnag/maze-runner/pull/304)
+- Add Android 12 and addition Android 7 devices [#308](https://github.com/bugsnag/maze-runner/pull/308)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.2.1)
+    bugsnag-maze-runner (6.3.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.2.1'
+  VERSION = '6.3.0'
 
   class << self
     attr_accessor :driver, :internal_hooks, :mode, :start_time

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -56,6 +56,7 @@ module Maze
       def create_hash
         hash = {
           # Classic, non-specific devices for each Android version
+          'ANDROID_12_0' => make_android_hash('Google Pixel 5', '12.0'),
           'ANDROID_11_0' => make_android_hash('Google Pixel 4', '11.0'),
           'ANDROID_10_0' => make_android_hash('Google Pixel 4', '10.0'),
           'ANDROID_9_0' => make_android_hash('Google Pixel 3', '9.0'),
@@ -87,11 +88,17 @@ module Maze
         add_android 'Samsung Galaxy Note 9', '8.1', hash                  # ANDROID_8_1_SAMSUNG_GALAXY_NOTE_9
         add_android 'Samsung Galaxy J7 Prime', '8.1', hash                # ANDROID_8_1_SAMSUNG_GALAXY_J7_PRIME
         add_android 'Samsung Galaxy Tab S4', '8.1', hash                  # ANDROID_8_1_SAMSUNG_GALAXY_TAB_S4
+        add_android 'Samsung Galaxy Tab S3', '8.0', hash                  # ANDROID_8_0_SAMSUNG_GALAXY_TAB_S3
         add_android 'Google Pixel', '8.0', hash                           # ANDROID_8_0_GOOGLE_PIXEL
         add_android 'Google Pixel 2', '8.0', hash                         # ANDROID_8_0_GOOGLE_PIXEL_2
         add_android 'Samsung Galaxy S9', '8.0', hash                      # ANDROID_8_0_SAMSUNG_GALAXY_S9
         add_android 'Samsung Galaxy S9 Plus', '8.0', hash                 # ANDROID_8_0_SAMSUNG_GALAXY_S9_PLUS
-        add_android 'Samsung Galaxy Tab S3', '7.0', hash                  # ANDROID_7_0_SAMSUNG_GALAXY_TAB_S3
+
+        add_android 'Samsung Galaxy A8', '7.1', hash                      # ANDROID_7_1_SAMSUNG_GALAXY_A8
+        add_android 'Samsung Galaxy Note 8', '7.1', hash                  # ANDROID_7_1_SAMSUNG_GALAXY_NOTE_8
+        add_android 'Samsung Galaxy S8', '7.0', hash                      # ANDROID_7_0_SAMSUNG_GALAXY_S8
+        add_android 'Samsung Galaxy S8 Plus', '7.0', hash                 # ANDROID_7_0_SAMSUNG_GALAXY_S8_PLUS
+
         add_android 'Motorola Moto X 2nd Gen', '6.0', hash                # ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN
         add_android 'Google Nexus 6', '6.0', hash                         # ANDROID_6_0_GOOGLE_NEXUS_6
         add_android 'Samsung Galaxy S7', '6.0', hash                      # ANDROID_6_0_SAMSUNG_GALAXY_S7


### PR DESCRIPTION
## Goal

Add Android 12 and additional Android 7 devices on BrowserStack.

## Tests

Use of new symbolic device names tested locally.