### PR TITLE
Add support for CrossBrowserTesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-# TBD
+# 6.10.0 - TBD
 
 ## Enhancements
 
 - Add method to download device logs from BrowserStack [#344](https://github.com/bugsnag/maze-runner/pull/344)
 - Only report to Bugsnag on genuine errors, not test failures [#347](https://github.com/bugsnag/maze-runner/pull/347)
+- Add support for CrossBrowserTesting [#342](https://github.com/bugsnag/maze-runner/pull/342)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,6 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES
@@ -156,4 +155,4 @@ DEPENDENCIES
   yard-cucumber!
 
 BUNDLED WITH
-   2.3.8
+   2.3.0

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -21,6 +21,7 @@ require_relative '../lib/maze/proxy'
 require_relative '../lib/maze/retry_handler'
 require_relative '../lib/maze/runner'
 require_relative '../lib/maze/sauce_labs_utils'
+require_relative '../lib/maze/smart_bear_utils'
 
 require_relative '../lib/maze/servlets/base_servlet'
 require_relative '../lib/maze/servlets/command_servlet'

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -18,6 +18,9 @@ RUN wget -q https://storage.googleapis.com/bugsnag-public-test-dependencies/sc-4
   && rm sc-4.7.1-linux.tar.gz \
   && mv sc-4.7.1-linux sauce-connect
 
+RUN wget -q https://sbsecuretunnel.s3.amazonaws.com/cli/linux/SBSecureTunnel \
+  && chmod +x SBSecureTunnel
+
 WORKDIR /app/
 
 COPY bin/ bin/

--- a/lib/maze/browsers_cbt.yml
+++ b/lib/maze/browsers_cbt.yml
@@ -1,0 +1,100 @@
+# Selenium capabilities for browserNames available on CrossbrowserNameTesting
+---
+ie_8:
+  browserName: "Internet Explorer"
+  version: "8"
+  platform: "Windows 7"
+
+ie_9:
+  browserName: "Internet Explorer"
+  version: "9"
+  platform: "Windows 7"
+
+ie_10:
+  browserName: "Internet Explorer"
+  version: "10"
+  os: "windows"
+  platform: "Windows 7 64-Bit"
+
+ie_11:
+  browserName: "Internet Explorer"
+  version: "11"
+  platform: "Windows 7 64-Bit"
+
+edge_14:
+  browserName: "MicrosoftEdge"
+  version: "14"
+  platform: "Windows 10"
+
+edge_15:
+  browserName: "MicrosoftEdge"
+  version: "15"
+  platform: "Windows 10"
+
+safari_8:
+  browserName: "Safari"
+  version: "8"
+  platform: "Mac OSX 10.10"
+
+safari_10:
+  browserName: "Safari"
+  version: "10.0"
+  platform: "Mac OSX 10.12"
+
+safari_13:
+  browserName: "Safari"
+  version: "13.0"
+  platform: "Mac OSX 10.15"
+
+safari_14:
+  browserName: "Safari"
+  version: "14.0"
+  platform: "MacOS 11"
+
+iphone_7_simulator:
+  browserName: "Safari"
+  deviceName: "iPhone 7 Simulator"
+  platformVersion': "10.0"
+  platformName': "iOS"
+
+iphone_xr:
+  browserName: "Safari"
+  deviceName': "iPhone XR"
+  platformVersion': "12.1"
+  platformName': "iOS"
+
+android_s7:
+  browserName: "Chrome"
+  deviceName: "Galaxy S7"
+  platformVersion: "7.0"
+  platformName: "Android"
+
+firefox_30:
+  browserName: "Firefox"
+  version: "30"
+  platform: "Windows 7"
+
+firefox_56:
+  browserName: "Firefox"
+  version: "56"
+  platform: "Mac OSX 10.13"
+
+firefox_95:
+  browserName: "Firefox"
+  version: "95"
+  platform: "Windows 10"
+
+chrome_43:
+  browserName: "Chrome"
+  version: "43"
+  platform: "Windows 7"
+
+chrome_61:
+  browserName: "Chrome"
+  version: "61"
+  platform: "Windows 10"
+
+chrome_96:
+  browserName: "Chrome"
+  version: "96"
+  platform: "Windows 10"

--- a/lib/maze/browsers_cbt.yml
+++ b/lib/maze/browsers_cbt.yml
@@ -49,7 +49,7 @@ safari_13:
 safari_14:
   browserName: "Safari"
   version: "14"
-  platform: "MacOS 11"
+  platform: "MacOS 11.0"
 
 iphone_7_simulator:
   browserName: "Safari"

--- a/lib/maze/browsers_cbt.yml
+++ b/lib/maze/browsers_cbt.yml
@@ -38,17 +38,17 @@ safari_8:
 
 safari_10:
   browserName: "Safari"
-  version: "10.0"
+  version: "10"
   platform: "Mac OSX 10.12"
 
 safari_13:
   browserName: "Safari"
-  version: "13.0"
+  version: "13"
   platform: "Mac OSX 10.15"
 
 safari_14:
   browserName: "Safari"
-  version: "14.0"
+  version: "14"
   platform: "MacOS 11"
 
 iphone_7_simulator:

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -34,6 +34,18 @@ module Maze
         capabilities
       end
 
+      # @param browser_type [String] A key from @see browsers_cbt.yml
+      # @param local_id [String] unique key for the SB tunnel instance
+      # @param capabilities_option [String] extra capabilities provided on the command line
+      def for_cbt_browser(browser_type, local_id, capabilities_option)
+        capabilities = Selenium::WebDriver::Remote::Capabilities.new
+        capabilities['tunnel_name'] = local_id
+        browsers = YAML.safe_load(File.read("#{__dir__}/browsers_cbt.yml"))
+        capabilities.merge! browsers[browser_type]
+        capabilities.merge! JSON.parse(capabilities_option)
+        capabilities
+      end
+
       # Constructs Appium capabilities for running on a local Android or iOS device.
       # @param platform [String] 'ios' or 'android'
       # @param capabilities_option [String] extra capabilities provided on the command line

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -79,6 +79,7 @@ module Maze
     attr_accessor :resilient
 
     # Device farm to be used, one of:
+    # :cbt (CrossBrowserTesting)
     # :bs (BrowserStack)
     # :local (Using Appium Server with a local device)
     # :none (Cucumber-driven testing with no devices)
@@ -87,6 +88,9 @@ module Maze
     #
     # Device farm specific configuration
     #
+
+    # Location of the SmartBear binary (if used)
+    attr_accessor :sb_local
 
     # Location of the BrowserStackLocal binary (if used)
     attr_accessor :bs_local

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -11,6 +11,8 @@ module Maze
       attr_reader :capabilities
 
       def initialize(driver_for, selenium_url=nil, capabilities=nil)
+        $logger.info 'Starting Selenium driver...'
+        time = Time.now
         if driver_for == :remote
           # Sets up identifiers for ease of connecting jobs
           @capabilities = capabilities
@@ -22,6 +24,7 @@ module Maze
         else
           @driver = ::Selenium::WebDriver.for driver_for
         end
+        $logger.info "Selenium driver started in #{(Time.now - time).to_i}s"
       end
 
       def find_element(*args)

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -29,6 +29,9 @@ module Maze
     OS = 'os'
     OS_VERSION = 'os-version'
 
+    # CrossBrowserTesting/Bitbar options
+    SB_LOCAL = 'sb-local'
+
     # BrowserStack-only options
     BS_LOCAL = 'bs-local'
 

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -105,14 +105,19 @@ module Maze
                 'The Appium version to use',
                 type: :string
 
-            # BrowserStack-only options
-            opt Option::BS_LOCAL,
-                '(BS only) Path to the BrowserStackLocal binary. MAZE_BS_LOCAL env var or "/BrowserStackLocal" by default',
+            # SmartBear-only options
+            opt Option::SB_LOCAL,
+                '(SB only) Path to the SBSecureTunnel binary. MAZE_SB_LOCAL env var or "/SBSecureTunnel" by default',
                 type: :string
 
             # Sauce Labs-only options
             opt Option::SL_LOCAL,
                 '(SL only) Path to the Sauce Connect binary. MAZE_SL_LOCAL env var or "/sauce-connect/bin/sc" by default',
+                type: :string
+
+            # BrowserStack-only options
+            opt Option::BS_LOCAL,
+                '(BS only) Path to the BrowserStackLocal binary. MAZE_BS_LOCAL env var or "/BrowserStackLocal" by default',
                 type: :string
 
             text ''
@@ -186,6 +191,9 @@ module Maze
         # @returns [Hash] The options hash with environment vars added
         def populate_environmental_defaults(options)
           case options.farm
+          when 'cbt'
+            options[Option::USERNAME] ||= ENV['CBT_USERNAME']
+            options[Option::ACCESS_KEY] ||= ENV['CBT_ACCESS_KEY']
           when 'bs'
             options[Option::USERNAME] ||= ENV['BROWSER_STACK_USERNAME']
             options[Option::ACCESS_KEY] ||= ENV['BROWSER_STACK_ACCESS_KEY']
@@ -193,6 +201,7 @@ module Maze
             options[Option::USERNAME] ||= ENV['SAUCE_LABS_USERNAME']
             options[Option::ACCESS_KEY] ||= ENV['SAUCE_LABS_ACCESS_KEY']
           end
+          options[Option::SB_LOCAL] ||= ENV['MAZE_SB_LOCAL'] || '/SBSecureTunnel'
           options[Option::BS_LOCAL] ||= ENV['MAZE_BS_LOCAL'] || '/BrowserStackLocal'
           options[Option::SL_LOCAL] ||= ENV['MAZE_SL_LOCAL'] || '/sauce-connect/bin/sc'
           options[Option::APPIUM_SERVER] ||= ENV['MAZE_APPIUM_SERVER'] || 'http://localhost:4723/wd/hub'

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -38,6 +38,7 @@ module Maze
           farm = options[Maze::Option::FARM]
           config.farm = case farm
                         when nil then :none
+                        when 'cbt' then :cbt
                         when 'bs' then :bs
                         when 'sl' then :sl
                         when 'local' then :local
@@ -49,6 +50,11 @@ module Maze
 
           # Farm specific options
           case config.farm
+          when :cbt
+            config.browser = options[Maze::Option::BROWSER]
+            config.sb_local = Maze::Helper.expand_path(options[Maze::Option::SB_LOCAL])
+            username = config.username = options[Maze::Option::USERNAME]
+            access_key = config.access_key = options[Maze::Option::ACCESS_KEY]
           when :bs
             device_option = options[Maze::Option::DEVICE]
             if device_option.nil? || device_option.empty?

--- a/lib/maze/option/validator.rb
+++ b/lib/maze/option/validator.rb
@@ -15,8 +15,8 @@ module Maze
 
         # Common options
         farm = options[Option::FARM]
-        if farm && !%w[bs sl local].include?(farm)
-          errors << "--#{Option::FARM} must be 'bs', 'sl' or 'local' if provided"
+        if farm && !%w[bs cbt sl local].include?(farm)
+          errors << "--#{Option::FARM} must be 'bs', 'cbt', 'sl' or 'local' if provided"
         end
 
         begin

--- a/lib/maze/smart_bear_utils.rb
+++ b/lib/maze/smart_bear_utils.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Maze
+  # Utils supporting the BrowserStack device farm integration
+  class SmartBearUtils
+    class << self
+      SB_READY_FILE = 'sb.ready'
+      SB_KILL_FILE = 'sb.kill'
+
+      # Starts the BitBar local tunnel
+      # @param sb_local [String] path to the SBSecureTunnel binary
+      # @param tunnel_name [String] Tunnel name
+      # @param username [String] Username to start the tunnel with
+      # @param access_key [String] CBT access key
+      def start_local_tunnel(sb_local, tunnel_name, username, access_key)
+        # Make sure the ready/kill files are already deleted
+        File.delete(SB_READY_FILE) if File.exist?(SB_READY_FILE)
+        File.delete(SB_KILL_FILE) if File.exist?(SB_KILL_FILE)
+
+        $logger.info 'Starting CBT SBSecureTunnel'
+        command = "#{sb_local} --username #{username} --authkey #{access_key} --acceptAllCerts " \
+                  "--ready #{SB_READY_FILE} --tunnelname #{tunnel_name} --kill #{SB_KILL_FILE}"
+
+        output = start_tunnel_thread(command)
+
+        success = Maze::Wait.new(timeout: 30).until do
+          File.exist?(SB_READY_FILE)
+        end
+        unless success
+          $logger.error "Failed: #{output}"
+        end
+      end
+
+      # Stops the local tunnel
+      def stop_local_tunnel
+        FileUtils.touch(SB_KILL_FILE)
+        Maze::Wait.new(timeout: 30).until do
+          !File.exist?(SB_READY_FILE)
+        end
+        File.delete(SB_READY_FILE) if File.exist?(SB_READY_FILE)
+        File.delete(SB_KILL_FILE) if File.exist?(SB_KILL_FILE)
+      end
+
+      private
+
+      def start_tunnel_thread(cmd)
+        executor = lambda do
+          Open3.popen2e(Maze::Runner.environment, cmd) do |_stdin, stdout_and_stderr, wait_thr|
+
+            output = []
+            stdout_and_stderr.each do |line|
+              output << line
+              $logger.debug('SBSecureTunnel') {line.chomp}
+            end
+
+            exit_status = wait_thr.value.to_i
+            $logger.debug "Exit status: #{exit_status}"
+
+            output.each { |line| $logger.warn('SBSecureTunnel') {line.chomp} } unless exit_status == 0
+
+            return [output, exit_status]
+          end
+        end
+
+        Thread.new(&executor)
+      end
+    end
+  end
+end

--- a/test/option/parser_test.rb
+++ b/test/option/parser_test.rb
@@ -11,6 +11,8 @@ class ParserTest < Test::Unit::TestCase
     ENV.delete('BROWSER_STACK_ACCESS_KEY')
     ENV.delete('SAUCE_LABS_USERNAME')
     ENV.delete('SAUCE_LABS_ACCESS_KEY')
+    ENV.delete('CBT_USERNAME')
+    ENV.delete('CBT_ACCESS_KEY')
     ENV.delete('MAZE_BS_LOCAL')
     ENV.delete('MAZE_SL_LOCAL')
     ENV.delete('MAZE_APPIUM_SERVER')

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -16,6 +16,8 @@ class ProcessorTest < Test::Unit::TestCase
     ENV.delete('BROWSER_STACK_ACCESS_KEY')
     ENV.delete('SAUCE_LABS_USERNAME')
     ENV.delete('SAUCE_LABS_ACCESS_KEY')
+    ENV.delete('CBT_USERNAME')
+    ENV.delete('CBT_ACCESS_KEY')
 
     Maze::Helper.stubs(:expand_path).with('/BrowserStackLocal').returns('/BrowserStackLocal')
   end

--- a/test/option/validator_test.rb
+++ b/test/option/validator_test.rb
@@ -18,6 +18,8 @@ class ValidatorTest < Test::Unit::TestCase
     ENV.delete('BROWSER_STACK_ACCESS_KEY')
     ENV.delete('SAUCE_LABS_USERNAME')
     ENV.delete('SAUCE_LABS_ACCESS_KEY')
+    ENV.delete('CBT_USERNAME')
+    ENV.delete('CBT_ACCESS_KEY')
 
     Maze::Helper.stubs(:expand_path).with('/BrowserStackLocal').returns('/BrowserStackLocal')
     Maze::Helper.stubs(:expand_path).with('/sauce-connect/bin/sc').returns('/sauce-connect/bin/sc')

--- a/test/option/validator_test.rb
+++ b/test/option/validator_test.rb
@@ -33,7 +33,7 @@ class ValidatorTest < Test::Unit::TestCase
     errors = @validator.validate options
 
     assert_equal 1, errors.length
-    assert_equal "--farm must be 'bs', 'sl' or 'local' if provided", errors[0]
+    assert_equal "--farm must be 'bs', 'cbt', 'sl' or 'local' if provided", errors[0]
   end
 
   def test_valid_browser_stack_options


### PR DESCRIPTION
## Goal

Add support for running Selenium tests on CrossBrowserTesting.

## Design

Follows the existing approach for BrowserStack browsers - the usage pattern is analogous. 

## Changeset

- New option for the `--farm` switch
- Capabilities YML file to support a range of browsers
- New SmartBear utils class for running the secure tunnel (this will overlap with Bitbar once added)

## Tests

Unit tests updated.  Also ran the browser test in the repo against each browser option in the YML file.  I've not updated the pipeline to run against CBT just yet, as we need to perform some further testing before we move everything across.