### PR TITLE
Ensure devices are unlocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
-# 6.11.0 - TBD
+# 6.11.0 - 2022/04/20
 
 ## Enhancements
 
 - Add Maze.driver.page_source [#348](https://github.com/bugsnag/maze-runner/pull/348)
+- Add Maze.driver.unlock [#351](https://github.com/bugsnag/maze-runner/pull/351)
 
 ## Fixes
 
-- Retry failed BrowserStack app uploads each minute for 10 minutes [#349](https://github.com/bugsnag/maze-runner/pull/349)
+- Retry failed BrowserStack app uploads each minute for 10 minutes [#350](https://github.com/bugsnag/maze-runner/pull/350)
 
 # 6.10.0 - 2022/04/12
 

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -124,6 +124,11 @@ module Maze
         @driver.page_source
       end
 
+      # Unlocks the device
+      def unlock
+        @driver.unlock
+      end
+
       # Sends keys to a given element
       #
       # @param element_id [String] the element to send text to

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -34,6 +34,9 @@ module Maze
 
         start_driver(config, tunnel_id)
 
+        # Ensure the device is unlocked
+        Maze.driver.unlock
+
         # Write links to device farm sessions, where applicable
         write_session_links
       end


### PR DESCRIPTION
## Goal

Ensure devices are unlocked at the start of each test run.

## Design

If a device is already unlocked then Appium simply ignores the call.

## Changeset

Expose the Appium `driver.unlock` method and call it after starting the test session.

## Tests

Covered by CI and I have tested that every version of Android and iOS that we run against is happy with the change.