### PR TITLE
Add driver.page_source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.11.0 - TBD
+
+## Enhancements
+
+- Add Maze.driver.page_source [#348](https://github.com/bugsnag/maze-runner/pull/348)
+
 # 6.10.0 - 2022/04/12
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.10.0)
+    bugsnag-maze-runner (6.11.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -104,7 +104,7 @@ GEM
     minitest (5.15.0)
     mocha (1.12.0)
     multi_test (0.1.2)
-    nokogiri (1.13.3-x86_64-darwin)
+    nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.10.0'
+  VERSION = '6.11.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -119,6 +119,11 @@ module Maze
         end
       end
 
+      # Gets the application hierarchy XML
+      def page_source
+        @driver.page_source
+      end
+
       # Sends keys to a given element
       #
       # @param element_id [String] the element to send text to


### PR DESCRIPTION
## Goal

Add access to driver.page_source, as described on https://appium.io/docs/en/commands/session/source.

## Tests

Tested locally by logging the result in a real `bugsnag-android` test run.