### PR TITLE
Basic support for Bitbar Web

### DIFF
--- a/lib/maze/browsers_bb.yml
+++ b/lib/maze/browsers_bb.yml
@@ -1,0 +1,62 @@
+chrome_97:
+  platform: 'Windows'
+  osVersion: '10'
+  browserName: 'chrome'
+  version: '97'
+  resolution: '1920x1080'
+
+chrome_98:
+  platform: 'Windows'
+  osVersion: '10'
+  browserName: 'chrome'
+  version: '98'
+  resolution: '1920x1080'
+
+chrome_99:
+  platform: 'Windows'
+  osVersion: '10'
+  browserName: 'chrome'
+  version: '99'
+  resolution: '1920x1080'
+
+firefox_96:
+  platform: 'Windows'
+  osVersion: '10'
+  browserName: 'firefox'
+  version: '96'
+  resolution: '1920x1080'
+
+firefox_97:
+  platform: 'Windows'
+  osVersion: '10'
+  browserName: 'firefox'
+  version: '97'
+  resolution: '1920x1080'
+
+firefox_98:
+  platform: 'Windows'
+  osVersion: '10'
+  browserName: 'firefox'
+  version: '98'
+  resolution: '1920x1080'
+
+ie_11:
+  platform: 'Windows'
+  osVersion: '10'
+  browserName: 'internet explorer'
+  version: '11'
+  resolution: '1920x1080'
+
+edge_97:
+  platform: 'Windows'
+  osVersion: '10'
+  browserName: 'MicrosoftEdge'
+  version: '97'
+  resolution: '1920x1080'
+
+edge_98:
+  platform: 'Windows'
+  osVersion: '10'
+  browserName: 'MicrosoftEdge'
+  version: '98'
+  resolution: '1920x1080'

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -66,6 +66,18 @@ module Maze
         capabilities
       end
 
+      # @param browser_type [String] A key from @see browsers_cbt.yml
+      # @param local_id [String] unique key for the SB tunnel instance
+      # @param capabilities_option [String] extra capabilities provided on the command line
+      def for_bitbar_browsers(browser_type, api_key, local_id, capabilities_option)
+        capabilities = Selenium::WebDriver::Remote::Capabilities.new
+        capabilities['bitbar_apiKey'] = api_key
+        browsers = YAML.safe_load(File.read("#{__dir__}/browsers_bb.yml"))
+        capabilities.merge! browsers[browser_type]
+        capabilities.merge! JSON.parse(capabilities_option)
+        capabilities
+      end
+
       # Constructs Appium capabilities for running on a local Android or iOS device.
       # @param platform [String] 'ios' or 'android'
       # @param capabilities_option [String] extra capabilities provided on the command line

--- a/lib/maze/hooks/browser_hooks.rb
+++ b/lib/maze/hooks/browser_hooks.rb
@@ -6,6 +6,17 @@ module Maze
       def before_all
         config = Maze.config
         case config.farm
+        when :bb
+          tunnel_id = SecureRandom.uuid
+          config.capabilities = Maze::Capabilities.for_bitbar_browsers config.browser,
+                                                                       config.access_key,
+                                                                       tunnel_id,
+                                                                       config.capabilities_option
+
+          Maze::SmartBearUtils.start_local_tunnel config.sb_local,
+                                                  config.username,
+                                                  config.access_key
+          tunnel_id
         when :bs
           # BrowserStack browser
           tunnel_id = SecureRandom.uuid
@@ -31,6 +42,11 @@ module Maze
         case config.farm
         when :cbt
           selenium_url = "http://#{config.username}:#{config.access_key}@hub.crossbrowsertesting.com:80/wd/hub"
+          Maze.driver = Maze::Driver::Browser.new :remote, selenium_url, config.capabilities
+        when :bb
+          # TODO: This probably needs to be settable via an environment variable
+          # selenium_url = 'https://us-west-desktop-hub.bitbar.com/wd/hub'
+          selenium_url = 'https://eu-desktop-hub.bitbar.com/wd/hub'
           Maze.driver = Maze::Driver::Browser.new :remote, selenium_url, config.capabilities
         when :bs
           selenium_url = "http://#{config.username}:#{config.access_key}@hub.browserstack.com/wd/hub"

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -82,12 +82,18 @@ module Maze
             config.access_key = options[Maze::Option::ACCESS_KEY]
             config.tms_uri = options[Maze::Option::TMS_URI]
             device_option = options[Maze::Option::DEVICE]
-            if device_option.is_a?(Array)
-              config.device = device_option.first
-              config.device_list = device_option.drop(1)
+            if device_option.nil? || device_option.empty?
+              # Bitbar Web
+              config.browser = options[Maze::Option::BROWSER]
             else
-              config.device = device_option
-              config.device_list = []
+              # Bitbar Devices
+              if device_option.is_a?(Array)
+                config.device = device_option.first
+                config.device_list = device_option.drop(1)
+              else
+                config.device = device_option
+                config.device_list = []
+              end
             end
             config.os = options[Maze::Option::OS]
             config.os_version = options[Maze::Option::OS_VERSION]

--- a/lib/maze/option/validator.rb
+++ b/lib/maze/option/validator.rb
@@ -83,14 +83,28 @@ module Maze
           errors << "--#{Option::ACCESS_KEY} must be specified" if options[Option::ACCESS_KEY].nil?
         end
 
-        app = options[Option::APP]
-        if app.nil?
-          errors << "--#{Option::APP} must be provided when running on a device"
-        else
-          uuid_regex = /\A[0-9]+\z/
-          unless uuid_regex.match? app
-            app = Maze::Helper.expand_path app
-            errors << "app file '#{app}' not found" unless File.exist?(app)
+        # Device
+        browser = options[Option::BROWSER]
+        device = options[Option::DEVICE]
+        if browser.nil? && device.empty?
+          errors << "Either --#{Option::BROWSER} or --#{Option::DEVICE} must be specified"
+        elsif browser
+          browsers = YAML.safe_load(File.read("#{__dir__}/../browsers_bb.yml"))
+
+          unless browsers.include? browser
+            browser_list = browsers.keys.join ', '
+            errors << "Browser type '#{browser}' unknown on BitBar.  Must be one of: #{browser_list}."
+          end
+        elsif device
+          app = options[Option::APP]
+          if app.nil?
+            errors << "--#{Option::APP} must be provided when running on a device"
+          else
+            uuid_regex = /\A[0-9]+\z/
+            unless uuid_regex.match? app
+              app = Maze::Helper.expand_path app
+              errors << "app file '#{app}' not found" unless File.exist?(app)
+            end
           end
         end
       end

--- a/lib/maze/smart_bear_utils.rb
+++ b/lib/maze/smart_bear_utils.rb
@@ -18,7 +18,7 @@ module Maze
         File.delete(SB_READY_FILE) if File.exist?(SB_READY_FILE)
         File.delete(SB_KILL_FILE) if File.exist?(SB_KILL_FILE)
 
-        $logger.info 'Starting CBT SBSecureTunnel'
+        $logger.info 'Starting SBSecureTunnel'
         command = "#{sb_local} --username #{username} --authkey #{access_key} --acceptAllCerts " \
                   "--ready #{SB_READY_FILE} --kill #{SB_KILL_FILE}"
         command << " --tunnelname #{tunnel_name}" unless tunnel_name.nil?


### PR DESCRIPTION
## Goal

Add basic support for Bitbar Web.

## Design

Note that this depends on us updating the Selenium client library, but other than that follows the approach for BrowserStack browsers and CrossBrowserTesting.

## Tests

Tested locally against Bitbar Web using the browser tests in this repo.  We should conduct some further tests using the bugsnag-js Browser tests before release this (but this will go into an integration branch before that).