### PR TITLE
Refactor remaining codebase to use Maze.check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Refactor
 
-- Add `Maze.check` to abstract from underlying assertion implementation [#327](https://github.com/bugsnag/maze-runner/pull/327)
+- Add `Maze.check` to abstract from underlying assertion implementation [#327](https://github.com/bugsnag/maze-runner/pull/327) [#328](https://github.com/bugsnag/maze-runner/pull/328)
 
 # 6.7.0 - 2021/12/15
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,24 +15,22 @@ PATH
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
-      minitest (~> 5.0)
       optimist (~> 3.0.1)
       os (~> 1.0.0)
       rake (~> 12.3.3)
       rubyzip (~> 2.3.2)
       selenium-webdriver (~> 3.11)
-      test-unit (~> 3.3.0)
+      test-unit (~> 3.5.2)
       webrick (~> 1.7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.1)
+    activesupport (7.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     appium_lib (11.2.0)
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
@@ -62,8 +60,8 @@ GEM
       cucumber-gherkin (~> 22.0, >= 22.0.0)
       cucumber-messages (~> 17.1, >= 17.1.1)
       cucumber-tag-expressions (~> 4.0, >= 4.0.2)
-    cucumber-create-meta (6.0.1)
-      cucumber-messages (~> 17.0, >= 17.0.1)
+    cucumber-create-meta (6.0.4)
+      cucumber-messages (~> 17.1, >= 17.1.1)
       sys-uname (~> 1.2, >= 1.2.2)
     cucumber-cucumber-expressions (14.0.0)
     cucumber-expressions (6.0.1)
@@ -84,7 +82,7 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     ffi (1.15.4)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     iniparser (1.0.1)
     kramdown (2.3.1)
@@ -101,10 +99,10 @@ GEM
       kramdown (>= 1.5.0)
       props (>= 1.1.2)
       textutils (>= 0.10.0)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0901)
-    minitest (5.14.4)
+    mime-types-data (3.2021.1115)
+    minitest (5.15.0)
     mocha (1.12.0)
     multi_test (0.1.2)
     nokogiri (1.12.5-x86_64-darwin)
@@ -124,7 +122,7 @@ GEM
       rubyzip (>= 1.2.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
-    test-unit (3.3.9)
+    test-unit (3.5.2)
       power_assert
     textutils (1.4.0)
       activesupport
@@ -142,8 +140,8 @@ GEM
     with_env (1.1.0)
     xml-simple (1.1.9)
       rexml
-    yard (0.9.26)
-    zeitwerk (2.4.2)
+    yard (0.9.27)
+      webrick (~> 1.7.0)
 
 PLATFORMS
   x86_64-darwin-19
@@ -158,4 +156,4 @@ DEPENDENCIES
   yard-cucumber!
 
 BUNDLED WITH
-   2.2.20
+   2.2.33

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -18,25 +18,24 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/[\w\-]+$}) { |f| File.basename(f) }
 
   spec.add_dependency 'cucumber', '~> 7.1'
-  spec.add_dependency 'minitest', '~> 5.0'
   spec.add_dependency 'os', '~> 1.0.0'
-  spec.add_dependency 'test-unit', '~> 3.3.0'
+  spec.add_dependency 'test-unit', '~> 3.5.2'
   spec.add_dependency 'webrick', '~> 1.7.0'
 
   spec.add_dependency 'appium_lib', '~> 11.2.0'
+  spec.add_dependency 'bugsnag', '~> 6.24'
   spec.add_dependency 'cucumber-expressions', '~> 6.0.0'
   spec.add_dependency 'curb', '~> 0.9.6'
   spec.add_dependency 'optimist', '~> 3.0.1'
   spec.add_dependency 'rake', '~> 12.3.3'
   spec.add_dependency 'selenium-webdriver', '~> 3.11'
-  spec.add_dependency 'bugsnag', '~> 6.24'
 
   # Pin indirect dependencies
   spec.add_runtime_dependency 'rubyzip', '~> 2.3.2'
 
+  spec.add_development_dependency 'license_finder', '~> 6.12.0'
   spec.add_development_dependency 'markdown', '~> 1.2'
   spec.add_development_dependency 'mocha', '~> 1.12.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'yard', '~> 0.9.1'
-  spec.add_development_dependency 'license_finder', '~> 6.12.0'
 end

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -190,9 +190,10 @@ def test_boolean_platform_values(request_type, field_path, platform_values)
   expected_value = get_expected_platform_value(platform_values)
   return if should_skip_platform_check(expected_value)
 
-  expected_bool = if expected_value.downcase == 'true'
+  expected_bool = case expected_value.downcase
+                  when 'true'
                     true
-                  elsif expected_value.downcase == 'false'
+                  when 'false'
                     false
                   else
                     expected_value
@@ -216,11 +217,12 @@ def test_numeric_platform_values(request_type, field_path, platform_values)
 end
 
 def assert_equal_with_nullability(expected_value, payload_value)
-  if expected_value.eql?('@null')
-    assert_nil(payload_value)
-  elsif expected_value.eql?('@not_null')
-    assert_not_nil(payload_value)
+  case expected_value
+  when '@null'
+    Maze.check.nil(payload_value)
+  when '@not_null'
+    Maze.check.not_nil(payload_value)
   else
-    assert_equal(expected_value, payload_value)
+    Maze.check.equal(expected_value, payload_value)
   end
 end

--- a/lib/features/steps/aws_sam_steps.rb
+++ b/lib/features/steps/aws_sam_steps.rb
@@ -26,15 +26,15 @@ end
 #
 # @step_input expected [Integer] The expected exit code
 Then('the SAM exit code equals {int}') do |expected|
-  assert_equal(expected, Maze::Aws::Sam.last_exit_code)
+  Maze.check.equal(expected, Maze::Aws::Sam.last_exit_code)
 end
 
 # Test the Lambda response is empty but not-null. This indicates the Lambda did
 # not respond but did run successfully
 Then('the lambda response is empty') do
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
-  assert_equal({}, Maze::Aws::Sam.last_response)
+  Maze.check.equal({}, Maze::Aws::Sam.last_response)
 end
 
 # Test a Lambda response field equals the given string.
@@ -42,11 +42,11 @@ end
 # @step_input key_path [String] The response element to test
 # @step_input expected [String] The string to test against
 Then('the lambda response {string} equals {string}') do |key_path, expected|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_equal(expected, actual)
+  Maze.check.equal(expected, actual)
 end
 
 # Test a Lambda response field contains the given string.
@@ -54,11 +54,11 @@ end
 # @step_input key_path [String] The response element to test
 # @step_input expected [String] The string to test against
 Then('the lambda response {string} contains {string}') do |key_path, expected|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_includes(actual, expected)
+  Maze.check.include(actual, expected)
 end
 
 # Test a Lambda response field equals the given integer.
@@ -66,55 +66,55 @@ end
 # @step_input key_path [String] The response element to test
 # @step_input expected [Integer] The integer to test against
 Then('the lambda response {string} equals {int}') do |key_path, expected|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_equal(expected, actual)
+  Maze.check.equal(expected, actual)
 end
 
 # Test a Lambda response field is true.
 #
 # @step_input key_path [String] The response element to test
 Then('the lambda response {string} is true') do |key_path|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_true(actual)
+  Maze.check.true(actual)
 end
 
 # Test a Lambda response field is false.
 #
 # @step_input key_path [String] The response element to test
 Then('the lambda response {string} is false') do |key_path|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_false(actual)
+  Maze.check.false(actual)
 end
 
 # Test a Lambda response field is null.
 #
 # @step_input key_path [String] The response element to test
 Then('the lambda response {string} is null') do |key_path|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_nil(actual)
+  Maze.check.nil(actual)
 end
 
 # Test a Lambda response field is not null.
 #
 # @step_input key_path [String] The response element to test
 Then('the lambda response {string} is not null') do |key_path|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_not_nil(actual)
+  Maze.check.not_nil(actual)
 end
 
 # Test a Lambda response field is greater than the given integer.
@@ -122,11 +122,11 @@ end
 # @step_input key_path [String] The response element to test
 # @step_input expected [Integer] The integer to test against
 Then('the lambda response {string} is greater than {int}') do |key_path, expected|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_operator(actual, :>, expected)
+  Maze.check.operator(actual, :>, expected)
 end
 
 # Test a Lambda response field is less than the given integer.
@@ -134,11 +134,11 @@ end
 # @step_input key_path [String] The response element to test
 # @step_input expected [Integer] The integer to test against
 Then('the lambda response {string} is less than {int}') do |key_path, expected|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_operator(actual, :<, expected)
+  Maze.check.operator(actual, :<, expected)
 end
 
 # Test a Lambda response field starts with the given string.
@@ -146,11 +146,11 @@ end
 # @step_input key_path [String] The response element to test
 # @step_input expected [String] The string to test against
 Then('the lambda response {string} starts with {string}') do |key_path, expected|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_kind_of(String, actual)
+  Maze.check.kind_of(String, actual)
   assert(
     actual.start_with?(expected),
     "Field '#{key_path}' value ('#{actual}') does not start with '#{expected}'"
@@ -162,11 +162,11 @@ end
 # @step_input key_path [String] The response element to test
 # @step_input expected [String] The string to test against
 Then('the lambda response {string} ends with {string}') do |key_path, expected|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_kind_of(String, actual)
+  Maze.check.kind_of(String, actual)
   assert(
     actual.end_with?(expected),
     "Field '#{key_path}' value ('#{actual}') does not start with '#{expected}'"
@@ -178,24 +178,24 @@ end
 # @step_input key_path [String] The response element to test
 # @step_input expected [Integer] The expected number of elements
 Then('the lambda response {string} is an array with {int} element(s)') do |key_path, expected|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_kind_of(Array, actual)
-  assert_equal(expected, actual.length)
+  Maze.check.kind_of(Array, actual)
+  Maze.check.equal(expected, actual.length)
 end
 
 # Test a Lambda response field is an array with at least 1 element.
 #
 # @step_input key_path [String] The response element to test
 Then('the lambda response {string} is a non-empty array') do |key_path|
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_kind_of(Array, actual)
-  assert_false(actual.empty?)
+  Maze.check.kind_of(Array, actual)
+  Maze.check.false(actual.empty?)
 end
 
 # Test a Lambda response field matches the given regex.
@@ -204,9 +204,9 @@ end
 # @step_input expected [String] The regex to match against
 Then('the lambda response {string} matches the regex {string}') do |key_path, regex|
   expected = Regexp.new(regex)
-  assert_not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
+  Maze.check.not_nil(Maze::Aws::Sam.last_response, 'No lambda response!')
 
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
-  assert_match(expected, actual)
+  Maze.check.match(expected, actual)
 end

--- a/lib/features/steps/aws_sam_steps.rb
+++ b/lib/features/steps/aws_sam_steps.rb
@@ -151,7 +151,7 @@ Then('the lambda response {string} starts with {string}') do |key_path, expected
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
   Maze.check.kind_of(String, actual)
-  assert(
+  Maze.check.true(
     actual.start_with?(expected),
     "Field '#{key_path}' value ('#{actual}') does not start with '#{expected}'"
   )
@@ -167,7 +167,7 @@ Then('the lambda response {string} ends with {string}') do |key_path, expected|
   actual = Maze::Helper.read_key_path(Maze::Aws::Sam.last_response, key_path)
 
   Maze.check.kind_of(String, actual)
-  assert(
+  Maze.check.true(
     actual.end_with?(expected),
     "Field '#{key_path}' value ('#{actual}') does not start with '#{expected}'"
   )

--- a/lib/features/steps/breadcrumb_steps.rb
+++ b/lib/features/steps/breadcrumb_steps.rb
@@ -46,5 +46,5 @@ Then('the event contains a breadcrumb matching the JSON fixture in {string}') do
   breadcrumbs = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.breadcrumbs')
   expected = JSON.parse(open(json_fixture, &:read))
   match = breadcrumbs.any? { |breadcrumb| Maze::Compare.value(expected, breadcrumb).equal? }
-  assert(match, 'No breadcrumbs in the event matched the given breadcrumb')
+  Maze.check.true(match, 'No breadcrumbs in the event matched the given breadcrumb')
 end

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -184,15 +184,13 @@ end
 
 Then('the event {string} string is empty') do |keypath|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], keypath)
-  Maze.check.block("The #{keypath} is not empty: '#{value}'") do
-    value.nil? || value.empty?
-  end
+  Maze.check.true(value.nil? || value.empty?, "The #{keypath} is not empty: '#{value}'")
 end
 
 Then('the event {string} is greater than {int}') do |keypath, int|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{keypath}")
   Maze.check.false(value.nil?, "The event #{keypath} is nil")
-  Maze.check.true(value > int)
+  Maze.check.operator(value, :>, int)
 end
 
 # Tests whether a value in the first exception of the first event entry starts with a string.

--- a/lib/features/steps/error_reporting_steps.rb
+++ b/lib/features/steps/error_reporting_steps.rb
@@ -97,7 +97,7 @@ Then('the error payload contains the payloadVersion {string}') do |payload_versi
   body_set = payload_version == body_version
   event_version = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.payloadVersion')
   event_set = payload_version == event_version
-  assert_true(
+  Maze.check.true(
     body_set || event_set,
     "The payloadVersion was not the expected value of #{payload_version}. " \
     "#{body_version} found in body, #{event_version} found in event"
@@ -184,15 +184,15 @@ end
 
 Then('the event {string} string is empty') do |keypath|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], keypath)
-  assert_block("The #{keypath} is not empty: '#{value}'") do
+  Maze.check.block("The #{keypath} is not empty: '#{value}'") do
     value.nil? || value.empty?
   end
 end
 
 Then('the event {string} is greater than {int}') do |keypath, int|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{keypath}")
-  assert_false(value.nil?, "The event #{keypath} is nil")
-  assert_true(value > int)
+  Maze.check.false(value.nil?, "The event #{keypath} is nil")
+  Maze.check.true(value > int)
 end
 
 # Tests whether a value in the first exception of the first event entry starts with a string.
@@ -307,13 +307,13 @@ end
 # @param payload_value [Any] The thread identifier value
 def validate_error_reporting_thread(payload_key, payload_value)
   threads = Maze::Server.errors.current[:body]['events'].first['threads']
-  assert_kind_of Array, threads
+  Maze.check.kind_of Array, threads
   count = 0
 
   threads.each do |thread|
     count += 1 if thread[payload_key].to_s == payload_value && thread['errorReportingThread'] == true
   end
-  assert_equal(1, count)
+  Maze.check.equal(1, count)
 end
 
 # Tests whether an event has the correct attributes we'd expect for un/handled events

--- a/lib/features/steps/feature_flag_steps.rb
+++ b/lib/features/steps/feature_flag_steps.rb
@@ -7,7 +7,7 @@
 # @step_input event_id [Integer] The id of the event in the payloads array
 Then('event {int} has no feature flags') do |event_id|
   event = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.#{event_id}")
-  assert_false(has_feature_flags?(event), "Feature flags expected to be absent or empty, was #{event['featureFlags']}")
+  Maze.check.false(has_feature_flags?(event), "Feature flags expected to be absent or empty, was #{event['featureFlags']}")
 end
 
 # Verifies that the are no feature flags present
@@ -66,7 +66,7 @@ Then('event {int} contains the feature flag {string} with no variant') do |event
 
   flag = feature_flags.find { |flag| flag['featureFlag'].eql?(flag_name) }
   # Test the variant value
-  assert_false(
+  Maze.check.false(
     flag.has_key?('variant'),
     "Feature flag: #{flag} expected to have no variant. All flags: #{feature_flags}"
   )
@@ -149,7 +149,7 @@ def verify_feature_flags_with_table(event, table)
     flag = feature_flags.find { |flag| flag['featureFlag'].eql?(flag_name) }
     # Test the variant value
     if variant.nil? || expected['variant'].empty?
-      assert_false(
+      Maze.check.false(
         flag.has_key?('variant'),
         "Feature flag: #{flag} expected to have no variant. All flags: #{feature_flags}"
       )
@@ -164,7 +164,7 @@ end
 
 def has_feature_flags?(event)
   if event.has_key?('featureFlags')
-    assert_false(
+    Maze.check.false(
       event['featureFlags'].nil?,
       'The feature flags key was present, but null'
     )

--- a/lib/features/steps/feature_flag_steps.rb
+++ b/lib/features/steps/feature_flag_steps.rb
@@ -24,17 +24,17 @@ end
 # @step_input variant [String] The variant value expected
 Then('event {int} contains the feature flag {string} with variant {string}') do |event_id, flag_name, variant|
   event = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.#{event_id}")
-  assert(has_feature_flags?(event), "Expected feature flags were not present in event #{event_id}: #{event}")
+  Maze.check.true(has_feature_flags?(event), "Expected feature flags were not present in event #{event_id}: #{event}")
   feature_flags = event['featureFlags']
   # Test for flag name uniqueness
-  assert(
+  Maze.check.true(
     feature_flags.one? { |flag| flag['featureFlag'].eql?(flag_name) },
     "Expected single flag with 'featureFlag' value: #{flag_name}. Present flags: #{feature_flags}"
   )
 
   flag = feature_flags.find { |flag| flag['featureFlag'].eql?(flag_name) }
   # Test the variant value
-  assert(
+  Maze.check.true(
     flag.has_key?('variant') && flag['variant'].eql?(variant),
     "Feature flag: #{flag} did not have variant: #{variant}. All flags: #{feature_flags}"
   )
@@ -56,10 +56,11 @@ end
 # @step_input flag_name [String] The featureFlag value expected
 Then('event {int} contains the feature flag {string} with no variant') do |event_id, flag_name|
   event = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.#{event_id}")
-  assert(has_feature_flags?(event), "Expected feature flags were not present in event #{event_id}: #{event}")
+  Maze.check.true(has_feature_flags?(event),
+                  "Expected feature flags were not present in event #{event_id}: #{event}")
   feature_flags = event['featureFlags']
   # Test for flag name uniqueness
-  assert(
+  Maze.check.true(
     feature_flags.one? { |flag| flag['featureFlag'].eql?(flag_name) },
     "Expected single flag with 'featureFlag' value: #{flag_name}. All flags: #{feature_flags}"
   )
@@ -115,9 +116,12 @@ end
 # @step_input flag_name [String] The featureFlag value not expected
 Then('event {int} does not contain the feature flag {string}') do |event_id, flag_name|
   event = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.#{event_id}")
-  assert(has_feature_flags?(event), "Expected feature flags were not present in event #{event_id}: #{event}")
+  Maze.check.true(
+    has_feature_flags?(event),
+    "Expected feature flags were not present in event #{event_id}: #{event}"
+  )
   feature_flags = event['featureFlags']
-  assert(
+  Maze.check.true(
     feature_flags.none? { |flag| flag['featureFlag'].eql?(flag_name) },
     "Expected to not find feature flag #{flag_name}.  All flags: #{feature_flags}"
   )
@@ -133,16 +137,23 @@ Then('the event does not contain the feature flag {string}') do |flag_name|
 end
 
 def verify_feature_flags_with_table(event, table)
-  assert(has_feature_flags?(event), "Expected feature flags were not present in event: #{event}")
+  Maze.check.true(
+    has_feature_flags?(event),
+    "Expected feature flags were not present in event: #{event}"
+  )
   feature_flags = event['featureFlags']
 
   expected_features = table.hashes
-  assert(feature_flags.size == expected_features.size, "Expected #{expected_features.size} features, found #{feature_flags}")
+  Maze.check.true(
+    feature_flags.size == expected_features.size,
+    "Expected #{expected_features.size} features,
+    found #{feature_flags}"
+  )
   expected_features.each do |expected|
     flag_name = expected['featureFlag']
     variant = expected['variant']
     # Test for flag name uniqueness
-    assert(
+    Maze.check.true(
       feature_flags.one? { |flag| flag['featureFlag'].eql?(flag_name) },
       "Expected single flag with 'featureFlag' value: #{flag_name}. Present flags: #{feature_flags}"
     )
@@ -154,7 +165,7 @@ def verify_feature_flags_with_table(event, table)
         "Feature flag: #{flag} expected to have no variant. All flags: #{feature_flags}"
       )
     else
-      assert(
+      Maze.check.true(
         flag.has_key?('variant') && flag['variant'].eql?(variant),
         "Feature flag: #{flag} did not have variant: #{variant}. All flags: #{feature_flags}"
       )
@@ -168,7 +179,8 @@ def has_feature_flags?(event)
       event['featureFlags'].nil?,
       'The feature flags key was present, but null'
     )
-    assert(event['featureFlags'].is_a?(Array),
+    Maze.check.true(
+      event['featureFlags'].is_a?(Array),
       "The feature flags key was present, but the value: #{event['featureFlags']} must be an array"
     )
     !event['featureFlags'].empty?

--- a/lib/features/steps/header_steps.rb
+++ b/lib/features/steps/header_steps.rb
@@ -7,8 +7,8 @@
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
 Then('the {word} {string} header is not null') do |request_type, header_name|
-  assert_not_nil(Maze::Server.list_for(request_type).current[:request][header_name],
-                 "The #{request_type} '#{header_name}' header should not be null")
+  Maze.check.not_nil(Maze::Server.list_for(request_type).current[:request][header_name],
+                     "The #{request_type} '#{header_name}' header should not be null")
 end
 
 # Tests that a request header is null
@@ -18,8 +18,8 @@ end
 Then('the {word} {string} header is null') do |request_type, header_name|
   request = Maze::Server.list_for(request_type).current[:request]
 
-  assert_nil(request[header_name],
-             "The #{request_type} '#{header_name}' header should be null")
+  Maze.check.nil(request[header_name],
+                 "The #{request_type} '#{header_name}' header should be null")
 end
 
 # Tests that request header equals a string
@@ -28,9 +28,9 @@ end
 # @step_input header_name [String] The header to test
 # @step_input header_value [String] The string it should match
 Then('the {word} {string} header equals {string}') do |request_type, header_name, header_value|
-  assert_not_nil(Maze::Server.list_for(request_type).current[:request][header_name],
-                 "The #{request_type} '#{header_name}' header wasn't present in the request")
-  assert_equal(header_value, Maze::Server.list_for(request_type).current[:request][header_name])
+  Maze.check.not_nil(Maze::Server.list_for(request_type).current[:request][header_name],
+                     "The #{request_type} '#{header_name}' header wasn't present in the request")
+  Maze.check.equal(header_value, Maze::Server.list_for(request_type).current[:request][header_name])
 end
 
 # Tests that a request header matches a regex
@@ -41,7 +41,7 @@ end
 Then('the {word} {string} header matches the regex {string}') do |request_type, header_name, regex_string|
   regex = Regexp.new(regex_string)
   value = Maze::Server.list_for(request_type).current[:request][header_name]
-  assert_match(regex, value)
+  Maze.check.match(regex, value)
 end
 
 # Tests that a request header matches one of a list of strings
@@ -50,7 +50,7 @@ end
 # @step_input header_name [String] The header to test
 # @step_input header_values [DataTable] A parsed data table
 Then('the {word} {string} header equals one of:') do |request_type, header_name, header_values|
-  assert_includes(header_values.raw.flatten, Maze::Server.list_for(request_type).current[:request][header_name])
+  Maze.check.include(header_values.raw.flatten, Maze::Server.list_for(request_type).current[:request][header_name])
 end
 
 # Tests that a request header is a timestamp.
@@ -59,14 +59,14 @@ end
 # @step_input header_name [String] The header to test
 Then('the {word} {string} header is a timestamp') do |request_type, header_name|
   header = Maze::Server.list_for(request_type).current[:request][header_name]
-  assert_match(TIMESTAMP_REGEX, header)
+  Maze.check.match(TIMESTAMP_REGEX, header)
 end
 
 # Checks that the Bugsnag-Integrity header is a SHA1 or simple digest
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 When('the {word} Bugsnag-Integrity header is valid') do |request_type|
-  assert_true(Maze::Helper.valid_bugsnag_integrity_header(Maze::Server.list_for(request_type).current),
-              'Invalid Bugsnag-Integrity header detected')
+  Maze.check.true(Maze::Helper.valid_bugsnag_integrity_header(Maze::Server.list_for(request_type).current),
+                  'Invalid Bugsnag-Integrity header detected')
 end
 

--- a/lib/features/steps/log_steps.rb
+++ b/lib/features/steps/log_steps.rb
@@ -8,10 +8,10 @@
 # @step_input message [String] The expected message
 Then('the {string} level log message equals {string}') do |log_level, message|
   request = Maze::Server.logs.current
-  assert_not_nil(request, 'No log message to check')
+  Maze.check.not_nil(request, 'No log message to check')
   log = request[:body]
-  assert_equal(log_level, Maze::Helper.read_key_path(log, 'level'))
-  assert_equal(message, Maze::Helper.read_key_path(log, 'message'))
+  Maze.check.equal(log_level, Maze::Helper.read_key_path(log, 'level'))
+  Maze.check.equal(message, Maze::Helper.read_key_path(log, 'message'))
 end
 
 # Tests that a log request matches a given level and message regex.
@@ -20,10 +20,10 @@ end
 # @step_input message_regex [String] Regex for the expected message
 Then('the {string} level log message matches the regex {string}') do |log_level, message_regex|
   request = Maze::Server.logs.current
-  assert_not_nil(request, 'No log message to check')
+  Maze.check.not_nil(request, 'No log message to check')
 
   log = request[:body]
-  assert_equal(log_level, Maze::Helper.read_key_path(log, 'level'))
+  Maze.check.equal(log_level, Maze::Helper.read_key_path(log, 'level'))
   regex = Regexp.new(message_regex)
-  assert_match(regex, Maze::Helper.read_key_path(log, 'message'))
+  Maze.check.match(regex, Maze::Helper.read_key_path(log, 'message'))
 end

--- a/lib/features/steps/multipart_request_steps.rb
+++ b/lib/features/steps/multipart_request_steps.rb
@@ -14,7 +14,7 @@ include Test::Unit::Assertions
 def valid_multipart_form_data?(request)
   content_regex = Regexp.new('^multipart\\/form-data; boundary=[\\h-]+$')
   content_header = request[:request]['Content-Type']
-  assert_match(content_regex, content_header)
+  Maze.check.match(content_regex, content_header)
   assert(request[:body].size.positive?, "Multipart request payload contained #{request[:body].size} fields")
 end
 
@@ -41,7 +41,7 @@ end
 Then('the {word} multipart request has {int} fields') do |request_type, part_count|
   list = Maze::Server.list_for request_type
   parts = list.current[:body]
-  assert_equal(part_count, parts.size)
+  Maze.check.equal(part_count, parts.size)
 end
 
 # Tests a given type of multipart request has at least one field.
@@ -73,13 +73,13 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the {word} multipart body does not match the JSON file in {string}') do |request_type, json_path|
-  assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
+  Maze.check.true(File.exist?(json_path), "'#{json_path}' does not exist")
   payload_list = Maze::Server.list_for request_type
   raw_payload_value = payload_list.current[:body]
   payload_value = parse_multipart_body(raw_payload_value)
   expected_value = JSON.parse(open(json_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
-  assert_false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
+  Maze.check.false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
 end
 
 # Tests that a given type of multipart payload body matches a JSON fixture.
@@ -88,13 +88,13 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the {word} multipart body matches the JSON file in {string}') do |request_type, json_path|
-  assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
+  Maze.check.true(File.exist?(json_path), "'#{json_path}' does not exist")
   payload_list = Maze::Server.list_for request_type
   raw_payload_value = payload_list.current[:body]
   payload_value = parse_multipart_body(raw_payload_value)
   expected_value = JSON.parse(open(json_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
-  assert_true(result.equal?, "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
+  Maze.check.true(result.equal?, "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
 end
 
 # Tests that a given type of multipart field matches a JSON fixture.
@@ -104,12 +104,12 @@ end
 # @step_input field_path [String] Path to the tested element
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
 Then('the {word} multipart field {string} matches the JSON file in {string}') do |request_type, field_path, json_path|
-  assert_true(File.exist?(json_path), "'#{json_path}' does not exist")
+  Maze.check.true(File.exist?(json_path), "'#{json_path}' does not exist")
   payload_list = Maze::Server.list_for request_type
   payload_value = JSON.parse(payload_list.current[:body][field_path].to_s)
   expected_value = JSON.parse(open(json_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
-  assert_true(result.equal?, "The multipart field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
+  Maze.check.true(result.equal?, "The multipart field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
 end
 
 # Tests that a multipart request field exists and is not null.
@@ -118,7 +118,7 @@ end
 # @step_input part_key [String] The key to the multipart element
 Then('the field {string} for multipart {word} is not null') do |part_key, request_type|
   parts = Maze::Server.list_for(request_type).current[:body]
-  assert_not_nil(parts[part_key], "The field '#{part_key}' should not be null")
+  Maze.check.not_nil(parts[part_key], "The field '#{part_key}' should not be null")
 end
 
 # Tests that a multipart request field exists and is null.
@@ -127,7 +127,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 Then('the field {string} for multipart {word} is null') do |part_key, request_type|
   parts = Maze::Server.list_for(request_type).current[:body]
-  assert_nil(parts[part_key], "The field '#{part_key}' should be null")
+  Maze.check.nil(parts[part_key], "The field '#{part_key}' should be null")
 end
 
 # Tests that a multipart request field equals a string.
@@ -137,5 +137,5 @@ end
 # @step_input expected_value [String] The string to match against
 Then('the field {string} for multipart {word} equals {string}') do |part_key, request_type, expected_value|
   parts = Maze::Server.list_for(request_type).current[:body]
-  assert_equal(parts[part_key], expected_value)
+  Maze.check.equal(parts[part_key], expected_value)
 end

--- a/lib/features/steps/multipart_request_steps.rb
+++ b/lib/features/steps/multipart_request_steps.rb
@@ -3,8 +3,6 @@ require 'open-uri'
 require 'json'
 require 'cgi'
 
-include Test::Unit::Assertions
-
 # @!group Multipart request assertion steps
 
 # Verifies a request contains the correct Content-Type header and some contents
@@ -15,7 +13,10 @@ def valid_multipart_form_data?(request)
   content_regex = Regexp.new('^multipart\\/form-data; boundary=[\\h-]+$')
   content_header = request[:request]['Content-Type']
   Maze.check.match(content_regex, content_header)
-  assert(request[:body].size.positive?, "Multipart request payload contained #{request[:body].size} fields")
+  Maze.check.true(
+    request[:body].size.positive?,
+    "Multipart request payload contained #{request[:body].size} fields"
+  )
 end
 
 # Verifies that any type of request contains multipart form-data
@@ -50,7 +51,7 @@ end
 Then('the {word} multipart request has a non-empty body') do |request_type|
   list = Maze::Server.list_for request_type
   parts = list.current[:body]
-  assert(parts.size.positive?, "Multipart request payload contained #{parts.size} fields")
+  Maze.check.true(parts.size.positive?, "Multipart request payload contained #{parts.size} fields")
 end
 
 # Takes a hashmap and parses all fields into strings or hashes depending on their format

--- a/lib/features/steps/payload_steps.rb
+++ b/lib/features/steps/payload_steps.rb
@@ -10,7 +10,7 @@ Then('the {word} payload body does not match the JSON fixture in {string}') do |
   payload_value = Maze::Server.list_for(request_type).current[:body]
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
-  assert_false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
+  Maze.check.false(result.equal?, "Payload:\n#{payload_value}\nExpected:#{expected_value}")
 end
 
 # Test the payload body matches a JSON fixture.
@@ -21,8 +21,8 @@ Then('the {word} payload body matches the JSON fixture in {string}') do |request
   payload_value = Maze::Server.list_for(request_type).current[:body]
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
-  assert_true(result.equal?,
-              "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
+  Maze.check.true(result.equal?,
+                  "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
 end
 
 # Test that a payload element matches a JSON fixture.
@@ -36,8 +36,8 @@ do |request_type, field_path, fixture_path|
   payload_value = Maze::Helper.read_key_path(list.current[:body], field_path)
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
-  assert_true(result.equal?,
-              "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
+  Maze.check.true(result.equal?,
+                  "The payload field '#{result.keypath}' does not match the fixture:\n #{result.reasons.join('\n')}")
 end
 
 # Tests that a request element is true.
@@ -46,7 +46,7 @@ end
 # @step_input field_path [String] Path to the tested element
 Then('the {word} payload field {string} is true') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
-  assert_true(Maze::Helper.read_key_path(list.current[:body], field_path))
+  Maze.check.true(Maze::Helper.read_key_path(list.current[:body], field_path))
 end
 
 # Tests that a request element is false.
@@ -55,7 +55,7 @@ end
 # @step_input field_path [String] Path to the tested element
 Then('the {word} payload field {string} is false') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
-  assert_false(Maze::Helper.read_key_path(list.current[:body], field_path))
+  Maze.check.false(Maze::Helper.read_key_path(list.current[:body], field_path))
 end
 
 # Tests that a request element is null.
@@ -64,7 +64,7 @@ end
 # @step_input field_path [String] Path to the tested element
 Then('the {word} payload field {string} is null') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
-  assert_nil(Maze::Helper.read_key_path(list.current[:body], field_path))
+  Maze.check.nil(Maze::Helper.read_key_path(list.current[:body], field_path))
 end
 
 # Tests that a request element is not null.
@@ -73,7 +73,7 @@ end
 # @step_input field_path [String] Path to the tested element
 Then('the {word} payload field {string} is not null') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
-  assert_not_nil(Maze::Helper.read_key_path(list.current[:body], field_path))
+  Maze.check.not_nil(Maze::Helper.read_key_path(list.current[:body], field_path))
 end
 
 # Tests that a payload element equals an integer.
@@ -82,7 +82,8 @@ end
 # @step_input field_path [String] Path to the tested element
 # @step_input int_value [Integer] The value to test against
 Then('the {word} payload field {string} equals {int}') do |request_type, field_path, int_value|
-  assert_equal(int_value, Maze::Helper.read_key_path(Maze::Server.list_for(request_type).current[:body], field_path))
+  Maze.check.equal(int_value,
+                   Maze::Helper.read_key_path(Maze::Server.list_for(request_type).current[:body], field_path))
 end
 
 # Tests the payload field value against an environment variable.
@@ -93,11 +94,11 @@ end
 Then('the {word} payload field {string} equals the environment variable {string}') \
 do |request_type, field_path, env_var|
   environment_value = ENV[env_var]
-  assert_false(environment_value.nil?, "The environment variable #{env_var} must not be nil")
+  Maze.check.false(environment_value.nil?, "The environment variable #{env_var} must not be nil")
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
 
-  assert_equal(environment_value, value)
+  Maze.check.equal(environment_value, value)
 end
 
 # Tests a payload field contains a number larger than a value.
@@ -108,7 +109,7 @@ end
 Then('the {word} payload field {string} is greater than {int}') do |request_type, field_path, int_value|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
-  assert_kind_of Integer, value
+  Maze.check.kind_of Integer, value
   assert(value > int_value, "The payload field '#{field_path}' (#{value}) is not greater than '#{int_value}'")
 end
 
@@ -120,7 +121,7 @@ end
 Then('the {word} payload field {string} is less than {int}') do |request_type, field_path, int_value|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
-  assert_kind_of Integer, value
+  Maze.check.kind_of Integer, value
   fail_message = "The #{request_type} payload field '#{field_path}' (#{value}) is not less than '#{int_value}'"
   assert(value < int_value, fail_message)
 end
@@ -132,7 +133,7 @@ end
 # @step_input string_value [String] The string to test against
 Then('the {word} payload field {string} equals {string}') do |request_type, field_path, string_value|
   list = Maze::Server.list_for(request_type)
-  assert_equal(string_value, Maze::Helper.read_key_path(list.current[:body], field_path))
+  Maze.check.equal(string_value, Maze::Helper.read_key_path(list.current[:body], field_path))
 end
 
 # Tests a payload field starts with a string.
@@ -143,7 +144,7 @@ end
 Then('the {word} payload field {string} starts with {string}') do |request_type, field_path, string_value|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
-  assert_kind_of String, value
+  Maze.check.kind_of String, value
   assert(value.start_with?(string_value),
          "Field '#{field_path}' value ('#{value}') does not start with '#{string_value}'")
 end
@@ -156,7 +157,7 @@ end
 Then('the {word} payload field {string} ends with {string}') do |request_type, field_path, string_value|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
-  assert_kind_of String, value
+  Maze.check.kind_of String, value
   assert(value.end_with?(string_value),
          "Field '#{field_path}' value ('#{value}') does not end with '#{string_value}'")
 end
@@ -169,8 +170,8 @@ end
 Then('the {word} payload field {string} is an array with {int} elements') do |request_type, field, count|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field)
-  assert_kind_of Array, value
-  assert_equal(count, value.length)
+  Maze.check.kind_of Array, value
+  Maze.check.equal(count, value.length)
 end
 
 # Tests a payload field is an array with at least one element.
@@ -180,7 +181,7 @@ end
 Then('the {word} payload field {string} is a non-empty array') do |request_type, field|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field)
-  assert_kind_of Array, value
+  Maze.check.kind_of Array, value
   assert(value.length.positive?,
          "the field '#{field}' must be a non-empty array")
 end
@@ -194,7 +195,7 @@ Then('the {word} payload field {string} matches the regex {string}') do |request
   regex = Regexp.new(regex_string)
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field)
-  assert_match(regex, value)
+  Maze.check.match(regex, value)
 end
 
 # Tests a payload field is a numeric timestamp.
@@ -210,7 +211,7 @@ Then('the {word} payload field {string} is a parsable timestamp in seconds') do 
   rescue StandardError
     parsed_time = nil
   end
-  assert_not_nil(parsed_time)
+  Maze.check.not_nil(parsed_time)
 end
 
 # Tests that every element in an array contains a specified key-value pair.
@@ -221,10 +222,10 @@ end
 Then('each element in {word} payload field {string} has {string}') do |request_type, key_path, element_key_path|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], key_path)
-  assert_kind_of Array, value
+  Maze.check.kind_of Array, value
   value.each do |element|
-    assert_not_nil(Maze::Helper.read_key_path(element, element_key_path),
-                   "Each element in '#{key_path}' must have '#{element_key_path}'")
+    Maze.check.not_nil(Maze::Helper.read_key_path(element, element_key_path),
+                       "Each element in '#{key_path}' must have '#{element_key_path}'")
   end
 end
 

--- a/lib/features/steps/payload_steps.rb
+++ b/lib/features/steps/payload_steps.rb
@@ -110,7 +110,7 @@ Then('the {word} payload field {string} is greater than {int}') do |request_type
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
   Maze.check.kind_of Integer, value
-  Maze.check.operator(value, :>, int, "The payload field '#{field_path}' (#{value}) is not greater than '#{int_value}'")
+  Maze.check.operator(value, :>, int_value, "The payload field '#{field_path}' (#{value}) is not greater than '#{int_value}'")
 end
 
 # Tests a payload field contains a number smaller than a value.

--- a/lib/features/steps/payload_steps.rb
+++ b/lib/features/steps/payload_steps.rb
@@ -110,7 +110,7 @@ Then('the {word} payload field {string} is greater than {int}') do |request_type
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
   Maze.check.kind_of Integer, value
-  assert(value > int_value, "The payload field '#{field_path}' (#{value}) is not greater than '#{int_value}'")
+  Maze.check.operator(value, :>, int, "The payload field '#{field_path}' (#{value}) is not greater than '#{int_value}'")
 end
 
 # Tests a payload field contains a number smaller than a value.
@@ -123,7 +123,7 @@ Then('the {word} payload field {string} is less than {int}') do |request_type, f
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
   Maze.check.kind_of Integer, value
   fail_message = "The #{request_type} payload field '#{field_path}' (#{value}) is not less than '#{int_value}'"
-  assert(value < int_value, fail_message)
+  Maze.check.operator(value, :<, int_value, fail_message)
 end
 
 # Tests a payload field equals a string.
@@ -145,8 +145,10 @@ Then('the {word} payload field {string} starts with {string}') do |request_type,
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
   Maze.check.kind_of String, value
-  assert(value.start_with?(string_value),
-         "Field '#{field_path}' value ('#{value}') does not start with '#{string_value}'")
+  Maze.check.true(
+    value.start_with?(string_value),
+    "Field '#{field_path}' value ('#{value}') does not start with '#{string_value}'"
+  )
 end
 
 # Tests a payload field ends with a string.
@@ -158,8 +160,10 @@ Then('the {word} payload field {string} ends with {string}') do |request_type, f
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
   Maze.check.kind_of String, value
-  assert(value.end_with?(string_value),
-         "Field '#{field_path}' value ('#{value}') does not end with '#{string_value}'")
+  Maze.check.true(
+    value.end_with?(string_value),
+    "Field '#{field_path}' value ('#{value}') does not end with '#{string_value}'"
+  )
 end
 
 # Tests a payload field is an array with a specific element count.
@@ -182,8 +186,7 @@ Then('the {word} payload field {string} is a non-empty array') do |request_type,
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field)
   Maze.check.kind_of Array, value
-  assert(value.length.positive?,
-         "the field '#{field}' must be a non-empty array")
+  Maze.check.true(value.length.positive?, "the field '#{field}' must be a non-empty array")
 end
 
 # Tests a payload field matches a regex.

--- a/lib/features/steps/proxy_steps.rb
+++ b/lib/features/steps/proxy_steps.rb
@@ -1,5 +1,7 @@
 # @!group Proxy steps
 
+include Test::Unit::Assertions
+
 # Starts an HTTP proxy server.
 #
 Then('I start an http proxy') do
@@ -28,8 +30,8 @@ end
 #
 # @step_input host [String] Destination host to check
 Then('the proxy handled a request for {string}') do |host|
-  Test::Unit::Assertions.assert_true(Maze::Proxy.instance.handled_host?(host),
-                                     "The proxy did not handle a request for #{host}")
+  Maze.check.assert(Maze::Proxy.instance.handled_host?(host),
+                    "The proxy did not handle a request for #{host}")
 end
 
 # @!endgroup

--- a/lib/features/steps/proxy_steps.rb
+++ b/lib/features/steps/proxy_steps.rb
@@ -1,7 +1,5 @@
 # @!group Proxy steps
 
-include Test::Unit::Assertions
-
 # Starts an HTTP proxy server.
 #
 Then('I start an http proxy') do
@@ -30,8 +28,7 @@ end
 #
 # @step_input host [String] Destination host to check
 Then('the proxy handled a request for {string}') do |host|
-  Maze.check.assert(Maze::Proxy.instance.handled_host?(host),
-                    "The proxy did not handle a request for #{host}")
+  Maze.check.true(Maze::Proxy.instance.handled_host?(host), "The proxy did not handle a request for #{host}")
 end
 
 # @!endgroup

--- a/lib/features/steps/query_parameter_steps.rb
+++ b/lib/features/steps/query_parameter_steps.rb
@@ -8,7 +8,8 @@
 # @step_input parameter_name [String] The parameter to test
 # @step_input parameter_value [String] The expected value
 Then('the {word} {string} query parameter equals {string}') do |request_type, parameter_name, parameter_value|
-  assert_equal(parameter_value, Maze::Helper.parse_querystring(Maze::Server.list_for(request_type).current)[parameter_name][0])
+  Maze.check.equal(parameter_value,
+                   Maze::Helper.parse_querystring(Maze::Server.list_for(request_type).current)[parameter_name][0])
 end
 
 # Tests that a query parameter is present and not null.
@@ -16,8 +17,8 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input parameter_name [String] The parameter to test
 Then('the {word} {string} query parameter is not null') do |request_type, parameter_name|
-  assert_not_nil(Maze::Helper.parse_querystring(Maze::Server.list_for(request_type).current)[parameter_name][0],
-                 "The '#{parameter_name}' query parameter should not be null")
+  Maze.check.not_nil(Maze::Helper.parse_querystring(Maze::Server.list_for(request_type).current)[parameter_name][0],
+                     "The '#{parameter_name}' query parameter should not be null")
 end
 
 # Tests that a query parameter is a timestamp.
@@ -26,5 +27,5 @@ end
 # @step_input parameter_name [String] The parameter to test
 Then('the {word} {string} query parameter is a timestamp') do |request_type, parameter_name|
   param = Maze::Helper.parse_querystring(Maze::Server.list_for(request_type).current)[parameter_name][0]
-  assert_match(TIMESTAMP_REGEX, param)
+  Maze.check.match(TIMESTAMP_REGEX, param)
 end

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -29,7 +29,7 @@ def assert_received_requests(request_count, list, list_name)
     MESSAGE
   end
 
-  assert_equal(request_count, list.size, "#{list.size} #{list_name} received")
+  Maze.check.equal(request_count, list.size, "#{list.size} #{list_name} received")
 end
 
 #
@@ -62,7 +62,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 Then('I have received at least {int} {word}') do |min_received, request_type|
   list = Maze::Server.list_for(request_type)
-  assert_operator(list.size, :>=, min_received, "Actually received #{list.size} #{request_type} requests")
+  Maze.check.operator(list.size, :>=, min_received, "Actually received #{list.size} #{request_type} requests")
 end
 
 # Assert that the test Server hasn't received any requests - of a specific, or any, type.
@@ -73,11 +73,11 @@ Then('I should receive no {word}') do |request_type|
   sleep Maze.config.receive_no_requests_wait
   if request_type == 'requests'
     # Assert that the test Server hasn't received any requests at all.
-    assert_equal(0, Maze::Server.errors.size, "#{Maze::Server.errors.size} errors received")
-    assert_equal(0, Maze::Server.sessions.size, "#{Maze::Server.sessions.size} sessions received")
+    Maze.check.equal(0, Maze::Server.errors.size, "#{Maze::Server.errors.size} errors received")
+    Maze.check.equal(0, Maze::Server.sessions.size, "#{Maze::Server.sessions.size} sessions received")
   else
     list = Maze::Server.list_for(request_type)
-    assert_equal(0, list.size, "#{list.size} #{request_type} received")
+    Maze.check.equal(0, list.size, "#{list.size} #{request_type} received")
   end
 end
 
@@ -102,9 +102,9 @@ Then('the received errors match:') do |table|
       next if (!request.key? :body) || (!request[:body].key? 'events')
 
       events = request[:body]['events']
-      assert_equal(1, events.length, 'Expected exactly one event per request')
+      Maze.check.equal(1, events.length, 'Expected exactly one event per request')
       match_count += 1 if request_matches_row(events[0], row)
     end
   end
-  assert_equal(requests.size, match_count, 'Unexpected number of requests matched the received payloads')
+  Maze.check.equal(requests.size, match_count, 'Unexpected number of requests matched the received payloads')
 end

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 require 'test/unit'
-require 'minitest'
 require 'open-uri'
 require 'json'
 require 'cgi'
 require_relative '../../maze/wait'
-
-include Test::Unit::Assertions
 
 # @!group Request assertion steps
 

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -72,7 +72,7 @@ end
 # @step_input service [String] The name of the service to run
 When('I run the service {string} interactively') do |service|
   # Stop the old session if one exists
-  step("I stop the current shell") if Maze::Runner.interactive_session?
+  step('I stop the current shell') if Maze::Runner.interactive_session?
 
   Maze::Docker.start_service(service, interactive: true)
 end
@@ -83,7 +83,7 @@ end
 # @step_input command [String] The command to run inside the service
 When('I run the service {string} with the command {string} interactively') do |service, command|
   # Stop the old session if one exists
-  step("I stop the current shell") if Maze::Runner.interactive_session?
+  step('I stop the current shell') if Maze::Runner.interactive_session?
 
   Maze::Docker.start_service(service, command: command, interactive: true)
 end
@@ -105,7 +105,7 @@ Then('the exit code of the last docker command was {int}') do |expected_code|
   wait = Maze::Wait.new(timeout: Maze.config.receive_requests_wait)
   success = wait.until { !Maze::Docker.last_exit_code.nil? }
 
-  assert(success, 'No docker exit code available to verify')
+  Maze.check.true(success, 'No docker exit code available to verify')
   Maze.check.equal(Maze::Docker.last_exit_code, expected_code)
 end
 
@@ -121,7 +121,7 @@ Then('the last run docker command did not exit successfully') do
   wait = Maze::Wait.new(timeout: Maze.config.receive_requests_wait)
   success = wait.until { !Maze::Docker.last_exit_code.nil? }
 
-  assert(success, 'No docker exit code available to verify')
+  Maze.check.true(success, 'No docker exit code available to verify')
   Maze.check.not_equal(Maze::Docker.last_exit_code, 0)
 end
 
@@ -133,12 +133,12 @@ Then('the last run docker command output {string}') do |expected_string|
   wait = Maze::Wait.new(timeout: Maze.config.receive_requests_wait)
   success = wait.until { !Maze::Docker.last_command_logs.nil? }
 
-  assert(success, 'No docker logs available to verify')
+  Maze.check.true(success, 'No docker logs available to verify')
 
   docker_output = Maze::Docker.last_command_logs
   output_included = docker_output.any? { |line| line.include?(expected_string) }
 
-  assert(output_included, %(
+  Maze.check.true(output_included, %(
     No line of output included '#{expected_string}'.
     Full output:
     #{docker_output.join('\n')}
@@ -156,7 +156,7 @@ end
 # Starts an interactive shell
 When('I start a new shell') do
   # Stop the old session if one exists
-  step("I stop the current shell") if Maze::Runner.interactive_session?
+  step('I stop the current shell') if Maze::Runner.interactive_session?
 
   Maze::Runner.start_interactive_session
 end
@@ -176,7 +176,7 @@ end
 When('I input {string} interactively') do |command|
   current_shell = Maze::Runner.interactive_session
   success = current_shell.run_command(command)
-  assert(success, 'The terminal had already closed')
+  Maze.check.true(success, 'The terminal had already closed')
 end
 
 # Send a return or enter to the interactive session
@@ -197,7 +197,7 @@ end
 # @step_input expected [String] The expected string
 Then('the current stdout line contains {string}') do |expected|
   current_shell = Maze::Runner.interactive_session
-  assert_includes(current_shell.current_buffer, expected)
+  Maze.check.include(current_shell.current_buffer, expected)
 end
 
 # Waits for a line matching a regex to be present in the current stdout
@@ -210,10 +210,11 @@ Then('I wait for the current stdout line to match the regex {string}') do |regex
 
   success = wait.until { shell.current_buffer.match?(regex) }
 
-  assert(success, "The current output line \"#{shell.current_buffer}\" did not match \"#{regex}\"")
+  Maze.check.true(success, "The current output line \"#{shell.current_buffer}\" did not match \"#{regex}\"")
 end
 
-# Waits for a specific shell prompt to be present in the buffered stdout line, timing out after Maze.config.receive_requests_wait seconds.
+# Waits for a specific shell prompt to be present in the buffered stdout line,
+# timing out after Maze.config.receive_requests_wait seconds.
 #
 # @step_input expected_prompt [String] The prompt expected in the current buffer
 Then('I wait for the shell prompt {string}') do |expected_prompt|
@@ -222,7 +223,7 @@ Then('I wait for the shell prompt {string}') do |expected_prompt|
 
   success = wait.until { shell.current_buffer == expected_prompt }
 
-  assert(success, "The current output line \"#{shell.current_buffer}\" did not match \"#{expected_prompt}\"")
+  Maze.check.true(success, "The current output line \"#{shell.current_buffer}\" did not match \"#{expected_prompt}\"")
 end
 
 # Verify a string appears in the stdout logs
@@ -231,7 +232,7 @@ end
 Then('the shell has output {string} to stdout') do |expected_line|
   current_shell = Maze::Runner.interactive_session
   match = current_shell.stdout_lines.any? { |line| line == expected_line }
-  assert(match, "No output lines from #{current_shell.stdout_lines} matched #{expected_line}")
+  Maze.check.true(match, "No output lines from #{current_shell.stdout_lines} matched #{expected_line}")
 end
 
 # Wait for a string to appear in the stdout logs, timing out after Maze.config.receive_requests_wait seconds.
@@ -245,7 +246,7 @@ Then('I wait for the shell to output {string} to stdout') do |expected_line|
     current_shell.stdout_lines.any? { |line| line == expected_line }
   end
 
-  assert(success, "No output lines from #{current_shell.stdout_lines} matched #{expected_line}")
+  Maze.check.true(success, "No output lines from #{current_shell.stdout_lines} matched #{expected_line}")
 end
 
 # Verify a string using a regex in the stdout logs
@@ -254,7 +255,7 @@ end
 Then('the shell has output a match for the regex {string} to stdout') do |regex_matcher|
   current_shell = Maze::Runner.interactive_session
   match = current_shell.stdout_lines.any? { |line| line.match?(regex_matcher) }
-  assert(match, "No output lines from #{current_shell.stdout_lines} matched #{regex_matcher}")
+  Maze.check.true(match, "No output lines from #{current_shell.stdout_lines} matched #{regex_matcher}")
 end
 
 # Wait for a string matching a regex in the stdout logs, timing out after Maze.config.receive_requests_wait seconds.
@@ -268,7 +269,7 @@ Then('I wait for the shell to output a match for the regex {string} to stdout') 
     current_shell.stdout_lines.any? { |line| line.match?(regex_matcher) }
   end
 
-  assert(success, "No output lines from #{current_shell.stdout_lines} matched #{regex_matcher}")
+  Maze.check.true(success, "No output lines from #{current_shell.stdout_lines} matched #{regex_matcher}")
 end
 
 # Wait for the shell to output a number of strings in STDOUT, as defined by a table.
@@ -284,7 +285,10 @@ Then('I wait for the interactive shell to output the following lines in stdout')
     current_stdout.include?(expected_lines)
   end
 
-  assert(success, "Lines present in stdout: #{current_shell.stdout_lines} did not include all of: #{expected_lines}")
+  Maze.check.true(
+    success,
+    "Lines present in stdout: #{current_shell.stdout_lines} did not include all of: #{expected_lines}"
+  )
 end
 
 # Verify a string appears in the stderr logs
@@ -293,7 +297,7 @@ end
 Then('the shell has output {string} to stderr') do |expected_err|
   current_shell = Maze::Runner.interactive_session
   match = current_shell.stderr_lines.any? { |line| line == expected_err }
-  assert(match, "No output lines from #{current_shell.stderr_lines} matched #{expected_err}")
+  Maze.check.true(match, "No output lines from #{current_shell.stderr_lines} matched #{expected_err}")
 end
 
 # Wait for a string to appear in the stderr logs
@@ -307,12 +311,15 @@ Then('I wait for the shell to output {string} to stderr') do |expected_line|
     current_shell.stderr_lines.any? { |line| line == expected_line }
   end
 
-  assert(success, "No output lines from #{current_shell.stderr_lines} matched #{expected_line}")
+  Maze.check.true(success, "No output lines from #{current_shell.stderr_lines} matched #{expected_line}")
 end
 
 # Verify the last interactive command exited successfully (assuming a 0 is a success)
 Then('the last interactive command exited successfully') do
-  assert(Maze::Runner.interactive_session?, 'No interactive session is running so the exit code cannot be checked')
+  Maze.check.true(
+    Maze::Runner.interactive_session?,
+    'No interactive session is running so the exit code cannot be checked'
+  )
 
   uuid = SecureRandom.uuid
 
@@ -326,7 +333,10 @@ end
 #
 # @step_input exit_code [Integer] The expected exit code
 Then('the last interactive command exit code is {int}') do |exit_code|
-  assert(Maze::Runner.interactive_session?, 'No interactive session is running so the exit code cannot be checked')
+  Maze.check.true(
+    Maze::Runner.interactive_session?,
+    'No interactive session is running so the exit code cannot be checked'
+  )
 
   uuid = SecureRandom.uuid
 
@@ -338,7 +348,10 @@ end
 
 # Assert that the last interactive command exited with an error code (assuming non-0 is an error)
 Then('the last interactive command exited with an error code') do
-  assert(Maze::Runner.interactive_session?, 'No interactive session is running so the exit code cannot be checked')
+  Maze.check.true(
+    Maze::Runner.interactive_session?,
+    'No interactive session is running so the exit code cannot be checked'
+  )
 
   uuid = SecureRandom.uuid
 

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -106,7 +106,7 @@ Then('the exit code of the last docker command was {int}') do |expected_code|
   success = wait.until { !Maze::Docker.last_exit_code.nil? }
 
   assert(success, 'No docker exit code available to verify')
-  assert_equal(Maze::Docker.last_exit_code, expected_code)
+  Maze.check.equal(Maze::Docker.last_exit_code, expected_code)
 end
 
 # A shortcut for the above assuming 0 as a successful exit code
@@ -122,7 +122,7 @@ Then('the last run docker command did not exit successfully') do
   success = wait.until { !Maze::Docker.last_exit_code.nil? }
 
   assert(success, 'No docker exit code available to verify')
-  assert_not_equal(Maze::Docker.last_exit_code, 0)
+  Maze.check.not_equal(Maze::Docker.last_exit_code, 0)
 end
 
 # Allows testing a docker command output a specific string
@@ -166,8 +166,8 @@ When('I stop the current shell') do
   shell = Maze::Runner.interactive_session
   result = Maze::Runner.stop_interactive_session
 
-  assert_true(result, 'The shell is still running when it should have exited')
-  assert_false(shell.running?, 'The shell is still running when it should have exited')
+  Maze.check.true(result, 'The shell is still running when it should have exited')
+  Maze.check.false(shell.running?, 'The shell is still running when it should have exited')
 end
 
 # Run a command on the shell
@@ -189,7 +189,7 @@ end
 # @step_input expected [String] The expected string
 Then('the current stdout line is {string}') do |expected|
   current_shell = Maze::Runner.interactive_session
-  assert_equal(expected, current_shell.current_buffer)
+  Maze.check.equal(expected, current_shell.current_buffer)
 end
 
 # Assert the current stdout line in the shell includes the given string

--- a/lib/maze/assertions/request_set_assertions.rb
+++ b/lib/maze/assertions/request_set_assertions.rb
@@ -8,7 +8,6 @@ module Maze
     # Provides helper routines for checking sets of requests against values in a table.
     class RequestSetAssertions
       class << self
-        include Test::Unit::Assertions
 
         # Checks that a set of requests satisfy the properties expressed by the table given.
         #

--- a/lib/maze/assertions/request_set_assertions.rb
+++ b/lib/maze/assertions/request_set_assertions.rb
@@ -17,7 +17,9 @@ module Maze
         #   - headings can be provided as key paths (e.g. events.0.breadcrumbs.0.name)
         #   - table values can be written as "null" for nil
         def assert_requests_match(requests, table)
-          assert_equal(table.hashes.length, requests.length, 'Number of requests do not match number of entries in table.')
+          Maze.check.equal(table.hashes.length,
+                           requests.length,
+                           'Number of requests do not match number of entries in table.')
           matches = matching_rows requests, table
           return if matches.length == table.hashes.length
 
@@ -27,7 +29,7 @@ module Maze
           matches.sort.to_h.each do |row, request|
             $logger.info "#{table.rows[row]} matched by request element #{matches[request]}"
           end
-          assert_equal(requests.length, matches.length, 'Not all requests matched a row in the table.')
+          Maze.check.equal(requests.length, matches.length, 'Not all requests matched a row in the table.')
         end
 
         # Given arrays of requests and table-based criteria, determines which rows of the table

--- a/lib/maze/checks/assert_check.rb
+++ b/lib/maze/checks/assert_check.rb
@@ -39,6 +39,14 @@ module Maze
       def kind_of(klass, object, message = nil)
         assert_kind_of(klass, object, message = nil)
       end
+
+      def block(message = 'block failed', &block)
+        assert_block(message, &block)
+      end
+
+      def include(collection, object, message = nil)
+        assert_include(collection, object, message)
+      end
     end
   end
 end

--- a/lib/maze/checks/assert_check.rb
+++ b/lib/maze/checks/assert_check.rb
@@ -47,6 +47,12 @@ module Maze
       def include(collection, object, message = nil)
         assert_include(collection, object, message)
       end
+      alias includes include
+
+      def refute_include(collection, object, message = nil)
+        Minitest::Assertions.refute_includes(collection, object, message)
+      end
+      alias refute_includes refute_include
     end
   end
 end

--- a/lib/maze/checks/assert_check.rb
+++ b/lib/maze/checks/assert_check.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
+require 'test/unit'
 
 module Maze
   module Checks
     # Assertion-backed data verification checks
     class AssertCheck
+      include Test::Unit::Assertions
+
       def true(test, message = nil)
         assert_true(test, message)
       end
@@ -37,7 +40,7 @@ module Maze
       end
 
       def kind_of(klass, object, message = nil)
-        assert_kind_of(klass, object, message = nil)
+        assert_kind_of(klass, object, message)
       end
 
       def block(message = 'block failed', &block)
@@ -49,10 +52,11 @@ module Maze
       end
       alias includes include
 
-      def refute_include(collection, object, message = nil)
-        Minitest::Assertions.refute_includes(collection, object, message)
+      def not_include(collection, object, message = nil)
+        assert_not_include(collection, object, message)
       end
-      alias refute_includes refute_include
+      alias not_includes not_include
     end
   end
 end
+

--- a/lib/maze/checks/noop_check.rb
+++ b/lib/maze/checks/noop_check.rb
@@ -25,6 +25,10 @@ module Maze
       def block(_message = 'block failed', &_block) end
 
       def include(_collection, _object, _message = nil) end
+      alias includes include
+
+      def refute_include(_collection, _object, _message = nil) end
+      alias refute_includes refute_include
     end
   end
 end

--- a/lib/maze/checks/noop_check.rb
+++ b/lib/maze/checks/noop_check.rb
@@ -27,8 +27,8 @@ module Maze
       def include(_collection, _object, _message = nil) end
       alias includes include
 
-      def refute_include(_collection, _object, _message = nil) end
-      alias refute_includes refute_include
+      def not_include(_collection, _object, _message = nil) end
+      alias not_includes not_include
     end
   end
 end

--- a/lib/maze/checks/noop_check.rb
+++ b/lib/maze/checks/noop_check.rb
@@ -21,6 +21,10 @@ module Maze
       def operator(_operand1, _operator, _operand2, _message = nil) end
 
       def kind_of(_klass, _object, _message = nil) end
+
+      def block(_message = 'block failed', &_block) end
+
+      def include(_collection, _object, _message = nil) end
     end
   end
 end

--- a/lib/maze/compare.rb
+++ b/lib/maze/compare.rb
@@ -40,7 +40,7 @@ module Maze
 
       # Provides a standard assertion of equality, with standardised output
       def assert_equal
-        assert(@equal, "The compared fields do not match:\n #{result.reasons.join('\n')}")
+        Maze.check.true(@equal, "The compared fields do not match:\n #{result.reasons.join('\n')}")
       end
     end
 


### PR DESCRIPTION
## Goal

Follow-up to #327, refactoring the remaining codebase to use the new `Maze.check` and adding a few methods that were missed at first.

## Changeset

Refactoring and new methods added.

## Tests

I have successfully tested local branches for the `bugsnag-js`, `bugsnag-cocoa` and `bugsnag-android` repos with updates to use this.  