### PR TITLE
Decrease noise in Bugsnag by skipping assertion failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Add method to download device logs from BrowserStack [#344](https://github.com/bugsnag/maze-runner/pull/344)
+- Only report to Bugsnag on genuine errors, not test failures [#347](https://github.com/bugsnag/maze-runner/pull/347)
 
 ## Fixes
 

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -15,7 +15,7 @@ def assert_received_requests(request_count, list, list_name)
   received = wait.until { list.size >= request_count }
 
   unless received
-    raise <<-MESSAGE
+    raise Test::Unit::AssertionFailedError.new <<-MESSAGE
     Expected #{request_count} #{list_name} but received #{list.size} within the #{timeout}s timeout.
     This could indicate that:
     - Bugsnag crashed with a fatal error.

--- a/lib/maze/bugsnag_config.rb
+++ b/lib/maze/bugsnag_config.rb
@@ -10,6 +10,7 @@ module Maze
 
         Bugsnag.configure do |config|
           config.api_key = ENV['MAZE_BUGSNAG_API_KEY']
+          config.discard_classes << 'Test::Unit::AssertionFailedError'
           config.add_metadata(:'test driver', {
             'driver type': Maze.driver.class,
             'device farm': Maze.config.farm,

--- a/lib/maze/plugins/bugsnag_reporting_plugin.rb
+++ b/lib/maze/plugins/bugsnag_reporting_plugin.rb
@@ -24,6 +24,9 @@ module Maze
           # Ensure we're in the correct test case and that it's failed
           next unless event.test_case.eql?(test_case) && event.result.failed?
 
+          # Ignore assertion failures (Test::Unit::AssertionFailedError)
+          next if event.result.exception.class.eql?(Test::Unit::AssertionFailedError)
+
           Bugsnag.notify(event.result.exception) do |bsg_event|
             unless @last_test_step.nil?
               bsg_event.context = @last_test_step.location

--- a/lib/maze/plugins/bugsnag_reporting_plugin.rb
+++ b/lib/maze/plugins/bugsnag_reporting_plugin.rb
@@ -24,9 +24,6 @@ module Maze
           # Ensure we're in the correct test case and that it's failed
           next unless event.test_case.eql?(test_case) && event.result.failed?
 
-          # Ignore assertion failures (Test::Unit::AssertionFailedError)
-          next if event.result.exception.class.eql?(Test::Unit::AssertionFailedError)
-
           Bugsnag.notify(event.result.exception) do |bsg_event|
             unless @last_test_step.nil?
               bsg_event.context = @last_test_step.location


### PR DESCRIPTION
## Goal

We've implemented Bugsnag error reporting in Cucumber, but it's very noisy due to the presence of test failures preventing us from seeing unexpected errors as easily.

## Changes

1. I've changed the "payloads not received" error from a standard `RuntimeError` to a `Test::Unit::AssertionFailedError`.  This isn't strictly correct, as there are many places where a systematic error can cause this assertion to fail, but it can also be reflective of a genuine test failure.  @twometresteve I'd suggest we make a custom error for this failure, then we can determine how to handle it on a separate basis (e.g. route it to a different bugsnag api-key)
2. I've added a filter to our Bugsnag config to drop events involving the `Test::Unit::AssertionFailedError` class, which will filter assertion failures out of our reporting errors.