### PR TITLE
Set capabilities to speed up App Hang tests locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add `Maze.timers` and Appium operation timing summary [#329](https://github.com/bugsnag/maze-runner/pull/329)
 
+## Fixes
+
+- Set Appium capabilities to speed up iOS App Hang tests locally [#330](https://github.com/bugsnag/maze-runner/pull/330)
+
 ## Refactor
 
 - Add `Maze.check` to abstract from underlying assertion implementation [#327](https://github.com/bugsnag/maze-runner/pull/327) [#328](https://github.com/bugsnag/maze-runner/pull/328)

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -58,7 +58,9 @@ module Maze
                            'xcodeOrgId' => team_id,
                            'xcodeSigningId' => 'iPhone Developer',
                            'udid' => udid,
-                           'noReset' => 'true'
+                           'noReset' => 'true',
+                           'waitForQuiescence' => false,
+                           'newCommandTimeout' => 0
                          }
                        when 'macos'
                          {


### PR DESCRIPTION
## Goal

Reduce the time the iOS App Hang scenarios take to run locally.  For me it reduced the time from 8 minutes to 5.5.

## Design

These capabilities are set by default on BrowserStack, providing some confidence that they won't break tests.

## Tests

Tested will a full test run locally.