### PR TITLE
Add support for Android 13 beta on BrowserStack

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,7 +150,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: 'Browserstack app-automate test - Android 11 using Ruby 3'
+  - label: 'Browserstack app-automate test - Android 12 using Ruby 3'
     depends_on: "ci-image-ruby-3"
     plugins:
       docker-compose#v3.7.0:
@@ -166,7 +166,7 @@ steps:
       bundle exec maze-runner
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
-      --device=ANDROID_11_0
+      --device=ANDROID_12_0
     concurrency: 24
     concurrency_group: 'browserstack-app'
     concurrency_method: eager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.24.0 - 2022/08/17
+
+## Enhancements
+
+- Add support for Android 13 Beta on BrowserStack [386](https://github.com/bugsnag/maze-runner/pull/386)
+  
 # 6.23.0 - 2022/07/22
 
 - Update BrowserStack target definitions [383](https://github.com/bugsnag/maze-runner/pull/383)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.23.0)
+    bugsnag-maze-runner (6.24.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -26,7 +26,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -81,7 +81,7 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     ffi (1.15.5)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     iniparser (1.0.1)
     kramdown (2.4.0)
@@ -101,10 +101,10 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    minitest (5.15.0)
+    minitest (5.16.2)
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.13.7-x86_64-darwin)
+    nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -130,7 +130,7 @@ GEM
       rubyzip (>= 1.0.0)
     thor (1.0.1)
     tomlrb (1.3.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     webrick (1.7.0)
     websocket-driver (0.7.5)
@@ -143,7 +143,6 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES
@@ -156,4 +155,4 @@ DEPENDENCIES
   yard-cucumber!
 
 BUNDLED WITH
-   2.3.11
+   2.3.0

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.23.0'
+  VERSION = '6.24.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -83,6 +83,7 @@ module Maze
       def create_hash
         hash = {
           # Classic, non-specific devices for each Android version
+          'ANDROID_13_0_BETA' => make_android_hash('Google Pixel 6 Pro', '13 Beta'),
           'ANDROID_12_0' => make_android_hash('Google Pixel 5', '12.0'),
           'ANDROID_11_0' => make_android_hash('Google Pixel 4', '11.0'),
           'ANDROID_10_0' => make_android_hash('Google Pixel 4', '10.0'),


### PR DESCRIPTION
## Goal

Add support for Android 13 beta on BrowserStack.

## Design

Follows the existing well-trodden path.

## Changeset

Also bumped the version that Maze Runner CI uses to Android 12 (will move to 13 once it's out of Beta).

## Tests

Tested by temporarily adjusting the buildkite to include the new device here: https://buildkite.com/bugsnag/maze-runner/builds/2453
