### PR TITLE
Close Selenium session at end of test run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Fix logging of BrowserStack session links [360](https://github.com/bugsnag/maze-runner/pull/360)
+- Close Selenium session at end of test run [361](https://github.com/bugsnag/maze-runner/pull/361)
 
 # 6.15.0 - 2022/05/05
 

--- a/lib/maze/hooks/browser_hooks.rb
+++ b/lib/maze/hooks/browser_hooks.rb
@@ -46,6 +46,7 @@ module Maze
       def at_exit
         if Maze.config.farm == :bs
           Maze::BrowserStackUtils.stop_local_tunnel
+          Maze.driver.driver_quit
         end
       end
 


### PR DESCRIPTION
## Goal

Close Selenium session at end of test run.

## Tests

Tested by inspecting the BrowserStack dashboard before and after the change (sessions did continue to report running, now they show as completed).