### PR TITLE
Add a browser smoke test platform to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -179,9 +179,10 @@ steps:
         run: browser-tests
         use-aliases: true
         verbose: true
-        command:
-          - --farm=bs
-          - --browser=firefox_latest
+        command: >-
+          bundle exec maze-runner
+          --farm=bs
+          --browser=firefox_latest
     env:
       RUBY_VERSION: "3"
     concurrency: 5

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -172,7 +172,7 @@ steps:
     concurrency_method: eager
 
   - label: 'Browserstack web browser test - Latest firefox'
-    depends_on: "ci-image-ruby-3"
+    depends_on: "ci-image-ruby-2-7"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.7.0:
@@ -184,7 +184,7 @@ steps:
       --farm=bs
       --browser=firefox_latest
     env:
-      RUBY_VERSION: "3"
+      RUBY_VERSION: "2.7"
     concurrency: 5
     concurrency_group: 'browserstack'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -176,12 +176,14 @@ steps:
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.7.0:
-        run: ci
+        run: browser-tests
         use-aliases: true
         verbose: true
         command:
           - --farm=bs
           - --browser=firefox_latest
+    env:
+      RUBY_VERSION: "3"
     concurrency: 5
     concurrency_group: 'browserstack'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -171,6 +171,20 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
+  - label: 'Browserstack web browser test - Latest firefox'
+    depends_on: "ci-image-ruby-3"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: ci
+        use-aliases: true
+        verbose: true
+        command:
+          - --farm=bs
+          - --browser=firefox_latest
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
   - wait
 
   - label: 'Update docs'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -179,10 +179,10 @@ steps:
         run: browser-tests
         use-aliases: true
         verbose: true
-        command: >-
-          bundle exec maze-runner
-          --farm=bs
-          --browser=firefox_latest
+    command: >-
+      bundle exec maze-runner
+      --farm=bs
+      --browser=firefox_latest
     env:
       RUBY_VERSION: "3"
     concurrency: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,14 @@ services:
       args:
         RUBY_VERSION:
 
+  browser-tests:
+    build:
+      context: test/fixtures/browser
+      args:
+        BRANCH_NAME:
+        RUBY_VERSION:
+
+
 networks:
   default:
     name: ${BUILDKITE_JOB_ID:-core-maze-runner}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,6 +171,9 @@ services:
       args:
         BRANCH_NAME:
         RUBY_VERSION:
+    environment:
+      BROWSER_STACK_USERNAME:
+      BROWSER_STACK_ACCESS_KEY:
 
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,6 @@ services:
       BROWSER_STACK_USERNAME:
       BROWSER_STACK_ACCESS_KEY:
 
-
 networks:
   default:
     name: ${BUILDKITE_JOB_ID:-core-maze-runner}

--- a/test/fixtures/browser/Dockerfile
+++ b/test/fixtures/browser/Dockerfile
@@ -1,0 +1,6 @@
+ARG BRANCH_NAME
+ARG RUBY_VERSION
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+
+COPY . /app
+WORKDIR /app

--- a/test/fixtures/browser/Gemfile
+++ b/test/fixtures/browser/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'bugsnag-maze-runner', path: '../../..'

--- a/test/fixtures/browser/features/fixtures/test.html
+++ b/test/fixtures/browser/features/fixtures/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="dist/a.js"></script>
+  </head>
+  <body>
+    <script>
+      fetch(url, {
+        method: 'POST', // *GET, POST, PUT, DELETE, etc.
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          test : "browser"
+        })
+      });
+    </script> 
+  </body>
+</html>

--- a/test/fixtures/browser/features/fixtures/test.html
+++ b/test/fixtures/browser/features/fixtures/test.html
@@ -2,11 +2,12 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <script src="dist/a.js"></script>
   </head>
   <body>
-    <script>
-      fetch(url, {
+    <h1>Hello World</h1>
+    <script type="text/javascript">
+      console.log("Hello");
+      fetch("http://bs-local.com:9339/notify", {
         method: 'POST', // *GET, POST, PUT, DELETE, etc.
         headers: {
           'Content-Type': 'application/json'
@@ -15,6 +16,6 @@
           test : "browser"
         })
       });
-    </script> 
+    </script>
   </body>
 </html>

--- a/test/fixtures/browser/features/handled_errors.feature
+++ b/test/fixtures/browser/features/handled_errors.feature
@@ -1,6 +1,6 @@
 Feature: Browser smoke tests
 
 Scenario Outline: Receiving responses from URLs
-  When I navigate to the test URL "test.html"
+  When I navigate to the test URL "/test.html"
   Then I wait to receive an error
   And the error payload field "test" equals "browser"

--- a/test/fixtures/browser/features/handled_errors.feature
+++ b/test/fixtures/browser/features/handled_errors.feature
@@ -1,0 +1,6 @@
+Feature: Browser smoke tests
+
+Scenario Outline: Receiving responses from URLs
+  When I navigate to the test URL "test.html"
+  Then I wait to receive an error
+  And the error payload field "test" equals "browser"

--- a/test/fixtures/browser/features/lib/server.rb
+++ b/test/fixtures/browser/features/lib/server.rb
@@ -1,0 +1,5 @@
+require 'webrick'
+
+root = File.expand_path File.join(__dir__, '..', 'fixtures')
+server = WEBrick::HTTPServer.new :Port => ENV['PORT'], :DocumentRoot => root
+server.start

--- a/test/fixtures/browser/features/steps/browser_steps.rb
+++ b/test/fixtures/browser/features/steps/browser_steps.rb
@@ -1,0 +1,43 @@
+When('I navigate to the test URL {string}') do |test_path|
+  path = get_test_url test_path
+  step("I navigate to the URL \"#{path}\"")
+end
+
+When('the exception matches the {string} values for the current browser') do |fixture|
+  err = get_error_message(fixture)
+  steps %(
+    And the exception "errorClass" equals "#{err['errorClass']}"
+    And the exception "message" equals "#{err['errorMessage']}"
+  )
+  if err['lineNumber']
+    step("the \"lineNumber\" of stack frame 0 equals #{err['lineNumber']}")
+  end
+  if err['columnNumber']
+    step("the \"columnNumber\" of stack frame 0 equals #{err['columnNumber']}")
+  end
+  if err['file']
+    step("the \"file\" of stack frame 0 ends with \"#{err['file']}\"")
+  end
+end
+
+When('the test should run in this browser') do
+  wait = Selenium::WebDriver::Wait.new(timeout: 10)
+  wait.until {
+    Maze.driver.find_element(id: 'bugsnag-test-should-run') &&
+        Maze.driver.find_element(id: 'bugsnag-test-should-run').text != 'PENDING'
+  }
+  skip_this_scenario if Maze.driver.find_element(id: 'bugsnag-test-should-run').text == 'NO'
+end
+
+When('I let the test page run for up to {int} seconds') do |n|
+  wait = Selenium::WebDriver::Wait.new(timeout: n)
+  wait.until {
+    Maze.driver.find_element(id: 'bugsnag-test-state') &&
+        (
+        Maze.driver.find_element(id: 'bugsnag-test-state').text == 'DONE' ||
+            Maze.driver.find_element(id: 'bugsnag-test-state').text == 'ERROR'
+        )
+  }
+  txt = Maze.driver.find_element(id: 'bugsnag-test-state').text
+  Maze.check.equal('DONE', txt, "Expected #bugsnag-test-state text to be 'DONE'. It was '#{txt}'.")
+end

--- a/test/fixtures/browser/features/support/env.rb
+++ b/test/fixtures/browser/features/support/env.rb
@@ -1,10 +1,8 @@
 require 'yaml'
 
 def get_test_url path
-  host = ENV['HOST']
-  notify = "http://#{ENV['API_HOST']}:#{Maze.config.port}/notify"
-  sessions = "http://#{ENV['API_HOST']}:#{Maze.config.port}/sessions"
-  "http://#{host}:#{FIXTURES_SERVER_PORT}#{path}?NOTIFY=#{notify}&SESSIONS=#{sessions}&API_KEY=#{$api_key}"
+  host = 'bs-local.com'
+  "http://#{host}:#{FIXTURES_SERVER_PORT}#{path}"
 end
 
 BeforeAll do

--- a/test/fixtures/browser/features/support/env.rb
+++ b/test/fixtures/browser/features/support/env.rb
@@ -1,0 +1,29 @@
+require 'yaml'
+
+def get_test_url path
+  host = ENV['HOST']
+  notify = "http://#{ENV['API_HOST']}:#{Maze.config.port}/notify"
+  sessions = "http://#{ENV['API_HOST']}:#{Maze.config.port}/sessions"
+  "http://#{host}:#{FIXTURES_SERVER_PORT}#{path}?NOTIFY=#{notify}&SESSIONS=#{sessions}&API_KEY=#{$api_key}"
+end
+
+BeforeAll do
+  Maze.config.receive_no_requests_wait = 15
+  Maze.config.enforce_bugsnag_integrity = false
+
+  FIXTURES_SERVER_PORT = '9020'
+  DEV_NULL = Gem.win_platform? ? 'NUL' : '/dev/null'
+    pid = Process.spawn({"PORT"=>FIXTURES_SERVER_PORT},
+                        'ruby features/lib/server.rb',
+                        :out => DEV_NULL,
+                        :err => DEV_NULL)
+  Process.detach(pid)
+end
+
+at_exit do
+  # Stop the web page server
+  begin
+    Process.kill('KILL', pid)
+  rescue
+  end
+end


### PR DESCRIPTION
## Goal

Adds a new test fixture based on the JS Browser fixture to CI, ensuring breaking changes will be caught before release.

## Discussion

This currently only works on Ruby 2.7.  We'll need to update Selenium Webdriver to `~> v4.1`, which will also require Appium to be updated to `~> v12`.

Unfortunately that doesn't seem like a trivial update ([as demonstrated here](https://buildkite.com/bugsnag/maze-runner/builds/2033#cff7583f-16d6-4368-a959-ae00609bf452/223-242)), but will hopefully be fairly quick.

I'd suggest we merge this PR and I'll ticket the driver updates separately.
