### PR TITLE
Add Safari 14 and 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.6.0 - 2021/11/23
+
+## Enhancements
+
+- Add Safari 14 and 15 [#316](https://github.com/bugsnag/maze-runner/pull/316)
+
 # 6.5.1 - 2021/11/19
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,9 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.5.0)
+    bugsnag-maze-runner (6.6.0)
       appium_lib (~> 11.2.0)
+      bugsnag (~> 6.24)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
@@ -39,6 +40,8 @@ GEM
     appium_lib_core (4.7.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
+    bugsnag (6.24.0)
+      concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (3.0.0)
     concurrent-ruby (1.1.9)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.5.0'
+  VERSION = '6.6.0'
 
   class << self
     attr_accessor :driver, :internal_hooks, :mode, :start_time

--- a/lib/maze/browsers.yml
+++ b/lib/maze/browsers.yml
@@ -54,6 +54,18 @@ safari_13:
   os: "OS X"
   os_version: "Catalina"
 
+safari_14:
+  browser: "Safari"
+  browser_version: "14.0"
+  os: "OS X"
+  os_version: "Big Sur"
+
+safari_15:
+  browser: "Safari"
+  browser_version: "15.0"
+  os: "OS X"
+  os_version: "Monterey"
+
 iphone_7:
   browser: "iphone"
   device: "iPhone 7"


### PR DESCRIPTION
## Goal

Add Safari 14 and 15 to set of options (for BrowserStack).

## Tests

Tested locally using a development branch of `bugang-js`.