### PR TITLE
Allow access to pids created by the Runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# TBD
+# 6.19.0 - 2022/06/14
 
 ## Enhancements
 
 - Add support for delivering and saving maze-runner reports [370](https://github.com/bugsnag/maze-runner/pull/370)
+- Allow access to pids created by the Runner [371](https://github.com/bugsnag/maze-runner/pull/371)
 
 # 6.18.1 - 2022/05/31
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.18.1)
+    bugsnag-maze-runner (6.19.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -143,6 +143,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.18.1'
+  VERSION = '6.19.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/runner.rb
+++ b/lib/maze/runner.rb
@@ -138,8 +138,9 @@ module Maze
         @environment ||= {}
       end
 
-      private
-
+      # Allows access to the process ids created by the runner.
+      #
+      # @return [Array] pids created by the runner
       def pids
         @pids ||= []
       end


### PR DESCRIPTION
## Goal

Allow access to pids created by the Runner.

## Design

This allows individual repos to perform special actions on processes created by the Runner without risking breaking the behaviour elsewhere (especially on different platforms).  E.g. it is useful to be able to use `pkill` to kill process groups, which Maze does not do.

## Changeset

`Maze::Runner.pids` made public.

## Tests

Covered by CI and I have verified locally that the change will do what is needed.