### PR TITLE
Remove workaround code no longer necessary 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Docs structure improved [388](https://github.com/bugsnag/maze-runner/pull/388)
 
+## Fixes
+
+- Remove assert_* methods no longer needed to avoid a breaking change [387](https://github.com/bugsnag/maze-runner/pull/387)
+
 # 7.0.0 - 2022/07/29
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    minitest (5.16.2)
+    minitest (5.16.3)
     mocha (1.13.0)
     multi_test (0.1.2)
     nokogiri (1.13.8-x86_64-darwin)

--- a/lib/maze/checks/assert_check.rb
+++ b/lib/maze/checks/assert_check.rb
@@ -59,33 +59,3 @@ module Maze
     end
   end
 end
-
-# Wrapper for Maze.check.true to avoid making a breaking change.
-# @deprecated TODO Remove in v7
-def assert_true(value, message = nil)
-  Maze.check.true value, message
-end
-
-# Wrapper for Maze.check.false to avoid making a breaking change.
-# @deprecated TODO Remove in v7
-def assert_false(value, message = nil)
-  Maze.check.false value, message
-end
-
-# Wrapper for Maze.check.not_nil to avoid making a breaking change.
-# @deprecated TODO Remove in v7
-def assert_not_nil(value, message = nil)
-  Maze.check.not_nil value, message
-end
-
-# Wrapper for Maze.check.not_nil to avoid making a breaking change.
-# @deprecated TODO Remove in v7
-def assert_block(message = 'block failed', &block)
-  Maze.check.block(message, &block)
-end
-
-# Wrapper for Maze.check.true to avoid making a breaking change.
-# @deprecated TODO Remove in v7
-def assert_equal(value, message = nil)
-  Maze.check.equal value, message
-end

--- a/lib/maze/plugins/cucumber_report_plugin.rb
+++ b/lib/maze/plugins/cucumber_report_plugin.rb
@@ -88,7 +88,7 @@ module Maze
 
         begin
           http = Net::HTTP.new(uri.hostname, uri.port)
-          response = http.request(request)
+          http.request(request)
         rescue => e
           $logger.warn 'Report delivery attempt failed'
           $logger.warn e.message


### PR DESCRIPTION
## Goal

Remove code that's no longer needed to avoid a breaking change.

## Design

This code was added in a previous version to avoid breaking some clients during a refactor.  Now the change has been made the code isn't needed anyway, especially now that we're into v7 (which no one is yet using).

## Changeset

Also fixed a minor code style issue.

## Tests

Covered by CI.