### PR TITLE
Use the app path instead of app name

### DIFF
--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -75,6 +75,9 @@ module Maze
     # - on macOS, the name of an installed or previously executed application
     attr_accessor :app
 
+    # The path to the app file used in macOS (generated)
+    attr_accessor :app_path
+
     # Whether the ResilientAppium driver should be used (only applicable when using Appium in the first place)
     attr_accessor :resilient
 

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -31,7 +31,7 @@ module Maze
           pp "Open app"
           pp config.app_path
           pp config.app
-          Maze::Runner.run_command(`open #{config.app_path}`) if config.os == 'macos'
+          Maze::Runner.run_command("open #{config.app_path}") if config.os == 'macos'
 
           # Attempt to start the local appium server
           appium_uri = URI(config.appium_server_url)

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -28,7 +28,7 @@ module Maze
                                                    config.access_key
         when :local
           # Open the app beforehand to ensure it runs correctly and is accessible
-          Maze::Runner.run_command(`open #{fixture_dir}/#{app_file}`) if config.os == 'macos'
+          Maze::Runner.run_command(`open #{config.app_path}`) if config.os == 'macos'
 
           # Attempt to start the local appium server
           appium_uri = URI(config.appium_server_url)

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -28,10 +28,6 @@ module Maze
                                                    config.access_key
         when :local
           # Open the app beforehand to ensure it runs correctly and is accessible
-          pp "Open app"
-          pp config.app_path
-          pp config.app
-          Maze::Runner.run_command("open #{config.app_path}") if config.os == 'macos'
           Maze::Runner.run_command("/System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted #{config.app_path}") if config.os == 'macos'
 
           # Attempt to start the local appium server

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -32,6 +32,7 @@ module Maze
           pp config.app_path
           pp config.app
           Maze::Runner.run_command("open #{config.app_path}") if config.os == 'macos'
+          Maze::Runner.run_command("/System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted #{config.app_path}") if config.os == 'macos'
 
           # Attempt to start the local appium server
           appium_uri = URI(config.appium_server_url)

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -28,7 +28,7 @@ module Maze
                                                    config.access_key
         when :local
           # Open the app beforehand to ensure it runs correctly and is accessible
-          Maze::Runner.run_command("/System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted #{config.app_path}") if config.os == 'macos'
+          Maze::Runner.run_command("open #{config.app_path}") if config.os == 'macos'
 
           # Attempt to start the local appium server
           appium_uri = URI(config.appium_server_url)

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -28,6 +28,9 @@ module Maze
                                                    config.access_key
         when :local
           # Open the app beforehand to ensure it runs correctly and is accessible
+          pp "Open app"
+          pp config.app_path
+          pp config.app
           Maze::Runner.run_command(`open #{config.app_path}`) if config.os == 'macos'
 
           # Attempt to start the local appium server

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -27,6 +27,9 @@ module Maze
                                                    config.username,
                                                    config.access_key
         when :local
+          # Open the app beforehand to ensure it runs correctly and is accessible
+          Maze::Runner.run_command(`open #{fixture_dir}/#{app_file}`) if config.os == 'macos'
+
           # Attempt to start the local appium server
           appium_uri = URI(config.appium_server_url)
           Maze::AppiumServer.start(address: appium_uri.host, port: appium_uri.port) if config.start_appium

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -97,6 +97,11 @@ module Maze
               if os == 'ios'
                 config.apple_team_id = options[Maze::Option::APPLE_TEAM_ID]
                 config.device_id = options[Maze::Option::UDID]
+              elsif os == 'macos'
+                # Process the application path into a path for pre-loading the app and a name for use in Appium
+                fullAppPath = File.expand_path(config.app)
+                config.app_path = fullAppPath
+                config.app = File.basename(fullAppPath, '.*')
               end
             end
           when :none


### PR DESCRIPTION
## Goal

Preheat the application so we no-longer need to copy the app into the `/Applications` directory

## Testing

[This run](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4230) shows the functionality working
[This run](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4234) will be required to work with the cocoa library, and should cover all of the desired macOS versions.