### PR TITLE
Allow multiple `--device` options to be specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - All `--app` to be specified in a file using `@` prefix [#312](https://github.com/bugsnag/maze-runner/pull/312)
+- Allows multiple `--device` options to be specified [#314](https://github.com/bugsnag/maze-runner/pull/314)
 
 # 6.4.0 - 2021/11/08
 

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -100,6 +100,9 @@ module Maze
     # Test device type
     attr_accessor :device
 
+    # A list of devices to attempt to connect to, in order
+    attr_accessor :device_list
+
     # Test browser type
     attr_accessor :browser
 

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -96,7 +96,7 @@ module Maze
 
       def device_capabilities(config, tunnel_id=nil)
         config = Maze.config
-        if config.farm == :bs_local
+        if config.farm == :bs
           capabilities = Maze::Capabilities.for_browser_stack_device config.device,
                                                                      tunnel_id,
                                                                      config.appium_version,

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -115,11 +115,12 @@ module Maze
             driver = create_driver(config)
             driver.start_driver unless config.appium_session_isolation
             Maze.driver = driver
-          rescue Selenium::WebDriver::Error::UnknownError => originalException
+          rescue Selenium::WebDriver::Error::UnknownError => original_exception
             $logger.warn "Attempt to acquire #{config.device} device from farm #{config.farm} failed"
+            $logger.warn "Exception: #{original_exception.message}"
             if config.device_list.empty?
               $logger.error 'No further devices to try - raising original exception'
-              raise originalException
+              raise original_exception
             else
               config.device = config.device_list.first
               config.device_list = config.device_list.drop(1)

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -82,9 +82,10 @@ module Maze
             text 'Device farm options:'
 
             opt Option::DEVICE,
-                'BrowserStack device to use (a key of BrowserStackDevices.DEVICE_HASH)',
+                'Device to use. Can be listed multiple times to have a prioritised list of devices',
                 short: :none,
-                type: :string
+                type: :string,
+                multi: true
             opt Option::BROWSER,
                 'BrowserStack browser to use (an entry in browsers.yml)',
                 short: :none,

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -50,7 +50,6 @@ module Maze
           case config.farm
           when :bs then
             if device_option = options[Maze::Option::DEVICE]
-              pp device_option
               if device_option.is_a?(Array)
                 config.device = device_option.first
                 config.device_list = device_option

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -55,6 +55,7 @@ module Maze
                 config.device_list = device_option
               else
                 config.device = device_option
+                config.device_list = []
               end
               config.os_version = Maze::BrowserStackDevices::DEVICE_HASH[config.device]['os_version'].to_f
             else

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -50,6 +50,7 @@ module Maze
           case config.farm
           when :bs then
             if device_option = options[Maze::Option::DEVICE]
+              pp device_option
               if device_option.is_a?(Array)
                 config.device = device_option.first
                 config.device_list = device_option

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -12,6 +12,7 @@ module Maze
         # @param config [Configuration] MazeRunner configuration to populate
         # @param options [Hash] Parsed command line options
         def populate(config, options)
+
           # Server options
           config.bind_address = options[Maze::Option::BIND_ADDRESS]
           config.port = options[Maze::Option::PORT]
@@ -48,8 +49,13 @@ module Maze
           # Farm specific options
           case config.farm
           when :bs then
-            if options[Maze::Option::DEVICE]
-              config.device = options[Maze::Option::DEVICE]
+            if device_option = options[Maze::Option::DEVICE]
+              if device_option.is_a?(Array)
+                config.device = device_option.first
+                config.device_list = device_option
+              else
+                config.device = device_option
+              end
               config.os_version = Maze::BrowserStackDevices::DEVICE_HASH[config.device]['os_version'].to_f
             else
               config.browser = options[Maze::Option::BROWSER]

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -52,7 +52,7 @@ module Maze
             if device_option = options[Maze::Option::DEVICE]
               if device_option.is_a?(Array)
                 config.device = device_option.first
-                config.device_list = device_option
+                config.device_list = device_option.drop(1)
               else
                 config.device = device_option
                 config.device_list = []

--- a/lib/maze/option/validator.rb
+++ b/lib/maze/option/validator.rb
@@ -42,7 +42,7 @@ module Maze
         # Device
         browser = options[Option::BROWSER]
         device = options[Option::DEVICE]
-        if browser.nil? && device.nil?
+        if browser.nil? && device.empty?
           errors << "Either --#{Option::BROWSER} or --#{Option::DEVICE} must be specified"
         elsif browser
 
@@ -53,8 +53,9 @@ module Maze
             errors << "Browser type '#{browser}' unknown on BrowserStack.  Must be one of: #{browser_list}."
           end
         elsif device
-          unless device.all? { |device| Maze::BrowserStackDevices::DEVICE_HASH.key? device }
-            errors << "Device type '#{device}' unknown on BrowserStack.  Must be one of #{Maze::BrowserStackDevices::DEVICE_HASH.keys}"
+          device.each do |device_key|
+            next if Maze::BrowserStackDevices::DEVICE_HASH.key? device_key
+            errors << "Device type '#{device_key}' unknown on BrowserStack.  Must be one of #{Maze::BrowserStackDevices::DEVICE_HASH.keys}"
           end
           # App
           app = Maze::Helper.read_at_arg_file options[Option::APP]

--- a/lib/maze/option/validator.rb
+++ b/lib/maze/option/validator.rb
@@ -53,7 +53,7 @@ module Maze
             errors << "Browser type '#{browser}' unknown on BrowserStack.  Must be one of: #{browser_list}."
           end
         elsif device
-          unless Maze::BrowserStackDevices::DEVICE_HASH.key? device
+          unless device.all? { |device| Maze::BrowserStackDevices::DEVICE_HASH.key? device }
             errors << "Device type '#{device}' unknown on BrowserStack.  Must be one of #{Maze::BrowserStackDevices::DEVICE_HASH.keys}"
           end
           # App

--- a/test/hooks/appium_hooks_test.rb
+++ b/test/hooks/appium_hooks_test.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require 'appium_lib'
+require_relative '../test_helper'
+require_relative '../../lib/maze/capabilities'
+require_relative '../../lib/maze/driver/appium'
+require_relative '../../lib/maze/driver/resilient_appium'
+require_relative '../../lib/maze/hooks/appium_hooks'
+
+class AppiumHooksTest < Test::Unit::TestCase
+
+  def setup
+    $logger = mock('logger')
+    $config = mock('config')
+    Maze.stubs(:config).returns($config)
+  end
+
+  def test_device_capabilities_bs
+    $config.expects(:farm).returns(:bs)
+    $config.expects(:device).returns(:device)
+    $config.expects(:appium_version).returns(:appium_version)
+    $config.expects(:capabilities_option).returns(:capabilities_option)
+    $config.expects(:app).returns(:app)
+
+    caps_base = {}
+
+    Maze::Capabilities.expects(:for_browser_stack_device).with(
+      :device,
+      :tunnel_id,
+      :appium_version,
+      :capabilities_option
+    ).returns(caps_base)
+
+    hooks = Maze::Hooks::AppiumHooks.new
+    caps = hooks.device_capabilities($config, :tunnel_id)
+    assert_equal(caps, caps_base)
+    assert_equal(:app, caps['app'])
+  end
+
+  def test_device_capabilities_local
+    $config.expects(:farm).twice.returns(:local)
+    $config.expects(:os).returns(:os)
+    $config.expects(:capabilities_option).returns(:capabilities_option)
+    $config.expects(:apple_team_id).returns(:apple_team_id)
+    $config.expects(:device_id).returns(:device_id)
+    $config.expects(:app).returns(:app)
+
+    caps_base = {}
+
+    Maze::Capabilities.expects(:for_local).with(
+      :os,
+      :capabilities_option,
+      :apple_team_id,
+      :device_id
+    ).returns(caps_base)
+
+    hooks = Maze::Hooks::AppiumHooks.new
+    caps = hooks.device_capabilities($config)
+    assert_equal(caps, caps_base)
+    assert_equal(:app, caps['app'])
+  end
+
+  def test_create_driver_resilient
+    $config.expects(:resilient).returns(true)
+    $config.expects(:appium_server_url).returns(:appium_server_url)
+    $config.expects(:capabilities).returns(:capabilities)
+    $config.expects(:locator).returns(:locator)
+    $logger.expects(:info).with('Creating ResilientAppium driver instance')
+
+    Maze::Driver::ResilientAppium.expects(:new).with(
+      :appium_server_url,
+      :capabilities,
+      :locator
+    ).returns(:driver)
+
+    hooks = Maze::Hooks::AppiumHooks.new
+    driver = hooks.create_driver($config)
+
+    assert_equal(:driver, driver)
+  end
+
+  def test_create_driver_default
+    $config.expects(:resilient).returns(false)
+    $config.expects(:appium_server_url).returns(:appium_server_url)
+    $config.expects(:capabilities).returns(:capabilities)
+    $config.expects(:locator).returns(:locator)
+    $logger.expects(:info).with('Creating Appium driver instance')
+
+    Maze::Driver::Appium.expects(:new).with(
+      :appium_server_url,
+      :capabilities,
+      :locator
+    ).returns(:driver)
+
+    hooks = Maze::Hooks::AppiumHooks.new
+    driver = hooks.create_driver($config)
+
+    assert_equal(:driver, driver)
+  end
+
+  def test_start_driver_success
+    driver_mock = mock('driver')
+    driver_mock.expects(:start_driver)
+
+    Maze.expects(:driver).twice.returns(false, true)
+    Maze.expects(:driver=).with(driver_mock)
+
+    hooks = Maze::Hooks::AppiumHooks.new
+    hooks.expects(:device_capabilities).with($config, nil).returns(:caps)
+    hooks.expects(:create_driver).with($config).returns(driver_mock)
+
+    $config.expects(:capabilities=).with(:caps)
+    $config.expects(:appium_session_isolation).returns(false)
+
+    hooks.start_driver($config)
+  end
+
+  def test_start_driver_fails_once
+    driver_mock = mock('driver')
+    driver_mock.expects(:start_driver).raises(Selenium::WebDriver::Error::UnknownError)
+
+    Maze.expects(:driver).returns(false)
+
+    hooks = Maze::Hooks::AppiumHooks.new
+    hooks.expects(:device_capabilities).with($config, nil).returns(:caps)
+    hooks.expects(:create_driver).with($config).returns(driver_mock)
+
+    $config.expects(:capabilities=).with(:caps)
+    $config.expects(:appium_session_isolation).returns(false)
+    $config.expects(:device).returns(:device)
+    $config.expects(:farm).returns(:farm)
+    $config.expects(:device_list).returns([])
+
+    $logger.expects(:warn).with("Attempt to acquire #{:device} device from farm #{:farm} failed")
+    $logger.expects(:error).with('No further devices to try - raising original exception')
+
+    assert_raise Selenium::WebDriver::Error::UnknownError do
+      hooks.start_driver($config)
+    end
+  end
+
+  def test_start_driver_fails_then_succeeds
+    driver_mock = mock('driver')
+    driver_mock.expects(:start_driver).twice.raises(Selenium::WebDriver::Error::UnknownError).then.returns(true)
+
+    Maze.expects(:driver).times(3).returns(false, false, true)
+
+    hooks = Maze::Hooks::AppiumHooks.new
+    hooks.expects(:device_capabilities).twice.with($config, nil).returns(:caps)
+    hooks.expects(:create_driver).twice.with($config).returns(driver_mock)
+
+    $config.expects(:capabilities=).twice.with(:caps)
+    $config.expects(:appium_session_isolation).twice.returns(false)
+    $config.expects(:device).twice.returns(:device)
+    $config.expects(:farm).returns(:farm)
+    device_list = mock('device_list')
+    $config.stubs(:device_list).returns(device_list)
+    $config.expects(:device_list=).with(device_list)
+    $config.expects(:device=).with(:next_device)
+    device_list.expects(:empty?).returns(false)
+    device_list.expects(:first).returns(:next_device)
+    device_list.expects(:drop).with(1).returns(device_list)
+
+    $logger.expects(:warn).with("Attempt to acquire #{:device} device from farm #{:farm} failed")
+    $logger.expects(:warn).with("Retrying driver initialisation using next device: #{:device}")
+
+    Maze.expects(:driver=).with(driver_mock)
+
+    hooks.start_driver($config)
+  end
+
+  def test_start_driver_fails_multiple_times
+    driver_mock = mock('driver')
+    driver_mock.expects(:start_driver).times(3).raises(Selenium::WebDriver::Error::UnknownError)
+
+    Maze.expects(:driver).times(3).returns(false, false, false)
+
+    hooks = Maze::Hooks::AppiumHooks.new
+    hooks.expects(:device_capabilities).times(3).with($config, nil).returns(:caps)
+    hooks.expects(:create_driver).times(3).with($config).returns(driver_mock)
+
+    $config.expects(:capabilities=).times(3).with(:caps)
+    $config.expects(:appium_session_isolation).times(3).returns(false)
+    $config.expects(:device).times(5).returns(:device)
+    $config.expects(:farm).times(3).returns(:farm)
+    device_list = mock('device_list')
+    $config.stubs(:device_list).returns(device_list)
+    $config.expects(:device_list=).twice.with(device_list)
+    $config.expects(:device=).twice.with(:next_device)
+    device_list.expects(:empty?).times(3).returns(false, false, true)
+    device_list.expects(:first).twice.returns(:next_device)
+    device_list.expects(:drop).with(1).twice.returns(device_list)
+
+    $logger.expects(:warn).times(3).with("Attempt to acquire #{:device} device from farm #{:farm} failed")
+    $logger.expects(:warn).twice.with("Retrying driver initialisation using next device: #{:device}")
+    $logger.expects(:error).with('No further devices to try - raising original exception')
+
+    assert_raise Selenium::WebDriver::Error::UnknownError do
+      hooks.start_driver($config)
+    end
+  end
+
+  def test_start_driver_session_isolation
+    driver_mock = mock('driver')
+
+    Maze.expects(:driver).twice.returns(false, true)
+    Maze.expects(:driver=).with(driver_mock)
+
+    hooks = Maze::Hooks::AppiumHooks.new
+    hooks.expects(:device_capabilities).with($config, nil).returns(:caps)
+    hooks.expects(:create_driver).with($config).returns(driver_mock)
+
+    $config.expects(:capabilities=).with(:caps)
+    $config.expects(:appium_session_isolation).returns(true)
+
+    hooks.start_driver($config)
+  end
+
+end

--- a/test/hooks/appium_hooks_test.rb
+++ b/test/hooks/appium_hooks_test.rb
@@ -132,6 +132,7 @@ class AppiumHooksTest < Test::Unit::TestCase
     $config.expects(:device_list).returns([])
 
     $logger.expects(:warn).with("Attempt to acquire #{:device} device from farm #{:farm} failed")
+    $logger.expects(:warn).with("Exception: #{Selenium::WebDriver::Error::UnknownError.new.message}")
     $logger.expects(:error).with('No further devices to try - raising original exception')
 
     assert_raise Selenium::WebDriver::Error::UnknownError do
@@ -162,6 +163,7 @@ class AppiumHooksTest < Test::Unit::TestCase
     device_list.expects(:drop).with(1).returns(device_list)
 
     $logger.expects(:warn).with("Attempt to acquire #{:device} device from farm #{:farm} failed")
+    $logger.expects(:warn).with("Exception: #{Selenium::WebDriver::Error::UnknownError.new.message}")
     $logger.expects(:warn).with("Retrying driver initialisation using next device: #{:device}")
 
     Maze.expects(:driver=).with(driver_mock)
@@ -192,6 +194,7 @@ class AppiumHooksTest < Test::Unit::TestCase
     device_list.expects(:drop).with(1).twice.returns(device_list)
 
     $logger.expects(:warn).times(3).with("Attempt to acquire #{:device} device from farm #{:farm} failed")
+    $logger.expects(:warn).times(3).with("Exception: #{Selenium::WebDriver::Error::UnknownError.new.message}")
     $logger.expects(:warn).twice.with("Retrying driver initialisation using next device: #{:device}")
     $logger.expects(:error).with('No further devices to try - raising original exception')
 

--- a/test/option/parser_test.rb
+++ b/test/option/parser_test.rb
@@ -32,7 +32,7 @@ class ParserTest < Test::Unit::TestCase
 
     # BrowserStack-only options
     assert_equal('/BrowserStackLocal', options[Maze::Option::BS_LOCAL])
-    assert_nil(options[Maze::Option::DEVICE])
+    assert_equal([], options[Maze::Option::DEVICE])
     assert_nil(options[Maze::Option::BROWSER])
     assert_nil(options[Maze::Option::USERNAME])
     assert_nil(options[Maze::Option::ACCESS_KEY])
@@ -95,7 +95,7 @@ class ParserTest < Test::Unit::TestCase
 
     # BrowserStack-only options
     assert_equal('ARG_BS_LOCAL', options[Maze::Option::BS_LOCAL])
-    assert_equal('ARG_DEVICE', options[Maze::Option::DEVICE])
+    assert_equal(['ARG_DEVICE'], options[Maze::Option::DEVICE])
     assert_equal('ARG_BROWSER', options[Maze::Option::BROWSER])
     assert_equal('ARG_USERNAME', options[Maze::Option::USERNAME])
     assert_equal('ARG_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])


### PR DESCRIPTION
## Goal

Allows multiple `--device` options when running maze-runner.  These options will then be iterated through when attaching to the appropriate device farm, moving onto the next if one fails, allowing us to specify several appropriate devices for a test.

## Testing

Unit tests cover the basic functionality of the added/refactored methods

Not tested in anger - I'd suggest using this release in a test job against android/cocoa before merging.