### PR TITLE
Update start-driver retry logic to re-enable device lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.18.1 - 2022/05/31
+
+## Fixes
+
+- Update start-driver retry logic to enable device lists [366](https://github.com/bugsnag/maze-runner/pull/366)
+
 # 6.18.0 - 2022/05/30
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.18.0)
+    bugsnag-maze-runner (6.18.1)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -143,7 +143,6 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  ruby
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.18.0'
+  VERSION = '6.18.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -51,24 +51,15 @@ module Maze
 
       # Starts the Appium driver
       def start_driver
-        wait = Maze::Wait.new(interval: 10, timeout: 60)
-        success = wait.until do
-          begin
-            $logger.info 'Starting Appium driver...'
-            time = Time.now
-            super
-            $logger.info "Appium driver started in #{(Time.now - time).to_i}s"
-            true
-          rescue => error
-            $logger.warn "Appium driver failed to start in #{(Time.now - time).to_i}s"
-            $logger.warn "#{error.class} occurred with message: #{error.message}"
-            false
-          end
-        end
-
-        unless success
-          $logger.error 'Appium driver failed to start after 6 attempts in 60 seconds'
-          raise RuntimeError.new('Appium driver failed to start in 60 seconds')
+        begin
+          $logger.info 'Starting Appium driver...'
+          time = Time.now
+          super
+          $logger.info "Appium driver started in #{(Time.now - time).to_i}s"
+        rescue => error
+          $logger.warn "Appium driver failed to start in #{(Time.now - time).to_i}s"
+          $logger.warn "#{error.class} occurred with message: #{error.message}"
+          raise error
         end
       end
 

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -130,7 +130,7 @@ module Maze
       end
 
       def start_driver(config, tunnel_id = nil)
-        retry_failure = !config.device_list.empty?
+        retry_failure = config.device_list.empty?
         until Maze.driver
           begin
             config.capabilities = device_capabilities(config, tunnel_id)
@@ -138,7 +138,7 @@ module Maze
 
             start_driver_closure = Proc.new do
               begin
-                driver.start_driver unless config.appium_session_isolation
+                driver.start_driver
                 true
               rescue => start_error
                 raise start_error unless retry_failure
@@ -146,16 +146,18 @@ module Maze
               end
             end
 
-            if retry_failure
-              wait = Maze::Wait.new(interval: 10, timeout: 60)
-              success = wait.until(&start_driver_closure)
+            unless config.appium_session_isolation
+              if retry_failure
+                wait = Maze::Wait.new(interval: 10, timeout: 60)
+                success = wait.until(&start_driver_closure)
 
-              unless success
-                $logger.error 'Appium driver failed to start after 6 attempts in 60 seconds'
-                raise RuntimeError.new('Appium driver failed to start in 60 seconds')
+                unless success
+                  $logger.error 'Appium driver failed to start after 6 attempts in 60 seconds'
+                  raise RuntimeError.new('Appium driver failed to start in 60 seconds')
+                end
+              else
+                start_driver_closure.call
               end
-            else
-              start_driver_closure.call
             end
 
             # Infer OS version if necessary when running locally

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -130,37 +130,56 @@ module Maze
       end
 
       def start_driver(config, tunnel_id = nil)
+        retry_failure = !config.device_list.empty?
         until Maze.driver
-          begin
-            config.capabilities = device_capabilities(config, tunnel_id)
-            driver = create_driver(config)
-            driver.start_driver unless config.appium_session_isolation
+          config.capabilities = device_capabilities(config, tunnel_id)
+          driver = create_driver(config)
 
-            # Infer OS version if necessary when running locally
-            if Maze.config.farm == :local && Maze.config.os_version.nil?
-              version = case Maze.config.os
-              when 'android'
-                driver.session_capabilities['platformVersion'].to_f
-              when 'ios'
-                driver.session_capabilities['sdkVersion'].to_f
-              end
-              $logger.info "Inferred OS version to be #{version}"
-              Maze.config.os_version = version
+          start_driver_closure = Proc.new do
+            begin
+              driver.start_driver unless config.appium_session_isolation
+              true
+            rescue => start_error
+              raise start_error unless retry_failure
+              false
             end
+          end
 
+          if retry_failure
+            wait = Maze::Wait.new(interval: 10, timeout: 60)
+            success = wait.until(&start_driver_closure)
 
-            Maze.driver = driver
-          rescue Selenium::WebDriver::Error::UnknownError => original_exception
-            $logger.warn "Attempt to acquire #{config.device} device from farm #{config.farm} failed"
-            $logger.warn "Exception: #{original_exception.message}"
-            if config.device_list.empty?
-              $logger.error 'No further devices to try - raising original exception'
-              raise original_exception
-            else
-              config.device = config.device_list.first
-              config.device_list = config.device_list.drop(1)
-              $logger.warn "Retrying driver initialisation using next device: #{config.device}"
+            unless success
+              $logger.error 'Appium driver failed to start after 6 attempts in 60 seconds'
+              raise RuntimeError.new('Appium driver failed to start in 60 seconds')
             end
+          else
+            start_driver_closure.call
+          end
+
+          # Infer OS version if necessary when running locally
+          if Maze.config.farm == :local && Maze.config.os_version.nil?
+            version = case Maze.config.os
+            when 'android'
+              driver.session_capabilities['platformVersion'].to_f
+            when 'ios'
+              driver.session_capabilities['sdkVersion'].to_f
+            end
+            $logger.info "Inferred OS version to be #{version}"
+            Maze.config.os_version = version
+          end
+
+          Maze.driver = driver
+        rescue Selenium::WebDriver::Error::UnknownError => original_exception
+          $logger.warn "Attempt to acquire #{config.device} device from farm #{config.farm} failed"
+          $logger.warn "Exception: #{original_exception.message}"
+          if config.device_list.empty?
+            $logger.error 'No further devices to try - raising original exception'
+            raise original_exception
+          else
+            config.device = config.device_list.first
+            config.device_list = config.device_list.drop(1)
+            $logger.warn "Retrying driver initialisation using next device: #{config.device}"
           end
         end
       end

--- a/test/appium_driver_test.rb
+++ b/test/appium_driver_test.rb
@@ -277,52 +277,5 @@ class AppiumDriverTest < Test::Unit::TestCase
 
     driver.start_driver
   end
-
-  def test_start_driver_retry_then_success
-    logger = start_logger_mock
-
-    driver = Maze::Driver::Appium.new SERVER_URL, @capabilities, :accessibility_id
-
-    Time.expects(:now).times(4).returns(0)
-    logger.expects(:info).with('Starting Appium driver...').twice
-    logger.expects(:warn).with('Appium driver failed to start in 0s')
-
-    driver_failure = RuntimeError.new('Appium driver failed')
-    logger.expects(:warn).with("#{driver_failure.class} occurred with message: #{driver_failure.message}")
-
-    Maze::Wait.any_instance.expects(:sleep).with(10)
-
-    Appium::Driver.any_instance.expects(:start_driver).twice.raises(driver_failure).then.returns(true)
-
-    logger.expects(:info).with('Appium driver started in 0s')
-
-    driver.start_driver
-  end
-
-  def test_start_driver_retry_to_failure
-    logger = start_logger_mock
-
-    driver = Maze::Driver::Appium.new SERVER_URL, @capabilities, :accessibility_id
-
-    Time.expects(:now).times(12).returns(0)
-    logger.expects(:info).with('Starting Appium driver...').times(6)
-    logger.expects(:warn).with('Appium driver failed to start in 0s').times(6)
-
-    driver_failure = RuntimeError.new('Appium driver failed')
-    logger.expects(:warn).with("#{driver_failure.class} occurred with message: #{driver_failure.message}").times(6)
-
-    Maze::Wait.any_instance.expects(:sleep).with(10).times(6)
-
-    Appium::Driver.any_instance.expects(:start_driver).times(6).raises(driver_failure)
-
-    logger.expects(:error).with('Appium driver failed to start after 6 attempts in 60 seconds')
-
-    begin
-      driver.start_driver
-    rescue => e
-      assert_equal e.class, RuntimeError
-      assert_equal e.message, 'Appium driver failed to start in 60 seconds'
-    end
-  end
 end
 


### PR DESCRIPTION
## Goal

Updates the logic of retrying driver initialisation to:
- Retry 6 times on driver failures if a single device is provided
- Retry by iterating through the given list of devices if one is present

## Tests

I've updated the current tests, and run some functional tests using existing e2e test fixtures which have worked as expected - this should be ready for review now.