### PR TITLE
Refresh support for Sauce Labs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.6.2 - TBD
+
+## Fixes
+
+- Fix support for Sauce Labs [#318](https://github.com/bugsnag/maze-runner/pull/318)
+
 # 6.6.1 - 2021/12/02
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.6.1)
+    bugsnag-maze-runner (6.6.2)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -13,10 +13,10 @@ RUN wget -q https://storage.googleapis.com/bugsnag-public-test-dependencies/Brow
   && unzip BrowserStackLocal-linux-x64-v8_4.zip \
   && rm BrowserStackLocal-linux-x64-v8_4.zip
 
-RUN wget -q https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz \
-  && tar --extract --file sc-4.6.4-linux.tar.gz \
-  && rm sc-4.6.4-linux.tar.gz \
-  && mv sc-4.6.4-linux sauce-connect
+RUN wget -q https://storage.googleapis.com/bugsnag-public-test-dependencies/sc-4.7.1-linux.tar.gz \
+  && tar --extract --file sc-4.7.1-linux.tar.gz \
+  && rm sc-4.7.1-linux.tar.gz \
+  && mv sc-4.7.1-linux sauce-connect
 
 WORKDIR /app/
 

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -160,16 +160,7 @@ When('I clear and send the keys {string} to the element {string}') do |keys, ele
 end
 
 def get_expected_platform_value(platform_values)
-  if Maze.config.farm == :bs
-    os = Maze.config.capabilities['os']
-  elsif Maze.config.farm == :sl
-    os = Maze.driver.capabilities['platformName']
-  else
-    os = Maze.config.os
-  end
-
-  raise('Unable to determine the current platform') if os.nil?
-
+  os = Maze::Helper.get_current_platform
   expected_value = Hash[platform_values.raw][os.downcase]
   raise("There is no expected value for the current platform \"#{os}\"") if expected_value.nil?
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -217,3 +217,7 @@ AfterAll do
   # Invoke the internal hook for the mode of operation
   Maze.internal_hooks.after_all
 end
+
+at_exit do
+  Maze.internal_hooks.at_exit
+end

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -6,7 +6,7 @@ require_relative 'maze/hooks/hooks'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.6.1'
+  VERSION = '6.6.2'
 
   class << self
     attr_accessor :driver, :internal_hooks, :mode, :start_time

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -42,14 +42,15 @@ module Maze
       # @param udid [String] device UDID, for iOS only
       # noinspection RubyStringKeysInHashInspection
       def for_local(platform, capabilities_option, team_id = nil, udid = nil)
-        capabilities = if platform.downcase == 'android'
+        capabilities = case platform.downcase
+                       when 'android'
                          {
                            'platformName' => 'Android',
                            'automationName' => 'UiAutomator2',
                            'autoGrantPermissions' => 'true',
                            'noReset' => 'true'
                          }
-                       elsif platform.downcase == 'ios'
+                       when 'ios'
                          {
                            'platformName' => 'iOS',
                            'automationName' => 'XCUITest',
@@ -59,10 +60,12 @@ module Maze
                            'udid' => udid,
                            'noReset' => 'true'
                          }
-                       elsif platform.downcase == 'macos'
+                       when 'macos'
                          {
                            'platformName' => 'Mac'
                          }
+                       else
+                         raise "Unsupported platform: #{platform}"
                        end
         common = {
           'os' => platform,

--- a/lib/maze/helper.rb
+++ b/lib/maze/helper.rb
@@ -85,6 +85,24 @@ module Maze
         file = argument[1..argument.size]
         File.read file
       end
+
+      # Returns the current platform all lower-case.
+      # @@return Typically 'ios', 'android' or 'mac'.
+      def get_current_platform
+        os = case Maze.config.farm
+             when :bs
+               Maze.config.capabilities['os']
+             when :sl
+               Maze.driver.capabilities['platformName']
+             else
+               Maze.config.os
+             end
+        os = os&.downcase
+
+        raise('Unable to determine the current platform') if os.nil?
+
+        os
+      end
     end
   end
 end

--- a/lib/maze/hooks/browser_hooks.rb
+++ b/lib/maze/hooks/browser_hooks.rb
@@ -1,6 +1,7 @@
 # Contains logic for the Cucumber hooks when in Browser mode
 module Maze
   module Hooks
+    # Hooks for Browser mode use
     class BrowserHooks < InternalHooks
       def before_all
         config = Maze.config
@@ -16,10 +17,11 @@ module Maze
         end
 
         # Create and start the relevant driver
-        if config.farm == :bs
+        case config.farm
+        when :bs
           selenium_url = "http://#{config.username}:#{config.access_key}@hub.browserstack.com/wd/hub"
           Maze.driver = Maze::Driver::Browser.new :remote, selenium_url, config.capabilities
-        elsif config.farm == :local
+        when :local
           Maze.driver = Maze::Driver::Browser.new Maze.config.browser.to_sym
         end
       end

--- a/lib/maze/hooks/command_hooks.rb
+++ b/lib/maze/hooks/command_hooks.rb
@@ -1,6 +1,7 @@
 # Contains logic for the Cucumber hooks when in Command mode
 module Maze
   module Hooks
+    # Hooks for Command mode use
     class CommandHooks < InternalHooks
       # Nothing required at present
     end

--- a/lib/maze/hooks/hooks.rb
+++ b/lib/maze/hooks/hooks.rb
@@ -54,6 +54,8 @@ module Maze
       def after; end
 
       def after_all; end
+
+      def at_exit; end
     end
   end
 end

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -69,8 +69,14 @@ module Maze
             access_key = config.access_key = options[Maze::Option::ACCESS_KEY]
             config.appium_server_url = "http://#{username}:#{access_key}@hub-cloud.browserstack.com/wd/hub"
           when :sl
-            config.device = options[Maze::Option::DEVICE]
-            config.device_list = []
+            device_option = options[Maze::Option::DEVICE]
+            if device_option.is_a?(Array)
+              config.device = device_option.first
+              config.device_list = device_option.drop(1)
+            else
+              config.device = device_option
+              config.device_list = []
+            end
             config.browser = options[Maze::Option::BROWSER]
             config.os = options[Maze::Option::OS]
             config.os_version = options[Maze::Option::OS_VERSION]
@@ -78,7 +84,7 @@ module Maze
             config.appium_version = options[Maze::Option::APPIUM_VERSION]
             username = config.username = options[Maze::Option::USERNAME]
             access_key = config.access_key = options[Maze::Option::ACCESS_KEY]
-            config.appium_server_url = "http://#{username}:#{access_key}@ondemand.us-west-1.saucelabs.com/wd/hub"
+            config.appium_server_url = "https://#{username}:#{access_key}@ondemand.us-west-1.saucelabs.com/wd/hub"
           when :local
             if options[Maze::Option::BROWSER]
               config.browser = options[Maze::Option::BROWSER]

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -49,7 +49,7 @@ module Maze
 
           # Farm specific options
           case config.farm
-          when :bs then
+          when :bs
             device_option = options[Maze::Option::DEVICE]
             if device_option.nil? || device_option.empty?
               config.browser = options[Maze::Option::BROWSER]
@@ -68,8 +68,9 @@ module Maze
             username = config.username = options[Maze::Option::USERNAME]
             access_key = config.access_key = options[Maze::Option::ACCESS_KEY]
             config.appium_server_url = "http://#{username}:#{access_key}@hub-cloud.browserstack.com/wd/hub"
-          when :sl then
+          when :sl
             config.device = options[Maze::Option::DEVICE]
+            config.device_list = []
             config.browser = options[Maze::Option::BROWSER]
             config.os = options[Maze::Option::OS]
             config.os_version = options[Maze::Option::OS_VERSION]
@@ -78,7 +79,7 @@ module Maze
             username = config.username = options[Maze::Option::USERNAME]
             access_key = config.access_key = options[Maze::Option::ACCESS_KEY]
             config.appium_server_url = "http://#{username}:#{access_key}@ondemand.us-west-1.saucelabs.com/wd/hub"
-          when :local then
+          when :local
             if options[Maze::Option::BROWSER]
               config.browser = options[Maze::Option::BROWSER]
             else

--- a/test/hooks/appium_hooks_test.rb
+++ b/test/hooks/appium_hooks_test.rb
@@ -38,7 +38,7 @@ class AppiumHooksTest < Test::Unit::TestCase
   end
 
   def test_device_capabilities_local
-    $config.expects(:farm).twice.returns(:local)
+    $config.expects(:farm).returns(:local)
     $config.expects(:os).returns(:os)
     $config.expects(:capabilities_option).returns(:capabilities_option)
     $config.expects(:apple_team_id).returns(:apple_team_id)


### PR DESCRIPTION
## Goal

Fix support for Sauce Labs, which was partially broken in a recent refactor.  Also makes a few code improvements.

## Changeset

- Necessary code for Sauce Labs reinstated into Cucumber hooks 
- Code style violations resolved
- Sauce Connect version bumped
- Platform detection code moved to Helper class to allow reuse

## Tests

Tested locally against Sauce Labs, CI covers the BrowserStack side.  Some further testing will be performed against notifier pipelines before release.