### PR TITLE
Retry: Browser driver fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add automatic retries when appium element cannot be found [#309](https://github.com/bugsnag/maze-runner/pull/309)
 
+## Fixes
+
+- Use `refresh` when Browser driver can retry scenario [#311](https://github.com/bugsnag/maze-runner/pull/311)
+
 # 6.3.0 - 2021/11/03
 
 ## Enhancements

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -32,6 +32,11 @@ module Maze
         @driver.navigate
       end
 
+      # Refreshes the page
+      def refresh
+        @driver.refresh
+      end
+
       # Quits the driver
       def driver_quit
         @driver.quit

--- a/lib/maze/retry_handler.rb
+++ b/lib/maze/retry_handler.rb
@@ -31,7 +31,11 @@ module Maze
 
         if retry_on_driver_error?(event)
           $logger.warn "Retrying #{test_case.name} due to driver error: #{event.result.exception}"
-          Maze.driver.restart
+          if Maze.driver.is_a?(Maze::Driver::Appium) || Maze.driver.is_a?(Maze::Driver::ResilientAppium)
+            Maze.driver.restart
+          elsif Maze.driver.is_a?(Maze::Driver::Browser)
+            Maze.driver.refresh
+          end
           increment_retry_count(test_case)
           true
         elsif retry_on_tag?(test_case)


### PR DESCRIPTION
## Goal

The Browser driver does not have a `restart` method, so instead we should call the `refresh` method (to refresh the webpage) when a driver error happens.

This likely won't fix any critical driver issues, but if the webpage doesn't load correctly for some reason it may help, and it'll also float the original error out.