### PR TITLE
Add support for Android 13 beta on BrowserStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.1.0 - 2022/08/17
+
+## Enhancements
+
+- Add support for Android 13 Beta on BrowserStack [385](https://github.com/bugsnag/maze-runner/pull/385)
+
 # 7.0.0 - 2022/07/29
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.0.0)
+    bugsnag-maze-runner (7.1.0)
       appium_lib (~> 12.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -35,9 +35,9 @@ GEM
       appium_lib_core (~> 5.0)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (>= 1.1, < 3.0)
-    appium_lib_core (5.2.2)
+    appium_lib_core (5.3.0)
       faye-websocket (~> 0.11.0)
-      selenium-webdriver (~> 4.2, < 4.4)
+      selenium-webdriver (~> 4.2, < 4.5)
     bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.0.0'
+  VERSION = '7.1.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -86,6 +86,7 @@ module Maze
       def create_hash
         hash = {
           # Classic, non-specific devices for each Android version
+          'ANDROID_13_0_BETA' => make_android_hash('Google Pixel 6 Pro', '13 Beta'),
           'ANDROID_12_0' => make_android_hash('Google Pixel 5', '12.0'),
           'ANDROID_11_0' => make_android_hash('Google Pixel 4', '11.0'),
           'ANDROID_10_0' => make_android_hash('Google Pixel 4', '10.0'),


### PR DESCRIPTION
## Goal

Add support for Android 13 beta on BrowserStack.

## Design

Follows the existing well-trodden path.

## Tests

Tested by temporarily adjusting the buildkite to include the new device here: https://buildkite.com/bugsnag/maze-runner/builds/2451#0182a84f-c72e-4e8b-985a-eaf7ff63afde
