### PR TITLE
V6 BS Browser updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.23.0 - TBD
+
+- Update BrowserStack target definitions []()
+
 # 6.22.1 - 2022/07/15
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 6.23.0 - TBD
+# 6.23.0 - 2022/07/22
 
-- Update BrowserStack target definitions []()
+- Update BrowserStack target definitions [383](https://github.com/bugsnag/maze-runner/pull/383)
 
 # 6.22.1 - 2022/07/15
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.22.1)
+    bugsnag-maze-runner (6.23.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.22.1'
+  VERSION = '6.23.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/browsers_bs.yml
+++ b/lib/maze/browsers_bs.yml
@@ -36,6 +36,12 @@ edge_15:
   os: "windows"
   os_version: "10"
 
+edge_17:
+  browser: "edge"
+  browser_version: "17"
+  os: "windows"
+  os_version: "10"
+
 safari_6:
   browser: "safari"
   browser_version: "6"
@@ -127,6 +133,12 @@ firefox_56:
   os: "windows"
   os_version: "10"
 
+firefox_78:
+  browser: "firefox"
+  browser_version: "78"
+  os: "windows"
+  os_version: "10"
+
 firefox_latest:
   browser: "firefox"
   browser_version: "latest"
@@ -182,9 +194,21 @@ chrome_43:
   os: "windows"
   os_version: "7"
 
+chrome_53:
+  browser: "chrome"
+  browser_version: "53.0"
+  os: "windows"
+  os_version: "10"
+
 chrome_61:
   browser: "chrome"
   browser_version: "61.0"
+  os: "windows"
+  os_version: "10"
+
+chrome_72:
+  browser: "chrome"
+  browser_version: "72.0"
   os: "windows"
   os_version: "10"
 


### PR DESCRIPTION
## Goal

Adds some extra required browsers to the BS definitions file to facilitate their usage in Browser JS tests, based on the migration of browser tests doc.