### PR TITLE
Retry Failed BrowserStack App Uploads

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
   - name: ':copyright: License Audit'
     plugins:
       docker-compose#v3.7.0:
-        run: license_finder:6.15.0
+        run: license_finder
     command: /bin/bash -lc '/scan/scripts/license_finder.sh'
 
   - label: ':docker: Build CI image for Ruby 2.7'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -145,7 +145,9 @@ steps:
       bundle exec maze-runner
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
-      --device=ANDROID_6_0
+      --device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN
+      --device=ANDROID_6_0_SAMSUNG_GALAXY_S7
+      --device=ANDROID_6_0_GOOGLE_NEXUS_6
     concurrency: 9
     concurrency_group: 'browserstack-app'
     concurrency_method: eager

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
   - name: ':copyright: License Audit'
     plugins:
       docker-compose#v3.7.0:
-        run: license_finder
+        run: license_finder:6.15.0
     command: /bin/bash -lc '/scan/scripts/license_finder.sh'
 
   - label: ':docker: Build CI image for Ruby 2.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+# 6.9.5 - 2022/03/18
+
+## Fixes
+
+- Add retry to BrowserStack app upload [#338](https://github.com/bugsnag/maze-runner/pull/338)
+
 # 6.9.4 - 2022/03/16
 
 ## Fixes
 
-- Add the `--color` arg to cucumber a default option [#337](https://github.com/bugsnag/maze-runner/pull/340)
+- Add the `--color` arg to cucumber a default option [#340](https://github.com/bugsnag/maze-runner/pull/340)
 
 # 6.9.3 - 2022/01/28
 

--- a/dockerfiles/Dockerfile.audit
+++ b/dockerfiles/Dockerfile.audit
@@ -1,4 +1,4 @@
-FROM licensefinder/license_finder
+FROM licensefinder/license_finder:6.15.0
 
 # Workaround for expired nodesource certificate: https://github.com/nodesource/distributions/issues/1266
 # TODO  Remove this in due course.

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.9.4'
+  VERSION = '6.9.5'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time

--- a/lib/maze/browser_stack_utils.rb
+++ b/lib/maze/browser_stack_utils.rb
@@ -39,7 +39,7 @@ module Maze
                 # Successful upload
                 break
               end
-            rescue
+            rescue JSON::ParserError
               $logger.error "Error: expected JSON response, received: #{body}"
             end
 

--- a/lib/maze/browser_stack_utils.rb
+++ b/lib/maze/browser_stack_utils.rb
@@ -34,7 +34,7 @@ module Maze
               if response.include?('error')
                 $logger.error "Upload failed due to error: #{response['error']}"
               elsif !response.include?('app_url')
-                $logger.error "Upload failed, response did not include and app_url: #{res}"
+                $logger.error "Upload failed, response did not include an app_url: #{res}"
               else
                 # Successful upload
                 break

--- a/lib/maze/browser_stack_utils.rb
+++ b/lib/maze/browser_stack_utils.rb
@@ -46,7 +46,7 @@ module Maze
             upload_tries += 1
           end
 
-          if response.include?('error') || !response.include?('app_url')
+          if response.nil? || response.include?('error') || !response.include?('app_url')
             raise "Failed to upload app after #{upload_tries} attempts"
           end
           

--- a/lib/maze/browser_stack_utils.rb
+++ b/lib/maze/browser_stack_utils.rb
@@ -37,8 +37,8 @@ module Maze
               raise "Error: expected JSON response, received: #{body}"
             end
 
-            upload_tries = 3 if response.exclude?('error') 
-            upload_tries = tries.next unless response.exclude?('error')
+            upload_tries = 3 if !response.include?('error') 
+            upload_tries = tries.next unless !response.include?('error')
           end
           
           app_url = response['app_url']

--- a/lib/maze/browser_stack_utils.rb
+++ b/lib/maze/browser_stack_utils.rb
@@ -39,7 +39,7 @@ module Maze
                 # Successful upload
                 break
               end
-            rescue JSON::ParserError
+            rescue
               $logger.error "Error: expected JSON response, received: #{body}"
             end
 

--- a/lib/maze/browser_stack_utils.rb
+++ b/lib/maze/browser_stack_utils.rb
@@ -23,7 +23,7 @@ module Maze
 
           wait = Maze::Wait.new(interval: 3, timeout: 30)
 
-          result = wait.until(&lambda do 
+          wait_result = wait.until(&lambda do 
             res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
               http.request(request)
             end

--- a/lib/maze/browser_stack_utils.rb
+++ b/lib/maze/browser_stack_utils.rb
@@ -31,9 +31,14 @@ module Maze
             begin
               body = res.body
               response = JSON.parse body
-              $logger.error "Upload failed due to error: #{response['error']}" if response.include?('error')
-              $logger.error "Upload failed, response did not include and app_url: #{res}" unless response.include?('app_url')
-              break if body.include?('app_url')
+              if response.include?('error')
+                $logger.error "Upload failed due to error: #{response['error']}"
+              elsif !response.include?('app_url')
+                $logger.error "Upload failed, response did not include and app_url: #{res}"
+              else
+                # Successful upload
+                break
+              end
             rescue JSON::ParserError
               $logger.error "Error: expected JSON response, received: #{body}"
             end

--- a/test/browser_stack_utils_test.rb
+++ b/test/browser_stack_utils_test.rb
@@ -98,7 +98,7 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
                                     443,
                                     use_ssl: true)&.returns(response_mock)
 
-    assert_raise(RuntimeError, 'Upload failed due to error: Error') do
+    assert_raise(Mocha::ExpectationError, 'Upload failed due to error: Error') do
       Maze::BrowserStackUtils.upload_app USERNAME, ACCESS_KEY, APP
     end
   end

--- a/test/browser_stack_utils_test.rb
+++ b/test/browser_stack_utils_test.rb
@@ -93,10 +93,10 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
     post_mock.expects(:basic_auth).with(USERNAME, ACCESS_KEY)
     post_mock.expects(:set_form).with({ 'file' => 'file' }, 'multipart/form-data')
 
-    json_response = JSON.dump(app_url: TEST_APP_URL)
-    error_response = JSON.dump(error: 'Useless error')
+    success_json_response = JSON.dump(app_url: TEST_APP_URL)
+    error_json_response = JSON.dump(error: 'Useless error')
     response_mock = mock('response')
-    response_mock.expects(:body).returns(error_response).then.returns(json_response).at_most(2)
+    response_mock.expects(:body).returns(error_json_response).then.returns(success_json_response).at_most(2)
 
     uri = URI('https://api-cloud.browserstack.com/app-automate/upload')
     Net::HTTP::Post.expects(:new)&.with(uri)&.returns post_mock

--- a/test/browser_stack_utils_test.rb
+++ b/test/browser_stack_utils_test.rb
@@ -74,7 +74,7 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
                                     443,
                                     use_ssl: true)&.returns(response_mock)
 
-    assert_raise(RuntimeError, 'Upload failed due to error: Error') do
+    assert_raise(RuntimeError, 'Failed to upload app after 3 attempts') do
       Maze::BrowserStackUtils.upload_app USERNAME, ACCESS_KEY, APP
     end
   end

--- a/test/browser_stack_utils_test.rb
+++ b/test/browser_stack_utils_test.rb
@@ -56,6 +56,7 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
 
   def test_upload_app_error
     $logger.expects(:info).with("Uploading app: #{APP}").once
+    $logger.expects(:error).with("Error: expected JSON response, received: gobbledygook").once
 
     File.expects(:new)&.with(APP, 'rb')&.returns('file')
     Maze::Helper.expects(:expand_path).with(APP).returns(APP)
@@ -74,7 +75,7 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
                                     443,
                                     use_ssl: true)&.returns(response_mock)
 
-    assert_raise(Mocha::ExpectationError, 'Upload failed due to error: Useless error') do
+    assert_raise(RuntimeError, 'Upload failed due to error: Error') do
       Maze::BrowserStackUtils.upload_app USERNAME, ACCESS_KEY, APP
     end
   end

--- a/test/browser_stack_utils_test.rb
+++ b/test/browser_stack_utils_test.rb
@@ -74,7 +74,7 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
                                     443,
                                     use_ssl: true)&.returns(response_mock)
 
-    assert_raise(RuntimeError, 'Failed to upload app after 3 attempts') do
+    assert_raise(ExpectationError, 'Upload failed due to error: Error') do
       Maze::BrowserStackUtils.upload_app USERNAME, ACCESS_KEY, APP
     end
   end

--- a/test/browser_stack_utils_test.rb
+++ b/test/browser_stack_utils_test.rb
@@ -74,7 +74,7 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
                                     443,
                                     use_ssl: true)&.returns(response_mock)
 
-    assert_raise(ExpectationError, 'Upload failed due to error: Error') do
+    assert_raise(RuntimeError, 'Upload failed due to error: Useless error') do
       Maze::BrowserStackUtils.upload_app USERNAME, ACCESS_KEY, APP
     end
   end

--- a/test/browser_stack_utils_test.rb
+++ b/test/browser_stack_utils_test.rb
@@ -74,7 +74,7 @@ class BrowserStackUtilsTest < Test::Unit::TestCase
                                     443,
                                     use_ssl: true)&.returns(response_mock)
 
-    assert_raise(RuntimeError, 'Upload failed due to error: Useless error') do
+    assert_raise(Mocha::ExpectationError, 'Upload failed due to error: Useless error') do
       Maze::BrowserStackUtils.upload_app USERNAME, ACCESS_KEY, APP
     end
   end


### PR DESCRIPTION
## Goal

Retry uploading the app to BrowserStack for a max of 3 times or until we get a success.

## Design

Decided to use a while loop rather than `Maze::Wait` as the upload could take longer than the timeout specified.

## Changeset

Add while loop to the `upload_app` function in the `browser_stack_utils.rb` to retry the app upload for max of 3 attempts or until we get a success

## Tests

Full CI
