### PR TITLE
Correct Maze.check.match implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add Chrome 40, 42 and iPhone 62 (iOS 9), iPhone 13 (iOS 15.4) support [355](https://github.com/bugsnag/maze-runner/pull/355)
 
+## Fixes
+
+- Correct Maze.check.match implementation to allow message to be provided [354](https://github.com/bugsnag/maze-runner/pull/354)
+
 # 6.12.0 - 2022/04/28
 
 ## Enhancements

--- a/lib/maze/checks/assert_check.rb
+++ b/lib/maze/checks/assert_check.rb
@@ -23,8 +23,8 @@ module Maze
         assert_not_nil(test, message)
       end
 
-      def match(test, message = nil)
-        assert_match(test, message)
+      def match(pattern, string, message = nil)
+        assert_match(pattern, string, message)
       end
 
       def equal(expected, act, message = nil)

--- a/lib/maze/checks/noop_check.rb
+++ b/lib/maze/checks/noop_check.rb
@@ -12,7 +12,7 @@ module Maze
 
       def not_nil(_test, _message = nil) end
 
-      def match(_test, _message = nil) end
+      def match(_pattern, _string, _message = nil) end
 
       def equal(_expected, _actual, _message = nil) end
 


### PR DESCRIPTION
## Goal

Corrects the implementation of `Maze.check.match`, which worked by chance for the simple case - but had misleading parameter names and would not have allowed a failure message to have been provided.

## Tests

Tested locally with a scenario that uses the step `the {word} payload field {string} matches the regex {string}`.