### PR TITLE
Allow invalid requests to be ignored on specific endpoints

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -129,7 +129,7 @@ steps:
       bundle exec maze-runner
       --no-log-requests
 
-  - label: 'Browserstack app-automate test - Android 6 using Ruby 2.7'
+  - label: 'Browserstack app-automate test - Android 7 using Ruby 2.7'
     depends_on: "ci-image-ruby-2-7"
     plugins:
       docker-compose#v3.7.0:
@@ -145,9 +145,7 @@ steps:
       bundle exec maze-runner
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
-      --device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN
-      --device=ANDROID_6_0_SAMSUNG_GALAXY_S7
-      --device=ANDROID_6_0_GOOGLE_NEXUS_6
+      --device=ANDROID_7_1
     concurrency: 9
     concurrency_group: 'browserstack-app'
     concurrency_method: eager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# 6.16.0 - TBD
+# 6.16.0 - 2022/05/10
 
 ## Enhancements
 
 - Allow appium driver start failures to be retried within 60s [359](https://github.com/bugsnag/maze-runner/pull/359)
+- Add `Maze.config.captured_invalid_requests` to allow invalid requests to be ignored on specific endpoints [362](https://github.com/bugsnag/maze-runner/pull/362)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.4)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -104,7 +104,7 @@ GEM
     minitest (5.15.0)
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.13.5-x86_64-darwin)
+    nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -9,7 +9,7 @@ module Maze
       self.receive_no_requests_wait = 30
       self.receive_requests_wait = 30
       self.enforce_bugsnag_integrity = true
-      self.captured_invalid_requests = Set[:errors, :sessions, :builds, :uploads]
+      self.captured_invalid_requests = Set[:errors, :sessions, :builds, :uploads, :sourcemaps]
     end
 
     #

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -9,7 +9,7 @@ module Maze
       self.receive_no_requests_wait = 30
       self.receive_requests_wait = 30
       self.enforce_bugsnag_integrity = true
-      self.captured_invalid_requests = [:errors, :sessions, :builds, :uploads]
+      self.captured_invalid_requests = Set[:errors, :sessions, :builds, :uploads]
     end
 
     #

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -9,6 +9,7 @@ module Maze
       self.receive_no_requests_wait = 30
       self.receive_requests_wait = 30
       self.enforce_bugsnag_integrity = true
+      self.captured_invalid_requests = [:errors, :sessions, :builds, :uploads]
     end
 
     #
@@ -55,6 +56,9 @@ module Maze
 
     # Enables bugsnag reporting
     attr_accessor :enable_bugsnag
+
+    # The server endpoints for which invalid requests should be captured and cause tests to fail
+    attr_accessor :captured_invalid_requests
 
     #
     # General appium configuration

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -47,10 +47,10 @@ module Maze
 
       # Provides dynamic access to request lists by name
       #
-      # @param type [String] Request type
+      # @param type [String, Symbol] Request type
       # @return Request list for the type given
       def list_for(type)
-        type = type.to_s if type.is_a? Symbol
+        type = type.to_s
         case type
         when 'error', 'errors'
           errors
@@ -165,9 +165,9 @@ module Maze
             server.mount '/notify', Servlets::Servlet, :errors
             server.mount '/sessions', Servlets::Servlet, :sessions
             server.mount '/builds', Servlets::Servlet, :builds
-            server.mount '/uploads', Servlets::Servlet, uploads
-            server.mount '/sourcemap', Servlets::Servlet, sourcemaps
-            server.mount '/react-native-source-map', Servlets::Servlet, sourcemaps
+            server.mount '/uploads', Servlets::Servlet, :uploads
+            server.mount '/sourcemap', Servlets::Servlet, :sourcemaps
+            server.mount '/react-native-source-map', Servlets::Servlet, :sourcemaps
             server.mount '/command', Servlets::CommandServlet
             server.mount '/logs', Servlets::LogServlet
             server.start

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -50,6 +50,7 @@ module Maze
       # @param type [String] Request type
       # @return Request list for the type given
       def list_for(type)
+        type = type.to_s if type.is_a? Symbol
         case type
         when 'error', 'errors'
           errors
@@ -161,9 +162,9 @@ module Maze
             end
 
             # When adding more endpoints, be sure to update the 'I should receive no requests' step
-            server.mount '/notify', Servlets::Servlet, errors
-            server.mount '/sessions', Servlets::Servlet, sessions
-            server.mount '/builds', Servlets::Servlet, builds
+            server.mount '/notify', Servlets::Servlet, :errors
+            server.mount '/sessions', Servlets::Servlet, :sessions
+            server.mount '/builds', Servlets::Servlet, :builds
             server.mount '/uploads', Servlets::Servlet, uploads
             server.mount '/sourcemap', Servlets::Servlet, sourcemaps
             server.mount '/react-native-source-map', Servlets::Servlet, sourcemaps

--- a/test/fixtures/android-appium-test/features/handled_exception.feature
+++ b/test/fixtures/android-appium-test/features/handled_exception.feature
@@ -14,14 +14,15 @@ Scenario: Test Handled Android Exception
 Scenario: Test driving a scenario using commands
   Given I issue a command to notify a "Big bang" handled error
   And I issue a command to notify a "Small bang" handled error
-
-  Then I run the next command
   And I run the next command
-  And I wait to receive 2 errors
+  And I wait to receive an error
 
   Then the exception "message" equals "Big bang"
   And I discard the oldest error
-  And the exception "message" equals "Small bang"
+  And I run the next command
+  And I wait to receive an error
+
+  Then the exception "message" equals "Small bang"
 
 Scenario: Verify text entry and clearing steps
   Given the element "trigger_error" is present

--- a/test/fixtures/http-response/features/invalid_requests.feature
+++ b/test/fixtures/http-response/features/invalid_requests.feature
@@ -1,0 +1,6 @@
+Feature: Tests with invalid requests
+
+  Scenario: Ignore invalid errors
+    When I ignore invalid errors
+    And I run the script "features/scripts/send_invalid_error.rb" using ruby synchronously
+    And I wait to receive an error

--- a/test/fixtures/http-response/features/scripts/send_invalid_error.rb
+++ b/test/fixtures/http-response/features/scripts/send_invalid_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'net/http'
+
+http = Net::HTTP.new('localhost', '9339')
+first_request = Net::HTTP::Post.new('/notify')
+first_request['Content-Type'] = 'application/json'
+first_request.body = '{"req": "first!"}'
+http.request(first_request)
+
+second_request = Net::HTTP::Post.new('/notify')
+second_request['Content-Type'] = 'application/json'
+second_request.body = %({what bad form})
+http.request(second_request)

--- a/test/fixtures/http-response/features/steps/steps.rb
+++ b/test/fixtures/http-response/features/steps/steps.rb
@@ -1,0 +1,3 @@
+When('I ignore invalid {word}') do |type|
+  Maze.config.captured_invalid_requests -= [type.to_sym]
+end

--- a/test/fixtures/http-response/features/steps/steps.rb
+++ b/test/fixtures/http-response/features/steps/steps.rb
@@ -1,3 +1,3 @@
 When('I ignore invalid {word}') do |type|
-  Maze.config.captured_invalid_requests -= [type.to_sym]
+  Maze.config.captured_invalid_requests.delete(type.to_sym)
 end


### PR DESCRIPTION
## Goal

Allow invalid requests to be ignored on specific endpoints.

## Design

By default, Maze will captured invalid (e.g. unparsable as JSON) requests that are received and fail the scenario.  This isn't always desirable, though, so a new config value `captured_invalid_requests` is added to specify the types of requests that should be monitored for invalidity.

To use, a test suite would remove the request type it wants to remove in its `BeforeAll` hook, e.g:

```
Maze.config.captured_invalid_requests -= [:sessions]
```

## Changeset

Includes a slight refactor to pass a symbol from `Server` to each `Servlet` so that the `Servlet` know what type of request it is handling.

## Tests

New test added, which fails if the `When I ignore invalid errors` step is commented out.