### PR TITLE
Fix logging of BrowserStack session links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.15.1 - TBD
+
+## Fixes
+
+- Fix logging of BrowserStack session links [360](https://github.com/bugsnag/maze-runner/pull/360)
+
 # 6.15.0 - 2022/05/05
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.15.0)
+    bugsnag-maze-runner (6.15.1)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,7 @@ services:
         BRANCH_NAME:
         RUBY_VERSION:
     environment:
+      BUILDKITE:
       BROWSER_STACK_USERNAME:
       BROWSER_STACK_ACCESS_KEY:
       BROWSER_STACK_BROWSERS_USERNAME:

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.15.0'
+  VERSION = '6.15.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -38,7 +38,7 @@ module Maze
         Maze.driver.unlock
 
         # Write links to device farm sessions, where applicable
-        write_session_links
+        write_session_link
       end
 
       def before
@@ -75,16 +75,12 @@ module Maze
         end
       end
 
-      def write_session_links
+      def write_session_link
         config = Maze.config
         if config.farm == :bs && (config.device || config.browser)
           # Log a link to the BrowserStack session search dashboard
           build = Maze.driver.capabilities[:build]
-          url = if config.device
-                  "https://app-automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"
-                else
-                  "https://automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"
-                end
+          url = "https://app-automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"
           if ENV['BUILDKITE']
             $logger.info Maze::LogUtil.linkify url, 'BrowserStack session(s)'
           else

--- a/lib/maze/hooks/browser_hooks.rb
+++ b/lib/maze/hooks/browser_hooks.rb
@@ -38,11 +38,28 @@ module Maze
         when :local
           Maze.driver = Maze::Driver::Browser.new Maze.config.browser.to_sym
         end
+
+        # Write links to device farm sessions, where applicable
+        write_session_link
       end
 
       def at_exit
         if Maze.config.farm == :bs
           Maze::BrowserStackUtils.stop_local_tunnel
+        end
+      end
+
+      def write_session_link
+        config = Maze.config
+        if config.farm == :bs
+          # Log a link to the BrowserStack session search dashboard
+          build = Maze.driver.capabilities[:build]
+          url = "https://automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"
+          if ENV['BUILDKITE']
+            $logger.info Maze::LogUtil.linkify url, 'BrowserStack session(s)'
+          else
+            $logger.info "BrowserStack session(s): #{url}"
+          end
         end
       end
     end


### PR DESCRIPTION
## Goal

Fix logging of BrowserStack session links.

## Tests

Tested locally and by inspection of the CI build.