### PR TITLE
Change the @max_received_size to 1MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.11.1 - 2022/04/21
+
+## Enhancements
+
+- Defaults the read size to 1 MB for the terminating server
+
 # 6.11.0 - 2022/04/20
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Defaults the read size to 1 MB for the terminating server
+- Defaults the read size to 1 MB for the terminating server [352](https://github.com/bugsnag/maze-runner/pull/352)
 
 # 6.11.0 - 2022/04/20
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.11.0)
+    bugsnag-maze-runner (6.11.1)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -155,4 +155,4 @@ DEPENDENCIES
   yard-cucumber!
 
 BUNDLED WITH
-   2.3.0
+   2.3.11

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.11.0'
+  VERSION = '6.11.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time

--- a/lib/maze/terminating_server.rb
+++ b/lib/maze/terminating_server.rb
@@ -50,9 +50,9 @@ module Maze
 
       # The maximum string length to be received before disconnecting
       #
-      # @return [Integer] The string length, defaults to 150B
+      # @return [Integer] The string length, defaults to 1MB
       def max_received_size
-        @max_received_size ||= 150
+        @max_received_size ||= 1048576
       end
 
       # Set the maximum string length to be received before disconnecting
@@ -76,10 +76,10 @@ module Maze
         @response = new_response
       end
 
-      # Resets the response string to "400/BAD REQUEST" and the read size to 150B
+      # Resets the response string to "400/BAD REQUEST" and the read size to 1MB
       def reset_elements
         @response = BAD_REQUEST_RESPONSE
-        @max_received_size = 150
+        @max_received_size = 1048576
       end
 
       # Whether the server thread is running


### PR DESCRIPTION
## Goal

Up the '@max_received_size' for the terminating server to 1MB

## Changeset

Change `@max_received_size` to `1048576` for the terminating server.

## Tests

<!-- How was it tested? -->
Covered by CI
I've also installed this version and tested it locally.

```
I, [2022-04-21 16:27:41#61176]  INFO -- : Terminating server received request
I, [2022-04-21 16:27:41#61176]  INFO -- : Reading 1048576 bytes
```