### PR TITLE
Use -KILL to terminate deadlocked Mac apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Fixes
 
+- Fix killing deadlocked Mac fixtures [#320](https://github.com/bugsnag/maze-runner/pull/320)
 - Fix support for Sauce Labs [#318](https://github.com/bugsnag/maze-runner/pull/318)
 
 # 6.6.1 - 2021/12/02

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -50,7 +50,7 @@ module Maze
           Maze.driver.driver_quit
         elsif Maze.config.os == 'macos'
           # Close the app - without the sleep, launching the app for the next scenario intermittently fails
-          system("killall #{Maze.config.app} && sleep 1")
+          system("killall -KILL #{Maze.config.app} && sleep 1")
         else
           Maze.driver.reset
         end

--- a/test/fixtures/ios-app/features/steps/test_steps.rb
+++ b/test/fixtures/ios-app/features/steps/test_steps.rb
@@ -50,7 +50,7 @@ When('I relaunch the app') do
   case Maze.driver.capabilities['platformName']
   when 'Mac'
     app = Maze.driver.capabilities['app']
-    system("killall #{app} > /dev/null && sleep 1")
+    system("killall -KILL #{app} > /dev/null && sleep 1")
     Maze.driver.get(app)
   else
     Maze.driver.launch_app


### PR DESCRIPTION
## Goal

Kill the the Mac test fixture even if it deadlocks while running a scenario.

## Changeset

Passes the `-KILL` option to `killall` to forcibly terminate the app rather than sending a signal that needs to be handled by the fixture itself.

## Tests

Tested here - https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4140#903d8512-a752-47c8-8332-a33190e65ad7 and observed via screen sharing to verify that the fixture is terminated.