### PR TITLE
Stop BrowserStack tunnel after browser test runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Allow BrowserStack credentials to be set separately for devices and browsers [358](https://github.com/bugsnag/maze-runner/pull/358)
 
+## Fixes
+
+- Stop BrowserStack tunnel after browser test runs [357](https://github.com/bugsnag/maze-runner/pull/357)
+
 # 6.14.0 - 2022/05/03
 
 ## Enhancements

--- a/lib/maze/hooks/browser_hooks.rb
+++ b/lib/maze/hooks/browser_hooks.rb
@@ -39,6 +39,12 @@ module Maze
           Maze.driver = Maze::Driver::Browser.new Maze.config.browser.to_sym
         end
       end
+
+      def at_exit
+        if Maze.config.farm == :bs
+          Maze::BrowserStackUtils.stop_local_tunnel
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Goal

Stop BrowserStack tunnel after browser test runs.

## Design

I stumbled upon the missing call, which was introduced in a refactor as part of v5.8.0 (July 2021).  I'm not sure if it could be causing PLAT-7670 or not (browser tests not always shutting down).

## Changeset

Reinstated call to stop the BrowserStack tunnel for browser test runs.

## Tests

Covered by CI.