### PR TITLE
Add  option to list available device farm devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.17.0 - TBD
+
+## Enhancements
+
+- Add --list-devices option [368](https://github.com/bugsnag/maze-runner/pull/368)
+
 # 6.16.0 - 2022/05/10
 
 ## Enhancements

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -91,12 +91,26 @@ class MazeRunnerEntry
     paths.each { |path| @args << '-r' << path }
   end
 
+  # List devices for the given device farm, or all otherwise
+
   def start(args)
     $logger.info "Maze Runner v#{Maze::VERSION}"
 
     # Parse args, processing any Maze Runner specific options
     @args = args.dup
     options = Maze::Option::Parser.parse args
+
+    if options[Maze::Option::LIST_DEVICES]
+      case options[Maze::Option::FARM]
+      when :bs
+        Maze::BrowserStackDevices.list_devices('ios')
+        Maze::BrowserStackDevices.list_devices('android')
+      else
+        Maze::BrowserStackDevices.list_devices('ios')
+        Maze::BrowserStackDevices.list_devices('android')
+      end
+      exit 0
+    end
 
     # Validate CL options
     errors = Maze::Option::Validator.new.validate options

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.16.0'
+  VERSION = '6.17.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -11,6 +11,27 @@ module Maze
     APPIUM_1_21_0 = '1.21.0'
 
     class << self
+
+      def list_devices(os)
+        puts "BrowserStack #{os} devices available"
+        devices = DEVICE_HASH.dup
+        devices.select { |key, device|
+          device['os'].eql?(os)
+        }.map { |key, device|
+          new_device = device.dup
+          new_device['key'] = key
+          new_device
+        }.sort { |dev_1, dev_2|
+          dev_1['os_version'].to_f <=> dev_2['os_version'].to_f
+        }.each{ |device|
+          puts '------------------------------'
+          puts "Device key: #{device['key']}"
+          puts "Device: #{device['device']}"
+          puts "OS: #{device['os']}"
+          puts "OS version: #{device['os_version']}"
+        }
+      end
+
       def make_android_hash(device, version, appium_version = APPIUM_1_20_2)
         hash = {
           'device' => device,

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -29,6 +29,7 @@ module Maze
     BROWSER = 'browser'
     OS = 'os'
     OS_VERSION = 'os-version'
+    LIST_DEVICES = 'list-devices'
 
     # CrossBrowserTesting/Bitbar options
     SB_LOCAL = 'sb-local'

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -107,6 +107,10 @@ module Maze
             opt Option::APPIUM_VERSION,
                 'The Appium version to use',
                 type: :string
+            opt Option::LIST_DEVICES,
+                'Lists the devices available for the configured device-farm, or all devices if none are specified',
+                default: false
+
 
             # SmartBear-only options
             opt Option::SB_LOCAL,


### PR DESCRIPTION
## Goal
Adds an option to list all available device keys, along with the device and OS they represent in the command line.

Currently this only works for BrowserStack, but the method can be expanded upon to add more device farms as necessary.