### PR TITLE
Add --color as a default argument passed to Cucumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.9.4 - 2022/03/16
+
+## Fixes
+
+- Add the `--color` arg to cucumber a default option [#337](https://github.com/bugsnag/maze-runner/pull/340)
+
 # 6.9.3 - 2022/01/28
 
 ## Fixes

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -70,6 +70,7 @@ class MazeRunnerEntry
   def add_cucumber_args
     @args << 'features' if @args.empty?
     @args << '--publish-quiet'
+    @args << '--color'
 
     # Pass strict mode options through to cucumber if present
     # If not we default to strict for undefined and pending results,

--- a/dockerfiles/Dockerfile.audit
+++ b/dockerfiles/Dockerfile.audit
@@ -1,4 +1,4 @@
-FROM licensefinder/license_finder
+FROM licensefinder/license_finder:6.15.0
 
 # Workaround for expired nodesource certificate: https://github.com/nodesource/distributions/issues/1266
 # TODO  Remove this in due course.

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.9.3'
+  VERSION = '6.9.4'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time


### PR DESCRIPTION
## Goal

Add the `--color` as a default argument to the cucumber command to output ANSI escaped characters on Windows

## Changeset

Add `--color` as a default argument to cucumber
Set the licence audit docker container version to `6.15.0` to fix issues with the latest version causing tests to fail

## Tests

Argument has been manually added to a windows test to ensure that it gives the desired output.
