### PR TITLE
BitBar web credentials from TMS

### DIFF
--- a/lib/maze/browsers_bb.yml
+++ b/lib/maze/browsers_bb.yml
@@ -19,6 +19,13 @@ chrome_99:
   version: '99'
   resolution: '1920x1080'
 
+chrome_102:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'chrome'
+  version: '102'
+  resolution: '1920x1080'
+
 firefox_96:
   platform: 'Windows'
   osVersion: '10'
@@ -38,6 +45,13 @@ firefox_98:
   osVersion: '10'
   browserName: 'firefox'
   version: '98'
+  resolution: '1920x1080'
+
+firefox_101:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'firefox'
+  version: '101'
   resolution: '1920x1080'
 
 ie_11:
@@ -60,3 +74,17 @@ edge_98:
   browserName: 'MicrosoftEdge'
   version: '98'
   resolution: '1920x1080'
+
+edge_102:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'MicrosoftEdge'
+  version: '102'
+  resolution: '1920x1080'
+
+safari_15:
+  platform: 'macOS'
+  osVersion: '12'
+  browserName: 'safari'
+  version: '15'
+  resolution: '2560x1920'

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -75,8 +75,6 @@ module Maze
         browsers = YAML.safe_load(File.read("#{__dir__}/browsers_bb.yml"))
         capabilities.merge! browsers[browser_type]
         capabilities.merge! JSON.parse(capabilities_option)
-        pp 'DEBUG: CAPS'
-        pp capabilities
         capabilities
       end
 

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -75,6 +75,8 @@ module Maze
         browsers = YAML.safe_load(File.read("#{__dir__}/browsers_bb.yml"))
         capabilities.merge! browsers[browser_type]
         capabilities.merge! JSON.parse(capabilities_option)
+        pp 'DEBUG: CAPS'
+        pp capabilities
         capabilities
       end
 

--- a/lib/maze/hooks/browser_hooks.rb
+++ b/lib/maze/hooks/browser_hooks.rb
@@ -7,6 +7,11 @@ module Maze
         config = Maze.config
         case config.farm
         when :bb
+          if ENV['BUILDKITE']
+            credentials = Maze::BitBarUtils.account_credentials config.tms_uri
+            config.username = credentials[:username]
+            config.access_key = credentials[:access_key]
+          end
           tunnel_id = SecureRandom.uuid
           config.capabilities = Maze::Capabilities.for_bitbar_browsers config.browser,
                                                                        config.access_key,


### PR DESCRIPTION
## Goal

Allows the sue of more credentials by acquiring them from the TMS alongside BitBar devices.

Requires #380 to be merged first