### PR TITLE
Set capabilities to improve performance on Sauce Labs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Fixes
+
+- Set Appium capabilities for improved performance on Sauce Labs [#325](https://github.com/bugsnag/maze-runner/pull/325)
+
 # 6.6.2 - 2021/12/06
 
 ## Fixes

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -77,13 +77,13 @@ module Maze
 
       def for_sauce_labs_device(device_name, os, os_version, tunnel_id, appium_version, capabilities_option)
         capabilities = {
-          'noReset' => 'true',
+          'noReset' => true,
           'deviceOrientation' => 'portrait',
           'tunnelIdentifier' => tunnel_id,
           'browserName' => '',
-          'autoAcceptAlerts' => 'true',
+          'autoAcceptAlerts' => true,
           'sendKeyStrategy' => 'setValue',
-          'waitForQuiescence' => 'false',
+          'waitForQuiescence' => false,
           'newCommandTimeout' => 0
         }
         capabilities['deviceName'] = device_name unless device_name.nil?

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -80,7 +80,11 @@ module Maze
           'noReset' => 'true',
           'deviceOrientation' => 'portrait',
           'tunnelIdentifier' => tunnel_id,
-          'browserName' => ""
+          'browserName' => '',
+          'autoAcceptAlerts' => 'true',
+          'sendKeyStrategy' => 'setValue',
+          'waitForQuiescence' => 'false',
+          'newCommandTimeout' => 0
         }
         capabilities['deviceName'] = device_name unless device_name.nil?
         capabilities['platformName'] = os unless os.nil?


### PR DESCRIPTION
## Goal

Set capabilities to improve performance on Sauce Labs.

## Changeset

- Warnings in Appium resolve by using booleans rather than strings
- Capabilities set to avoid long waits for crashy scenarios (these are set by default on BrowserStack).

## Tests

Tested locally against Sauce Labs.