### PR TITLE
Display scenario locations in grey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.22.1 - 2022/07/15
+
+## Fixes
+
+- Display scenario locations in grey [381](https://github.com/bugsnag/maze-runner/pull/381)
+
 # 6.22.0 - 2022/07/12
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.22.0)
+    bugsnag-maze-runner (6.22.1)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -104,7 +104,7 @@ GEM
     minitest (5.15.0)
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.13.6-x86_64-darwin)
+    nokogiri (1.13.7-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -70,7 +70,10 @@ Before do |scenario|
   # Default to no dynamic try
   Maze.dynamic_retry = false
 
-  $stdout.puts "--- Scenario: #{scenario.name} - #{scenario.location}"
+  if ENV['BUILDKITE']
+    location = "\e[90m\t# #{scenario.location}\e[0m"
+    $stdout.puts "--- Scenario: #{scenario.name} #{location}"
+  end
 
   # Invoke the internal hook for the mode of operation
   Maze.internal_hooks.before

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.22.0'
+  VERSION = '6.22.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry


### PR DESCRIPTION
## Goal

Lessens the visual impact of displaying scenario locations in Buildkite.

## Design

Uses ANSI color codes to make the locations grey (the same approach as Cucumber).

## Changeset

I've also wrapped the line in a guard so that it only gets printed on Buildkite.  Locally the line has always been a duplicate to what Cucumber produces, which we accepted for the benefit of being able to fold the logs.

## Tests

See https://buildkite.com/bugsnag/maze-runner/builds/2435#018201ab-0de5-4964-80fd-63b0b51f2564.