### PR TITLE
Allow retry option to take effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.9.3 - 2022/01/28
+
+## Fixes
+
+- Correct retry pluging to allow `--retry` to have an effect [#337](https://github.com/bugsnag/maze-runner/pull/337)
+
 # 6.9.2 - 2022/01/21
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.9.2)
+    bugsnag-maze-runner (6.9.3)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -38,7 +38,7 @@ GEM
     appium_lib_core (4.7.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
-    bugsnag (6.24.1)
+    bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (3.0.0)

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -53,12 +53,14 @@ BeforeAll do
   Maze.hooks.call_before_all
 end
 
-InstallPlugin do |cucumber_config|
+# @param config The Cucumber config
+InstallPlugin do |config|
   # Start Bugsnag
-  Maze::BugsnagConfig.start_bugsnag(cucumber_config)
+  Maze::BugsnagConfig.start_bugsnag(config)
 
-  cucumber_config.filters << Maze::Plugins::GlobalRetryPlugin.new(cucumber_config)
-  cucumber_config.filters << Maze::Plugins::BugsnagReportingPlugin.new(cucumber_config)
+  # Only add the retry plugin if --retry is not used on the command line
+  config.filters << Maze::Plugins::GlobalRetryPlugin.new(config) if config.options[:retry].zero?
+  config.filters << Maze::Plugins::BugsnagReportingPlugin.new(config)
 end
 
 # Before each scenario

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.9.2'
+  VERSION = '6.9.3'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time


### PR DESCRIPTION
## Goal

Update the retry plugin so that it only applies a retry if `--retry` has not already been set.  This prevents the plugin from stopping retries that have a blank allow in place.

## Tests

Verified locally that `--retry` will retry all scenarios in a run and that `@retry` on a scenario will cause only that scenario to be retried (if `--retry` is not used).