### PR TITLE
Allow --app to be read from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.5.0 - TBD
+
+## Enhancements
+
+- All `--app` to be specified in a file using `@` prefix [#312](https://github.com/bugsnag/maze-runner/pull/312)
+
 # 6.4.0 - 2021/11/08
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.3.0)
+    bugsnag-maze-runner (6.5.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.4.0'
+  VERSION = '6.5.0'
 
   class << self
     attr_accessor :driver, :internal_hooks, :mode, :start_time

--- a/lib/maze/helper.rb
+++ b/lib/maze/helper.rb
@@ -75,6 +75,16 @@ module Maze
 
         File.expand_path path
       end
+
+      # Helps interpret "@file" arguments.  I.e. if the argument starts with an "@",
+      # read the contents of the filename given.
+      def read_at_arg_file(argument)
+        return nil if argument.nil?
+        return argument unless argument.start_with? '@'
+
+        file = argument[1..argument.size]
+        File.read file
+      end
     end
   end
 end

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -65,7 +65,7 @@ module Maze
                 'Device farm to use: "bs" (BrowserStack) or "local"',
                 type: :string
             opt Option::APP,
-                'The app to be installed and run against',
+                'The app to be installed and run against.  Assumed to be contained in a file if prefixed with @.',
                 type: :string
             opt Option::A11Y_LOCATOR,
                 'Locate elements by accessibility id rather than id',

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -31,7 +31,7 @@ module Maze
 
           # General appium options
           config.appium_session_isolation = options[Maze::Option::SEPARATE_SESSIONS]
-          config.app = options[Maze::Option::APP]
+          config.app = Maze::Helper.read_at_arg_file options[Maze::Option::APP]
           config.resilient = options[Maze::Option::RESILIENT]
           farm = options[Maze::Option::FARM]
           config.farm = case farm

--- a/lib/maze/option/validator.rb
+++ b/lib/maze/option/validator.rb
@@ -57,7 +57,7 @@ module Maze
             errors << "Device type '#{device}' unknown on BrowserStack.  Must be one of #{Maze::BrowserStackDevices::DEVICE_HASH.keys}"
           end
           # App
-          app = options[Option::APP]
+          app = Maze::Helper.read_at_arg_file options[Option::APP]
           if app.nil?
             errors << "--#{Option::APP} must be provided when running on a device"
           else

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -104,4 +104,17 @@ class ProcessorTest < Test::Unit::TestCase
     assert_false config.log_requests
     assert_false config.always_log
   end
+
+  def test_filename_options
+    args = %w[--app=@filename]
+
+    File.stubs(:read).with('filename').returns('file-contents')
+
+    options = Maze::Option::Parser.parse args
+    config = Maze::Configuration.new
+    Maze::Option::Processor.populate config, options
+
+    # Local-only options
+    assert_equal('file-contents', config.app)
+  end
 end


### PR DESCRIPTION
## Goal

Allows the `--app` option to be provided in a file by prefixing with `@`.  E.g: `bundle exec maze-runner --app=@in_this_file --farm=bs --device=ANDROID_9_0`

## Design

The need for this isn't obvious and came to light whilst developing a Buildkite pipeline to upload an app to BrowserStack only once (we currently do it on every Maze Runner step).  I found that the easiest way to pass the BrowserStack URL for uploaded apps between Buildkite steps is to write them to file and use build artefacts.  As Maze Runner commands are provided in the Buildkite YML files, I couldn't simply `cat` the file to pass it in via the existing command line and adding this feature seemed to be the easiest approach.

## Tests

New unit test added and overall effect tested locally.