### PR TITLE
Update Maze::Helper.get_current_platform to support browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.19.1 - 2022/06/17
+
+## Fixes
+
+- Update `Maze::Helper.get_current_platform` to support `browser` [373](https://github.com/bugsnag/maze-runner/pull/373)
+
 # 6.19.0 - 2022/06/14
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.19.0)
+    bugsnag-maze-runner (6.19.1)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -101,7 +101,7 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    minitest (5.15.0)
+    minitest (5.16.0)
     mocha (1.13.0)
     multi_test (0.1.2)
     nokogiri (1.13.6-x86_64-darwin)
@@ -139,7 +139,7 @@ GEM
     with_env (1.1.0)
     xml-simple (1.1.9)
       rexml
-    yard (0.9.27)
+    yard (0.9.28)
       webrick (~> 1.7.0)
 
 PLATFORMS

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.19.0'
+  VERSION = '6.19.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/helper.rb
+++ b/lib/maze/helper.rb
@@ -87,17 +87,21 @@ module Maze
       end
 
       # Returns the current platform all lower-case.
-      # @@return Typically 'ios', 'android' or 'mac'.
+      # @return Typically 'ios', 'android', 'mac' or 'browser'
       def get_current_platform
-        os = case Maze.config.farm
-             when :bs
-               Maze.config.capabilities['os']
-             when :sl
-               Maze.driver.capabilities['platformName']
-             else
-               Maze.config.os
-             end
-        os = os&.downcase
+        if Maze.mode == :browser
+          os = 'browser'
+        else
+          os = case Maze.config.farm
+               when :bs
+                 Maze.config.capabilities['os']
+               when :sl
+                 Maze.driver.capabilities['platformName']
+               else
+                 Maze.config.os
+               end
+          os = os&.downcase
+        end
 
         raise('Unable to determine the current platform') if os.nil?
 

--- a/test/fixtures/android-appium-test/features/handled_exception.feature
+++ b/test/fixtures/android-appium-test/features/handled_exception.feature
@@ -37,6 +37,7 @@ Scenario: Verify text entry and clearing steps
 
 Scenario: Verify "equals the correct platform value" step
   Given the element "trigger_error" is present within 30 seconds
+  Then Maze Runner reports the current platform as "android"
   When I click the element "trigger_error"
   Then I wait to receive an error
   And the error Bugsnag-Integrity header is valid

--- a/test/fixtures/android-appium-test/features/steps/steps.rb
+++ b/test/fixtures/android-appium-test/features/steps/steps.rb
@@ -9,3 +9,7 @@ end
 When('I run the next command') do
   step 'I click the element "run_command"'
 end
+
+Then('Maze Runner reports the current platform as {string}') do |platform|
+  Maze.check.equal(platform, Maze::Helper.get_current_platform)
+end

--- a/test/fixtures/browser/features/handled_errors.feature
+++ b/test/fixtures/browser/features/handled_errors.feature
@@ -1,6 +1,7 @@
 Feature: Browser smoke tests
 
-Scenario Outline: Receiving responses from URLs
+Scenario: Receiving responses from URLs
   When I navigate to the test URL "/test.html"
   Then I wait to receive an error
   And the error payload field "test" equals "browser"
+  And Maze Runner reports the current platform as "browser"

--- a/test/fixtures/browser/features/steps/browser_steps.rb
+++ b/test/fixtures/browser/features/steps/browser_steps.rb
@@ -41,3 +41,7 @@ When('I let the test page run for up to {int} seconds') do |n|
   txt = Maze.driver.find_element(id: 'bugsnag-test-state').text
   Maze.check.equal('DONE', txt, "Expected #bugsnag-test-state text to be 'DONE'. It was '#{txt}'.")
 end
+
+Then('Maze Runner reports the current platform as {string}') do |platform|
+  Maze.check.equal(platform, Maze::Helper.get_current_platform)
+end


### PR DESCRIPTION
## Goal

Update Maze::Helper.get_current_platform to support "browser" as a known platform.

## Design

I found this is useful on platforms like Unity where we want to discern between each of the target platforms (including WebGL, running in a browser).

## Changeset

Helper updated to report `browser` when in Browser mode, which is determined in the `BeforeAll` internal hook.

## Tests

New steps added for the browser and Android tests.