### PR TITLE
Bitbar web versions

### DIFF
--- a/lib/maze/browsers_bb.yml
+++ b/lib/maze/browsers_bb.yml
@@ -19,6 +19,13 @@ chrome_99:
   version: '99'
   resolution: '1920x1080'
 
+chrome_102:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'chrome'
+  version: '102'
+  resolution: '1920x1080'
+
 firefox_96:
   platform: 'Windows'
   osVersion: '10'
@@ -38,6 +45,13 @@ firefox_98:
   osVersion: '10'
   browserName: 'firefox'
   version: '98'
+  resolution: '1920x1080'
+
+firefox_101:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'firefox'
+  version: '101'
   resolution: '1920x1080'
 
 ie_11:
@@ -60,3 +74,17 @@ edge_98:
   browserName: 'MicrosoftEdge'
   version: '98'
   resolution: '1920x1080'
+
+edge_102:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'MicrosoftEdge'
+  version: '102'
+  resolution: '1920x1080'
+
+safari_15:
+  platform: 'macOS'
+  osVersion: '12'
+  browserName: 'safari'
+  version: '15'
+  resolution: '2560x1920'

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -75,8 +75,6 @@ module Maze
         browsers = YAML.safe_load(File.read("#{__dir__}/browsers_bb.yml"))
         capabilities.merge! browsers[browser_type]
         capabilities.merge! JSON.parse(capabilities_option)
-        pp 'DEBUG: CAPS'
-        pp capabilities
         capabilities
       end
 

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -75,6 +75,8 @@ module Maze
         browsers = YAML.safe_load(File.read("#{__dir__}/browsers_bb.yml"))
         capabilities.merge! browsers[browser_type]
         capabilities.merge! JSON.parse(capabilities_option)
+        pp 'DEBUG: CAPS'
+        pp capabilities
         capabilities
       end
 


### PR DESCRIPTION
## Goal

Add newer BitBar-web browsers to the yml.

Note - this doesn't include the mobile browsers, as while the documentation implies they should be available at times, they apparently aren't.  This could probably be resolved with a support requst.