### PR TITLE
Use UUIDs in command payloads for better tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Enhancements
+
+- Attach UUIDs to command payloads for better tracking []()
+
 # 6.24.0 - 2022/08/17
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# TBD
+# 6.25.0 - 2022/09/05
 
 ## Enhancements
 
-- Attach UUIDs to command payloads for better tracking []()
+- Attach UUIDs to command payloads for better tracking [389](https://github.com/bugsnag/maze-runner/pull/389)
 
 # 6.24.0 - 2022/08/17
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.24.0)
+    bugsnag-maze-runner (6.25.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.24.0'
+  VERSION = '6.25.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'securerandom'
 require 'webrick'
 require_relative './logger'
 require_relative './request_list'
@@ -21,6 +22,9 @@ module Maze
 
       # Dictates if the response delay should be reset after use
       attr_writer :reset_response_delay
+
+      # @return [String] The UUID attached to all command requests for this session
+      attr_reader :command_uuid
 
       # The intended HTTP status code on a successful request
       #
@@ -142,6 +146,8 @@ module Maze
       def start
         attempts = 0
         $logger.info 'Starting mock server'
+        @command_uuid = SecureRandom.uuid
+        $logger.info "Fixture commands UUID: #{@command_uuid}"
         loop do
 
           @thread = Thread.new do

--- a/lib/maze/servlets/command_servlet.rb
+++ b/lib/maze/servlets/command_servlet.rb
@@ -8,7 +8,6 @@ module Maze
     # Allows clients to queue up "commands", in the form of Ruby hashes, using Maze::Server.commands.add.  GET
     # requests made to the /command endpoint will then respond with each queued command in turn.
     class CommandServlet < BaseServlet
-
       # Serves the next command, if these is one.
       #
       # @param _request [HTTPRequest] The incoming GET request

--- a/lib/maze/servlets/command_servlet.rb
+++ b/lib/maze/servlets/command_servlet.rb
@@ -8,6 +8,7 @@ module Maze
     # Allows clients to queue up "commands", in the form of Ruby hashes, using Maze::Server.commands.add.  GET
     # requests made to the /command endpoint will then respond with each queued command in turn.
     class CommandServlet < BaseServlet
+
       # Serves the next command, if these is one.
       #
       # @param _request [HTTPRequest] The incoming GET request
@@ -20,7 +21,9 @@ module Maze
           response.body = 'No commands to provide'
           response.status = 400
         else
-          response.body = JSON.pretty_generate(commands.current)
+          command = commands.current
+          command[:uuid] = Maze::Server.command_uuid
+          response.body = JSON.pretty_generate(command)
           response.status = 200
           commands.next
         end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -27,6 +27,11 @@ module Maze
       # Expected logging calls
       @logger_mock.expects(:info).with('Starting mock server')
 
+      # Pre-set securerandom output to avoid issues with generated UUIDs
+      gen_uuid = 'random_uuid'
+      SecureRandom.expects(:uuid).once.returns(gen_uuid)
+      @logger_mock.expects(:info).with("Fixture commands UUID: #{gen_uuid}")
+
       # Force synchronous execution
       Thread.expects(:new).yields
 
@@ -65,6 +70,11 @@ module Maze
       @logger_mock.expects(:info).with('Starting mock server')
       @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
       @logger_mock.expects(:info).with('Retrying in 5 seconds')
+
+      # Pre-set securerandom output to avoid issues with generated UUIDs
+      gen_uuid = 'random_uuid'
+      SecureRandom.expects(:uuid).once.returns(gen_uuid)
+      @logger_mock.expects(:info).with("Fixture commands UUID: #{gen_uuid}")
 
       # Force synchronous execution
       Thread.expects(:new).yields.twice
@@ -108,6 +118,11 @@ module Maze
       @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
       @logger_mock.expects(:info).with('Retrying in 5 seconds')
       @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
+
+      # Pre-set securerandom output to avoid issues with generated UUIDs
+      gen_uuid = 'random_uuid'
+      SecureRandom.expects(:uuid).once.returns(gen_uuid)
+      @logger_mock.expects(:info).with("Fixture commands UUID: #{gen_uuid}")
 
       # Force synchronous execution
       Thread.expects(:new).yields.times(3)


### PR DESCRIPTION
## Goal

Adds a UUID to all command payloads, generated when the server first starts, which will enable us to match a particular Maze-runner test run message to a device.

This will help to determine if there's any cross contamination between maze-runner command payloads anywhere.