### PR TITLE
Bump BrowserStackLocal to 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.6.1 - 2021/12/02
+
+## Fixes
+
+- Bump BrowserStackLocal from 8.0 to 8.4 [#317](https://github.com/bugsnag/maze-runner/pull/317)
+
 # 6.6.0 - 2021/11/23
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.6.0)
+    bugsnag-maze-runner (6.6.1)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -40,7 +40,7 @@ GEM
     appium_lib_core (4.7.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
-    bugsnag (6.24.0)
+    bugsnag (6.24.1)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (3.0.0)

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -9,9 +9,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
 
 RUN ruby -v
 
-RUN wget -q https://storage.googleapis.com/bugsnag-public-test-dependencies/BrowserStackLocal-linux-x64.zip \
-  && unzip BrowserStackLocal-linux-x64.zip \
-  && rm BrowserStackLocal-linux-x64.zip
+RUN wget -q https://storage.googleapis.com/bugsnag-public-test-dependencies/BrowserStackLocal-linux-x64-v8_4.zip \
+  && unzip BrowserStackLocal-linux-x64-v8_4.zip \
+  && rm BrowserStackLocal-linux-x64-v8_4.zip
 
 RUN wget -q https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz \
   && tar --extract --file sc-4.6.4-linux.tar.gz \

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.6.0'
+  VERSION = '6.6.1'
 
   class << self
     attr_accessor :driver, :internal_hooks, :mode, :start_time


### PR DESCRIPTION
## Goal

Bump BrowserStackLocal to 8.4 (from 8.0).

See release notes on https://www.browserstack.com/local-testing/releases (v8.4 currently missing, raising with BS support).