### PR TITLE
Update Appium and Selenium dependencies (enforcing w3c capabilities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 7.0.0 - TBD
 
+## Enhancements
+
+- Update appium_lib (v12) and selenium-webdriver (v4), enforcing W3C [364](https://github.com/bugsnag/maze-runner/pull/364)
+
 ## Removals
 
 - Remove support for Sauce Labs [376](https://github.com/bugsnag/maze-runner/pull/376)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       os (~> 1.0.0)
       rake (~> 12.3.3)
       rubyzip (~> 2.3.2)
-      selenium-webdriver (~> 4.0)
+      selenium-webdriver (= 4.2.1)
       test-unit (~> 3.5.2)
       webrick (~> 1.7.0)
 
@@ -116,7 +116,7 @@ GEM
     redcarpet (3.5.1)
     rexml (3.2.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.3.0)
+    selenium-webdriver (4.2.1)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,6 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
   remote: .
   specs:
     bugsnag-maze-runner (7.0.0)
-      appium_lib (~> 11.2.0)
+      appium_lib (~> 12.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
@@ -19,7 +19,7 @@ PATH
       os (~> 1.0.0)
       rake (~> 12.3.3)
       rubyzip (~> 2.3.2)
-      selenium-webdriver (~> 3.11)
+      selenium-webdriver (~> 4.0)
       test-unit (~> 3.5.2)
       webrick (~> 1.7.0)
 
@@ -31,17 +31,17 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    appium_lib (11.2.0)
-      appium_lib_core (~> 4.1)
+    appium_lib (12.0.1)
+      appium_lib_core (~> 5.0)
       nokogiri (~> 1.8, >= 1.8.1)
-      tomlrb (~> 1.1)
-    appium_lib_core (4.7.1)
+      tomlrb (>= 1.1, < 3.0)
+    appium_lib_core (5.2.2)
       faye-websocket (~> 0.11.0)
-      selenium-webdriver (~> 3.14, >= 3.14.1)
+      selenium-webdriver (~> 4.2, < 4.4)
     bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
-    childprocess (3.0.0)
+    childprocess (4.1.0)
     concurrent-ruby (1.1.10)
     cucumber (7.1.0)
       builder (~> 3.2, >= 3.2.4)
@@ -101,7 +101,7 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    minitest (5.15.0)
+    minitest (5.16.1)
     mocha (1.13.0)
     multi_test (0.1.2)
     nokogiri (1.13.6-x86_64-darwin)
@@ -116,9 +116,11 @@ GEM
     redcarpet (3.5.1)
     rexml (3.2.5)
     rubyzip (2.3.2)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.3.0)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     test-unit (3.5.3)
@@ -129,10 +131,11 @@ GEM
       props (>= 1.1.2)
       rubyzip (>= 1.0.0)
     thor (1.0.1)
-    tomlrb (1.3.0)
+    tomlrb (2.0.3)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     webrick (1.7.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -143,7 +146,6 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES
@@ -156,4 +158,4 @@ DEPENDENCIES
   yard-cucumber!
 
 BUNDLED WITH
-   2.3.11
+   2.3.0

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -3,6 +3,8 @@
 
 require 'cucumber/cli/main'
 
+require_relative '../lib/utils/deep_merge'
+
 require_relative '../lib/maze'
 
 require_relative '../lib/maze/appium_server'

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'curb', '~> 0.9.6'
   spec.add_dependency 'optimist', '~> 3.0.1'
   spec.add_dependency 'rake', '~> 12.3.3'
-  spec.add_dependency 'selenium-webdriver', '~> 4.0'
+  spec.add_dependency 'selenium-webdriver', '4.2.1'
 
   # Pin indirect dependencies
   spec.add_runtime_dependency 'rubyzip', '~> 2.3.2'

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -22,13 +22,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'test-unit', '~> 3.5.2'
   spec.add_dependency 'webrick', '~> 1.7.0'
 
-  spec.add_dependency 'appium_lib', '~> 11.2.0'
+  spec.add_dependency 'appium_lib', '~> 12.0'
   spec.add_dependency 'bugsnag', '~> 6.24'
   spec.add_dependency 'cucumber-expressions', '~> 6.0.0'
   spec.add_dependency 'curb', '~> 0.9.6'
   spec.add_dependency 'optimist', '~> 3.0.1'
   spec.add_dependency 'rake', '~> 12.3.3'
-  spec.add_dependency 'selenium-webdriver', '~> 3.11'
+  spec.add_dependency 'selenium-webdriver', '~> 4.0'
 
   # Pin indirect dependencies
   spec.add_runtime_dependency 'rubyzip', '~> 2.3.2'

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -9,6 +9,7 @@ module Maze
     APPIUM_1_15_0 = '1.15.0'
     APPIUM_1_20_2 = '1.20.2'
     APPIUM_1_21_0 = '1.21.0'
+    APPIUM_1_22_0 = '1.22.0'
 
     class << self
 
@@ -34,16 +35,17 @@ module Maze
 
       def make_android_hash(device, version, appium_version = APPIUM_1_20_2)
         hash = {
-          'device' => device,
-          'os_version' => version,
+          'platformName' => 'android',
+          'platformVersion' => version,
+          'deviceName' => device,
           'autoGrantPermissions' => 'true',
-          'platformName' => 'Android',
-          'os' => 'android',
-          'browserstack.appium_version' => appium_version
+          'bstack:options' => {
+            "appiumVersion" => appium_version,
+          },
         }
         # disableAnimations only allowed > Android 6
         if version.to_i > 6
-          hash['disableAnimations'] = 'true'
+          hash['bstack:options']['disableAnimations'] = 'true'
         end
         hash.freeze
       end
@@ -60,12 +62,13 @@ module Maze
 
       def make_ios_hash(device, version, appium_version = APPIUM_1_21_0)
         {
-          'device' => device,
-          'os_version' => version,
-          'platformName' => 'iOS',
-          'os' => 'ios',
-          'disableAnimations' => 'true',
-          'browserstack.appium_version' => appium_version
+          'platformName' => 'ios',
+          'platformVersion' => version,
+          'deviceName' => device,
+          'bstack:options' => {
+            'appiumVersion' => appium_version,
+            'disableAnimations' => 'true'
+          },
         }.freeze
       end
 

--- a/lib/maze/browsers_bs.yml
+++ b/lib/maze/browsers_bs.yml
@@ -1,196 +1,195 @@
 # Selenium capabilities for browsers available on BrowserStack
 ---
 ie_8:
-  browser: "ie"
-  browser_version: "8"
+  browserName: "ie"
+  browserVersion: "8"
   os: "windows"
-  os_version: "7"
+  osVersion: "7"
 
 ie_9:
-  browser: "ie"
-  browser_version: "9"
+  browserName: "ie"
+  browserVersion: "9"
   os: "windows"
-  os_version: "7"
+  osVersion: "7"
 
 ie_10:
-  browser: "ie"
-  browser_version: "10"
+  browserName: "ie"
+  browserVersion: "10"
   os: "windows"
-  os_version: "8"
+  osVersion: "8"
 
 ie_11:
-  browser: "ie"
-  browser_version: "11"
+  browserName: "ie"
+  browserVersion: "11"
   os: "windows"
-  os_version: "10"
+  osVersion: "10"
 
 edge_14:
-  browser: "edge"
-  browser_version: "14"
+  browserName: "edge"
+  browserVersion: "14"
   os: "windows"
-  os_version: "10"
+  osVersion: "10"
 
 edge_15:
-  browser: "edge"
-  browser_version: "15"
+  browserName: "edge"
+  browserVersion: "15"
   os: "windows"
-  os_version: "10"
+  osVersion: "10"
 
 safari_6:
-  browser: "safari"
-  browser_version: "6"
+  browserName: "safari"
+  browserVersion: "6"
   os: "OS X"
-  os_version: "lion"
+  osVersion: "lion"
 
 safari_10:
-  browser: "safari"
-  browser_version: "10.0"
+  browserName: "safari"
+  browserVersion: "10.0"
   os: "OS X"
-  os_version: "sierra"
+  osVersion: "sierra"
 
 safari_13:
-  browser: "Safari"
-  browser_version: "13.0"
+  browserName: "Safari"
+  browserVersion: "13.0"
   os: "OS X"
-  os_version: "Catalina"
+  osVersion: "Catalina"
 
 safari_14:
-  browser: "Safari"
-  browser_version: "14.0"
+  browserName: "Safari"
+  browserVersion: "14.0"
   os: "OS X"
-  os_version: "Big Sur"
+  osVersion: "Big Sur"
 
 safari_15:
-  browser: "Safari"
-  browser_version: "15.0"
+  browserName: "Safari"
+  browserVersion: "15.0"
   os: "OS X"
-  os_version: "Monterey"
+  osVersion: "Monterey"
 
 iphone_6s:
-  browser: "iphone"
+  browserName: "iphone"
   device: "iPhone 6S"
   os: "ios"
-  os_version: "9.0"
-  real_mobile: true
+  osVersion: "9.0"
+  realMobile: true
 
 iphone_7:
-  browser: "iphone"
+  browserName: "iphone"
   device: "iPhone 7"
   os: "ios"
-  os_version: "10.3"
-  real_mobile: true
+  osVersion: "10.3"
+  realMobile: true
 
 iphone_13:
-  browser: "iphone"
+  browserName: "iphone"
   device: "iPhone 13"
   os: "ios"
-  os_version: "15.4"
-  real_mobile: true
+  osVersion: "15.4"
+  realMobile: true
 
 android_nexus5:
-  browser: "Android Browser"
+  browserName: "Android Browser"
   device: "Google Nexus 5"
   os: "android"
-  os_version: "4.4"
-  real_mobile: true
+  osVersion: "4.4"
+  realMobile: true
 
 android_s6:
-  browser: "Android Browser"
+  browserName: "Android Browser"
   device: "Samsung Galaxy S6"
   os: "android"
-  os_version: "5.0"
-  real_mobile: true
+  osVersion: "5.0"
+  realMobile: true
 
 android_s7:
-  browser: "Android Browser"
+  browserName: "Android Browser"
   device: "Samsung Galaxy S7"
   os: "android"
-  os_version: "6.0"
-  real_mobile: true
+  osVersion: "6.0"
+  realMobile: true
 
 android_s8:
-  browser: "Android Browser"
+  browserName: "Android Browser"
   device: "Samsung Galaxy S8 Plus"
   os: "android"
-  os_version: "7.0"
-  real_mobile: true
+  osVersion: "7.0"
+  realMobile: true
 
 firefox_30:
-  browser: "firefox"
-  browser_version: "30"
+  browserName: "firefox"
+  browserVersion: "30"
   os: "windows"
-  os_version: "7"
+  osVersion: "7"
 
 firefox_56:
-  browser: "firefox"
-  browser_version: "56"
+  browserName: "firefox"
+  browserVersion: "56"
   os: "windows"
-  os_version: "10"
+  osVersion: "10"
 
 firefox_latest:
-  browser: "firefox"
-  browser_version: "latest"
+  browserName: "firefox"
+  browserVersion: "latest"
   os: "windows"
-  os_version: "10"
-  selenium_version: "3.10.0"
+  osVersion: "10"
 
 chrome_30:
-  browser: "chrome"
-  browser_version: "30.0"
+  browserName: "chrome"
+  browserVersion: "30.0"
   os: "windows"
-  os_version: "7"
+  osVersion: "7"
 
 chrome_32:
-  browser: "chrome"
-  browser_version: "32.0"
+  browserName: "chrome"
+  browserVersion: "32.0"
   os: "windows"
-  os_version: "7"
+  osVersion: "7"
 
 chrome_34:
-  browser: "chrome"
-  browser_version: "34.0"
+  browserName: "chrome"
+  browserVersion: "34.0"
   os: "windows"
-  os_version: "7"
+  osVersion: "7"
 
 chrome_36:
-  browser: "chrome"
-  browser_version: "36.0"
+  browserName: "chrome"
+  browserVersion: "36.0"
   os: "windows"
-  os_version: "7"
+  osVersion: "7"
 
 chrome_38:
-  browser: "chrome"
-  browser_version: "38.0"
+  browserName: "chrome"
+  browserVersion: "38.0"
   os: "windows"
-  os_version: "7"
+  osVersion: "7"
 
 chrome_40:
-  browser: "chrome"
-  browser_version: "40.0"
+  browserName: "chrome"
+  browserVersion: "40.0"
   os: "windows"
-  os_version: "7"
+  osVersion: "7"
 
 chrome_42:
-  browser: "chrome"
-  browser_version: "42.0"
+  browserName: "chrome"
+  browserVersion: "42.0"
   os: "windows"
-  os_version: "7"
+  osVersion: "7"
 
 chrome_43:
-  browser: "chrome"
-  browser_version: "43.0"
+  browserName: "chrome"
+  browserVersion: "43.0"
   os: "windows"
-  os_version: "7"
+  osVersion: "7"
 
 chrome_61:
-  browser: "chrome"
-  browser_version: "61.0"
+  browserName: "chrome"
+  browserVersion: "61.0"
   os: "windows"
-  os_version: "10"
+  osVersion: "10"
 
 chrome_latest:
-  browser: "chrome"
-  browser_version: "latest"
+  browserName: "chrome"
+  browserVersion: "latest"
   os: "windows"
-  os_version: "10"
-  selenium_version: "3.14.0"
+  osVersion: "10"
+  seleniumVersion: "3.14.0"

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -25,14 +25,18 @@ module Maze
       # @param local_id [String] unique key for the tunnel instance
       # @param capabilities_option [String] extra capabilities provided on the command line
       def for_browser_stack_browser(browser_type, local_id, capabilities_option)
-        capabilities = Selenium::WebDriver::Remote::Capabilities.new
-        capabilities['browserstack.local'] = 'true'
-        capabilities['browserstack.localIdentifier'] = local_id
-        capabilities['browserstack.console'] = 'errors'
+        capabilities = {
+          'bstack:options' => {
+            'local' => 'true',
+            'localIdentifier' => local_id,
+            "os" => "Windows",
+            "osVersion" => "8.1"
+          }
+        }
         browsers = YAML.safe_load(File.read("#{__dir__}/browsers_bs.yml"))
-        capabilities.merge! browsers[browser_type]
-        capabilities.merge! JSON.parse(capabilities_option)
-        capabilities
+        capabilities.deep_merge! browsers[browser_type]
+        capabilities.deep_merge! JSON.parse(capabilities_option)
+        Selenium::WebDriver::Remote::Capabilities.new capabilities
       end
 
       # @param browser_type [String] A key from @see browsers_cbt.yml

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -9,14 +9,16 @@ module Maze
       # @param capabilities_option [String] extra capabilities provided on the command line
       def for_browser_stack_device(device_type, local_id, appium_version, capabilities_option)
         capabilities = {
-          'browserstack.console' => 'errors',
-          'browserstack.localIdentifier' => local_id,
-          'browserstack.local' => 'true',
+          'bstack:options' => {
+            'local' => 'true',
+            'localIdentifier' => local_id,
+            'console' => 'errors',
+          },
           'noReset' => 'true'
         }
         capabilities.merge! BrowserStackDevices::DEVICE_HASH[device_type]
         capabilities.merge! JSON.parse(capabilities_option)
-        capabilities['browserstack.appium_version'] = appium_version unless appium_version.nil?
+        capabilities['bstack:options']['appiumVersion'] = appium_version unless appium_version.nil?
         capabilities
       end
 

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -11,13 +11,12 @@ module Maze
         capabilities = {
           'bstack:options' => {
             'local' => 'true',
-            'localIdentifier' => local_id,
-            'console' => 'errors',
+            'localIdentifier' => local_id
           },
           'noReset' => 'true'
         }
-        capabilities.merge! BrowserStackDevices::DEVICE_HASH[device_type]
-        capabilities.merge! JSON.parse(capabilities_option)
+        capabilities.deep_merge! BrowserStackDevices::DEVICE_HASH[device_type]
+        capabilities.deep_merge! JSON.parse(capabilities_option)
         capabilities['bstack:options']['appiumVersion'] = appium_version unless appium_version.nil?
         capabilities
       end

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -10,8 +10,8 @@ module Maze
     # Provide a thin layer of abstraction above @see Appium::Driver
     class Appium < Appium::Driver
 
-      # @!attribute [rw] device_type
-      #   @return [String] The device, from the list of device capabilities, used for this test
+      # @!attribute [rw] app_id
+      #   @return [String] The app_id derived from session_capabilities (appPackage on Android, bundleID on iOS)
       attr_accessor :app_id
 
       # @!attribute [r] device_type

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -10,6 +10,10 @@ module Maze
     # Provide a thin layer of abstraction above @see Appium::Driver
     class Appium < Appium::Driver
 
+      # @!attribute [rw] device_type
+      #   @return [String] The device, from the list of device capabilities, used for this test
+      attr_accessor :app_id
+
       # @!attribute [r] device_type
       #   @return [String] The device, from the list of device capabilities, used for this test
       attr_reader :device_type

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -122,7 +122,7 @@ module Maze
           if driver_for == :remote
             driver = ::Selenium::WebDriver.for :remote,
                                                 url: selenium_url,
-                                                desired_capabilities: @capabilities
+                                                capabilities: @capabilities
           else
             driver = ::Selenium::WebDriver.for driver_for
           end

--- a/lib/maze/helper.rb
+++ b/lib/maze/helper.rb
@@ -101,7 +101,7 @@ module Maze
           os = os&.downcase
         end
 
-        
+
         raise('Unable to determine the current platform') if os.nil?
 
         os

--- a/lib/maze/helper.rb
+++ b/lib/maze/helper.rb
@@ -94,13 +94,14 @@ module Maze
         else
           os = case Maze.config.farm
                when :bs
-                 Maze.config.capabilities['os']
+                 Maze.config.capabilities['platformName']
                else
                  Maze.config.os
                end
           os = os&.downcase
         end
 
+        
         raise('Unable to determine the current platform') if os.nil?
 
         os

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -36,6 +36,13 @@ module Maze
 
         start_driver(config, tunnel_id)
 
+        # Set bundle/app id for later use
+        Maze.driver.app_id = case Maze::Helper.get_current_platform
+                             when 'android'
+                               Maze.driver.session_capabilities['appPackage']
+                             when 'ios'
+                               Maze.driver.session_capabilities['bundleId']
+                             end
         # Ensure the device is unlocked
         Maze.driver.unlock
 
@@ -59,7 +66,8 @@ module Maze
         elsif [:bb].include? Maze.config.farm
           Maze.driver.launch_app
         else
-          Maze.driver.reset
+          Maze.driver.terminate_app Maze.driver.app_id
+          Maze.driver.activate_app Maze.driver.app_id
         end
       end
 

--- a/lib/utils/deep_merge.rb
+++ b/lib/utils/deep_merge.rb
@@ -1,0 +1,17 @@
+class Hash
+  def deep_merge!(other_hash, &block)
+    merge!(other_hash) do |key, this_val, other_val|
+      if this_val.is_a?(Hash) && other_val.is_a?(Hash)
+        this_val.deep_merge(other_val, &block)
+      elsif block_given?
+        block.call(key, this_val, other_val)
+      else
+        other_val
+      end
+    end
+  end
+
+  def deep_merge(other_hash, &block)
+    dup.deep_merge!(other_hash, &block)
+  end
+end

--- a/test/capabilities/devices_test.rb
+++ b/test/capabilities/devices_test.rb
@@ -8,9 +8,9 @@ class DevicesTest < Test::Unit::TestCase
   def test_os_version
     # Ensure that every entry in the hash has a meaningful OS version
     Maze::BrowserStackDevices::DEVICE_HASH.each do |key, value|
-      os_version = value['os_version']
+      platform_version = value['platformVersion']
       regex = /^[1-9][0-9]*(\.[0-9])?/
-      assert_match(regex, os_version) unless %w(sl_android sl_ios).include?(key)
+      assert_match(regex, platform_version) unless %w(sl_android sl_ios).include?(key)
     end
   end
 end

--- a/test/fixtures/ios-app/features/steps/test_steps.rb
+++ b/test/fixtures/ios-app/features/steps/test_steps.rb
@@ -53,6 +53,7 @@ When('I relaunch the app') do
     system("killall -KILL #{app} > /dev/null && sleep 1")
     Maze.driver.get(app)
   else
+    Maze.driver.terminate_app Maze.driver.app_id
     Maze.driver.activate_app Maze.driver.app_id
   end
 end

--- a/test/fixtures/ios-app/features/steps/test_steps.rb
+++ b/test/fixtures/ios-app/features/steps/test_steps.rb
@@ -53,7 +53,7 @@ When('I relaunch the app') do
     system("killall -KILL #{app} > /dev/null && sleep 1")
     Maze.driver.get(app)
   else
-    Maze.driver.launch_app
+    Maze.driver.activate_app Maze.driver.app_id
   end
 end
 
@@ -65,7 +65,7 @@ When("I relaunch the app after a crash") do
   when 'Mac'
     Maze.driver.get(Maze.driver.capabilities['app'])
   else
-    Maze.driver.launch_app
+    Maze.driver.activate_app Maze.driver.app_id
   end
 end
 

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -34,7 +34,6 @@ class ProcessorTest < Test::Unit::TestCase
     assert_equal 'user', config.username
     assert_equal 'key', config.access_key
     assert_equal 'ANDROID_6_0', config.device
-    assert_equal 6, config.os_version
     assert_equal :id, config.locator
     assert_equal 'http://user:key@hub-cloud.browserstack.com/wd/hub', config.appium_server_url
   end


### PR DESCRIPTION
## Goal

Update the Appium and Selenium dependencies to the latest available, which will hopefully lead to greater stability in the longer term.

## Design

Upgrading to Appium 12 means using Selenium 4, which enforces use of w3c capabilities.  That in turn means using Appium 1.15 or later, which would cause a problem for our iOS 10/11 tests.  They are currently using Appium 1.8 to dodge various bugs on either side that caused our tests to flake (heavily at times).  

I'm therefore parking this as a draft for the time being while we consider where we take our testing of these versions.

## Changeset

- Appium/Selenium versions bumped.  
- Capabilities updated to comply with w3c
- Deprecation warnings resolved by moving to new driver methods (`terminate_app` etc)

## Tests

So far tested with the full bugsnag-cocoa pipeline, subset of bugsnag-android tests and the (limited) Maze Runner browser tests.  We should conduct some further testing before releasing this, hence why I have now created an integration branch.