### PR TITLE
Retry failed app uploads for ten minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add Maze.driver.page_source [#348](https://github.com/bugsnag/maze-runner/pull/348)
 
+## Fixes
+
+- Retry failed BrowserStack app uploads each minute for 10 minutes [#349](https://github.com/bugsnag/maze-runner/pull/349)
+
 # 6.10.0 - 2022/04/12
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     minitest (5.15.0)
-    mocha (1.12.0)
+    mocha (1.13.0)
     multi_test (0.1.2)
     nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
@@ -149,7 +149,7 @@ DEPENDENCIES
   bugsnag-maze-runner!
   license_finder (~> 6.12.0)
   markdown (~> 1.2)
-  mocha (~> 1.12.0)
+  mocha (~> 1.13.0)
   redcarpet (~> 3.5)
   yard (~> 0.9.1)
   yard-cucumber!

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'license_finder', '~> 6.12.0'
   spec.add_development_dependency 'markdown', '~> 1.2'
-  spec.add_development_dependency 'mocha', '~> 1.12.0'
+  spec.add_development_dependency 'mocha', '~> 1.13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'yard', '~> 0.9.1'
 end


### PR DESCRIPTION
## Goal

Retry failed app uploads for ten minutes, giving BrowserStack more of a chance to repair itself.

## Changeset

Number of iterations of retry loop increased, with sleep between and logging improved.

## Tests

Covered by updating the existing unit test.