### PR TITLE
Allow --os-version to be omitted when --farm=local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# 6.12.1 - 2022/04/29
+# 6.13.0 - 2022/04/29
 
 ## Enhancements
 
 - Add Chrome 40, 42 and iPhone 62 (iOS 9), iPhone 13 (iOS 15.4) support [355](https://github.com/bugsnag/maze-runner/pull/355)
+- Allow `--os-version` to be omitted when `--farm=local` [345](https://github.com/bugsnag/maze-runner/pull/345)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.12.1)
+    bugsnag-maze-runner (6.13.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -26,7 +26,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.3)
+    activesupport (7.0.2.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -84,7 +84,7 @@ GEM
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     iniparser (1.0.1)
-    kramdown (2.3.2)
+    kramdown (2.4.0)
       rexml
     license_finder (6.12.2)
       bundler
@@ -155,4 +155,4 @@ DEPENDENCIES
   yard-cucumber!
 
 BUNDLED WITH
-   2.3.11
+   2.3.0

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.12.1'
+  VERSION = '6.13.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -139,6 +139,14 @@ module Maze
             config.capabilities = device_capabilities(config, tunnel_id)
             driver = create_driver(config)
             driver.start_driver unless config.appium_session_isolation
+            if Maze.config.os_version < 1
+              Maze.config.os_version = case Maze.config.os
+              when 'android'
+                driver.session_capabilities['platformVersion'].to_f
+              when 'ios'
+                driver.session_capabilities['sdkVersion'].to_f
+              end
+            end
             Maze.driver = driver
           rescue Selenium::WebDriver::Error::UnknownError => original_exception
             $logger.warn "Attempt to acquire #{config.device} device from farm #{config.farm} failed"

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -139,14 +139,20 @@ module Maze
             config.capabilities = device_capabilities(config, tunnel_id)
             driver = create_driver(config)
             driver.start_driver unless config.appium_session_isolation
-            if Maze.config.os_version < 1
-              Maze.config.os_version = case Maze.config.os
+
+            # Infer OS version if necessary when running locally
+            if Maze.config.farm == :local && Maze.config.os_version.nil?
+              version = case Maze.config.os
               when 'android'
                 driver.session_capabilities['platformVersion'].to_f
               when 'ios'
                 driver.session_capabilities['sdkVersion'].to_f
               end
+              $logger.info "Inferred OS version to be #{version}"
+              Maze.config.os_version = version
             end
+
+
             Maze.driver = driver
           rescue Selenium::WebDriver::Error::UnknownError => original_exception
             $logger.warn "Attempt to acquire #{config.device} device from farm #{config.farm} failed"

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -97,7 +97,7 @@ module Maze
               config.browser = options[Maze::Option::BROWSER]
             else
               os = config.os = options[Maze::Option::OS].downcase
-              config.os_version = options[Maze::Option::OS_VERSION].to_f
+              config.os_version = options[Maze::Option::OS_VERSION].to_f unless options[Maze::Option::OS_VERSION].nil?
               config.appium_server_url = options[Maze::Option::APPIUM_SERVER]
               config.start_appium = options[Maze::Option::START_APPIUM]
               config.appium_logfile = options[Maze::Option::APPIUM_LOGFILE]

--- a/lib/maze/option/validator.rb
+++ b/lib/maze/option/validator.rb
@@ -146,9 +146,7 @@ module Maze
           end
 
           # OS Version
-          if options[Option::OS_VERSION].nil?
-            errors << "--#{Option::OS_VERSION} must be specified"
-          else
+          unless options[Option::OS_VERSION].nil?
             # Ensure OS version is a valid float so that notifier tests can perform numeric checks
             # e.g 'Maze.config.os_version > 7'
             unless /^[1-9][0-9]*(\.[0-9])?/.match? options[Option::OS_VERSION]

--- a/test/hooks/appium_hooks_test.rb
+++ b/test/hooks/appium_hooks_test.rb
@@ -111,6 +111,55 @@ class AppiumHooksTest < Test::Unit::TestCase
 
     $config.expects(:capabilities=).with(:caps)
     $config.expects(:appium_session_isolation).returns(false)
+    $config.expects(:farm).returns(:bs)
+
+    hooks.start_driver($config)
+  end
+
+  def test_start_driver_infer_ios_version
+    driver_mock = mock('driver')
+    driver_mock.expects(:start_driver)
+    driver_mock.expects(:session_capabilities).returns({'sdkVersion' => '9.0'})
+
+    Maze.expects(:driver).twice.returns(false, true)
+    Maze.expects(:driver=).with(driver_mock)
+
+    hooks = Maze::Hooks::AppiumHooks.new
+    hooks.expects(:device_capabilities).with($config, nil).returns(:caps)
+    hooks.expects(:create_driver).with($config).returns(driver_mock)
+
+    $config.expects(:capabilities=).with(:caps)
+    $config.expects(:appium_session_isolation).returns(false)
+    $config.expects(:farm).returns(:local)
+    $config.expects(:os_version).returns(nil)
+    $config.expects(:os).returns('ios')
+
+    $logger.expects(:info).with('Inferred OS version to be 9.0')
+    $config.expects(:os_version=).with(9.0)
+
+    hooks.start_driver($config)
+  end
+
+  def test_start_driver_infer_android_version
+    driver_mock = mock('driver')
+    driver_mock.expects(:start_driver)
+    driver_mock.expects(:session_capabilities).returns({'platformVersion' => '12.0'})
+
+    Maze.expects(:driver).twice.returns(false, true)
+    Maze.expects(:driver=).with(driver_mock)
+
+    hooks = Maze::Hooks::AppiumHooks.new
+    hooks.expects(:device_capabilities).with($config, nil).returns(:caps)
+    hooks.expects(:create_driver).with($config).returns(driver_mock)
+
+    $config.expects(:capabilities=).with(:caps)
+    $config.expects(:appium_session_isolation).returns(false)
+    $config.expects(:farm).returns(:local)
+    $config.expects(:os_version).returns(nil)
+    $config.expects(:os).returns('android')
+
+    $logger.expects(:info).with('Inferred OS version to be 12.0')
+    $config.expects(:os_version=).with(12.0)
 
     hooks.start_driver($config)
   end
@@ -153,7 +202,7 @@ class AppiumHooksTest < Test::Unit::TestCase
     $config.expects(:capabilities=).twice.with(:caps)
     $config.expects(:appium_session_isolation).twice.returns(false)
     $config.expects(:device).twice.returns(:device)
-    $config.expects(:farm).returns(:farm)
+    $config.expects(:farm).twice.returns(:farm)
     device_list = mock('device_list')
     $config.stubs(:device_list).returns(device_list)
     $config.expects(:device_list=).with(device_list)
@@ -215,6 +264,7 @@ class AppiumHooksTest < Test::Unit::TestCase
 
     $config.expects(:capabilities=).with(:caps)
     $config.expects(:appium_session_isolation).returns(true)
+    $config.expects(:farm).returns(:farm)
 
     hooks.start_driver($config)
   end

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -74,6 +74,29 @@ class ProcessorTest < Test::Unit::TestCase
     assert_false config.start_appium
   end
 
+  def test_populate_local_config_defaults
+    args = %w[--farm=local --app=my_app.apk --os=ios --apple-team-id=ABC --udid=123 \
+              --no-start-appium --document-server-root=root \
+              --document-server-bind-address=5.6.7.8 --document-server-port=5678]
+    options = Maze::Option::Parser.parse args
+    config = Maze::Configuration.new
+    Maze::Option::Processor.populate config, options
+
+    assert_equal :local, config.farm
+    assert_equal 'my_app.apk', config.app
+    assert_equal 'ios', config.os
+    assert_equal 'ABC', config.apple_team_id
+    assert_equal '123', config.device_id
+    assert_equal 'root', config.document_server_root
+    assert_equal '5.6.7.8', config.document_server_bind_address
+    assert_equal 5678, config.document_server_port
+    assert_false config.start_appium
+
+    assert_nil config.os_version
+    assert_nil config.bind_address
+    assert_equal 9339, config.port
+  end
+
   def test_logger_options
     args = %w[--no-file-log --log-requests --always-log]
     options = Maze::Option::Parser.parse args

--- a/test/option/validator_test.rb
+++ b/test/option/validator_test.rb
@@ -134,8 +134,7 @@ class ValidatorTest < Test::Unit::TestCase
     options = Maze::Option::Parser.parse args
     errors = @validator.validate options
 
-    assert_equal 1, errors.length
-    assert_equal '--os-version must be specified', errors[0]
+    assert_equal 0, errors.length
   end
 
   def test_local_missing_app


### PR DESCRIPTION
## Goal

Allow --os-version to be omitted when --farm=local.

## Changeset

Relaxes the CL parser and adds inference of OS version from the Appium session capabilities.  Those capabilities may not be right, but it doesn't really matter when running locally.

## Tests

Verified this works locally against Appium 1.21.0 with Android 10 and iOS 15.3.  Unit tests also updated.