### PR TITLE
Add retries to appium driver failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.16.0 - TBD
+
+## Enhancements
+
+- Allow appium driver start failures to be retried within 60s [359](https://github.com/bugsnag/maze-runner/pull/359)
+
 # 6.15.1 - TBD
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 - Allow appium driver start failures to be retried within 60s [359](https://github.com/bugsnag/maze-runner/pull/359)
 
-# 6.15.1 - TBD
-
 ## Fixes
 
 - Fix logging of BrowserStack session links [360](https://github.com/bugsnag/maze-runner/pull/360)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.15.1)
+    bugsnag-maze-runner (6.16.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.15.1'
+  VERSION = '6.16.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -51,10 +51,25 @@ module Maze
 
       # Starts the Appium driver
       def start_driver
-        $logger.info 'Starting Appium driver...'
-        time = Time.now
-        super
-        $logger.info "Appium driver started in #{(Time.now - time).to_i}s"
+        wait = Maze::Wait.new(interval: 10, timeout: 60)
+        success = wait.until do
+          begin
+            $logger.info 'Starting Appium driver...'
+            time = Time.now
+            super
+            $logger.info "Appium driver started in #{(Time.now - time).to_i}s"
+            true
+          rescue => error
+            $logger.warn "Appium driver failed to start in #{(Time.now - time).to_i}s"
+            $logger.warn "#{error.class} occurred with message: #{error.message}"
+            false
+          end
+        end
+
+        unless success
+          $logger.error 'Appium driver failed to start after 6 attempts in 60 seconds'
+          raise RuntimeError.new('Appium driver failed to start in 60 seconds')
+        end
       end
 
       # Checks for an element, waiting until it is present or the method times out


### PR DESCRIPTION
## Goal

Adds 5 retries with 10 seconds intervals over the course of a minute when starting the appium driver.
This should add some flexibility with appium test runs by allowing for initialisation/connection errors.

## Tests

Unit tests have been added to ensure the functionality resolves as expected.
Note - Due to adding a significant time to the unit tests the full failure situation has _not_ been added to these tests, but it can on request.

In addition to the unit tests, basic localised testing has been performed.  The resulting output in a full failure scenario read:

```
I, [2022-05-05 16:14:39#83031]  INFO -- : Creating Appium driver instance
I, [2022-05-05 16:14:39#83031]  INFO -- : Appium driver initialized for:
I, [2022-05-05 16:14:39#83031]  INFO -- :     project : local
I, [2022-05-05 16:14:39#83031]  INFO -- :     build   : c80a36f4-1e89-47d2-b5e5-b902907d20d2
I, [2022-05-05 16:14:39#83031]  INFO -- : Starting Appium driver...
W, [2022-05-05 16:14:40#83031]  WARN -- : Appium driver failed to start in 0s
W, [2022-05-05 16:14:40#83031]  WARN -- : Selenium::WebDriver::Error::UnknownError occurred with message: Invalid username or password
I, [2022-05-05 16:14:50#83031]  INFO -- : Starting Appium driver...
W, [2022-05-05 16:14:51#83031]  WARN -- : Appium driver failed to start in 1s
W, [2022-05-05 16:14:51#83031]  WARN -- : Selenium::WebDriver::Error::UnknownError occurred with message: Invalid username or password
I, [2022-05-05 16:15:01#83031]  INFO -- : Starting Appium driver...
W, [2022-05-05 16:15:03#83031]  WARN -- : Appium driver failed to start in 1s
W, [2022-05-05 16:15:03#83031]  WARN -- : Selenium::WebDriver::Error::UnknownError occurred with message: Invalid username or password
I, [2022-05-05 16:15:13#83031]  INFO -- : Starting Appium driver...
W, [2022-05-05 16:15:14#83031]  WARN -- : Appium driver failed to start in 1s
W, [2022-05-05 16:15:14#83031]  WARN -- : Selenium::WebDriver::Error::UnknownError occurred with message: Invalid username or password
I, [2022-05-05 16:15:24#83031]  INFO -- : Starting Appium driver...
W, [2022-05-05 16:15:25#83031]  WARN -- : Appium driver failed to start in 0s
W, [2022-05-05 16:15:25#83031]  WARN -- : Selenium::WebDriver::Error::UnknownError occurred with message: Invalid username or password
I, [2022-05-05 16:15:35#83031]  INFO -- : Starting Appium driver...
W, [2022-05-05 16:15:37#83031]  WARN -- : Appium driver failed to start in 1s
W, [2022-05-05 16:15:37#83031]  WARN -- : Selenium::WebDriver::Error::UnknownError occurred with message: Invalid username or password
E, [2022-05-05 16:15:47#83031] ERROR -- : Appium driver failed to start after 6 attempts in 60 seconds
Appium driver failed to start in 60 seconds (RuntimeError)
```
