### PR TITLE
Correct capability to disableAnimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Fixes
+
+- Correct BrowserStack capability to `disableAnimations` [#323](https://github.com/bugsnag/maze-runner/pull/323)
+
 # 6.9.6 - 2022/03/31
 
 ## Fixes

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -12,14 +12,19 @@ module Maze
 
     class << self
       def make_android_hash(device, version, appium_version = APPIUM_1_20_2)
-        {
+        hash = {
           'device' => device,
           'os_version' => version,
           'autoGrantPermissions' => 'true',
           'platformName' => 'Android',
           'os' => 'android',
           'browserstack.appium_version' => appium_version
-        }.freeze
+        }
+        # disableAnimations only allowed > Android 6
+        if version.to_i > 6
+          hash['disableAnimations'] = 'true'
+        end
+        hash.freeze
       end
 
       def add_android(device, version, hash, appium_version = APPIUM_1_20_2)
@@ -38,6 +43,7 @@ module Maze
           'os_version' => version,
           'platformName' => 'iOS',
           'os' => 'ios',
+          'disableAnimations' => 'true',
           'browserstack.appium_version' => appium_version
         }.freeze
       end

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -12,7 +12,6 @@ module Maze
           'browserstack.console' => 'errors',
           'browserstack.localIdentifier' => local_id,
           'browserstack.local' => 'true',
-          'disableAnimations' => 'true',
           'noReset' => 'true'
         }
         capabilities.merge! BrowserStackDevices::DEVICE_HASH[device_type]

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -12,7 +12,7 @@ module Maze
           'browserstack.console' => 'errors',
           'browserstack.localIdentifier' => local_id,
           'browserstack.local' => 'true',
-          'disabledAnimations' => 'true',
+          'disableAnimations' => 'true',
           'noReset' => 'true'
         }
         capabilities.merge! BrowserStackDevices::DEVICE_HASH[device_type]


### PR DESCRIPTION
## Goal

Correct capability name to `disableAnimation`.  

See https://www.browserstack.com/app-automate/capabilities.

## Design

Android 6 and below doesn't support this capability and BrowserStack will raise an error if you try to set it. 

## Testing

In addition to CI, I have manually run tests on Android against versions 5,6 and 7 (i.e. across the v6 boundary) and on iOS versions 10 and 15.