### PR TITLE
Fix received errors match step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.9.6 - 2022/03/31
+
+## Fixes
+
+- Fix received errors match step [#346](https://github.com/bugsnag/maze-runner/pull/346)
+
 # 6.9.5 - 2022/03/18
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.9.3)
+    bugsnag-maze-runner (6.9.6)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -100,7 +100,7 @@ Then('the received errors match:') do |table|
 
       events = request[:body]['events']
       Maze.check.equal(1, events.length, 'Expected exactly one event per request')
-      match_count += 1 if request_matches_row(events[0], row)
+      match_count += 1 if Maze::Assertions::RequestSetAssertions.request_matches_row(events[0], row)
     end
   end
   Maze.check.equal(requests.size, match_count, 'Unexpected number of requests matched the received payloads')

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.9.5'
+  VERSION = '6.9.6'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time

--- a/lib/maze/assertions/request_set_assertions.rb
+++ b/lib/maze/assertions/request_set_assertions.rb
@@ -71,6 +71,7 @@ module Maze
           row.each do |key, expected_value|
             obs_val = Maze::Helper.read_key_path(body, key)
             next if ('null'.eql? expected_value) && obs_val.nil? # Both are null/nil
+            next if ('@not_null'.eql? expected_value) && !obs_val.nil? # The value isn't null
 
             unless obs_val.nil?
               if expected_value[0] == '/' && expected_value[-1] == '/'

--- a/test/fixtures/comparison/features/scripts/send_request.sh
+++ b/test/fixtures/comparison/features/scripts/send_request.sh
@@ -49,6 +49,10 @@ when 'info-log'
  '{"level":"INFO","message":"Today is 2021-02-03"}'
 when 'error-log'
  '{"level":"ERROR","message":"The world is still on pause"}'
+when 'error 1'
+ '{"events":[{"null?":"nope","count":"one"}]}'
+when 'error 2'
+ '{"events":[{"count":"two"}]}'
 else
   exit(1)
 end

--- a/test/fixtures/comparison/features/test_unordered_requests.feature
+++ b/test/fixtures/comparison/features/test_unordered_requests.feature
@@ -12,3 +12,16 @@ Feature: Unordered requests can be tested using a table
           | foo | bar |
           | b   | a   |
           | a   | b   |
+
+    Scenario: Testing errors regardless of order
+        When I send a "error 1"-type request
+        And I send a "error 2"-type request
+        And I wait to receive 2 errors
+        Then the received errors match:
+          | null?     | count |
+          | @not_null | one   |
+          | null      | two   |
+        And the received errors match:
+          | null?     | count |
+          | null      | two   |
+          | @not_null | one   |


### PR DESCRIPTION
## Goal
Fixes an issue where the `the received errors match` step fails due to the `request_matches_row` method having been moved.