### PR TITLE
Handle nil device list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.25.1 - 2022/09/08
+
+## Fixes
+
+- Handle nil device list for `--farm=local` [392](https://github.com/bugsnag/maze-runner/pull/392)
+
 # 6.25.0 - 2022/09/05
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.25.0)
+    bugsnag-maze-runner (6.25.1)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.25.0'
+  VERSION = '6.25.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -154,7 +154,7 @@ module Maze
       end
 
       def start_driver(config, tunnel_id = nil)
-        retry_failure = config.device_list.empty?
+        retry_failure = config.device_list.nil? || config.device_list.empty?
         until Maze.driver
           begin
             config.capabilities = device_capabilities(config, tunnel_id)

--- a/test/hooks/appium_hooks_test.rb
+++ b/test/hooks/appium_hooks_test.rb
@@ -136,7 +136,7 @@ class AppiumHooksTest < Test::Unit::TestCase
     $config.expects(:farm).returns(:local)
     $config.expects(:os_version).returns(nil)
     $config.expects(:os).returns('ios')
-    $config.expects(:device_list).returns([])
+    $config.expects(:device_list).returns([]).twice()
 
     $logger.expects(:info).with('Inferred OS version to be 9.0')
     $config.expects(:os_version=).with(9.0)
@@ -161,7 +161,7 @@ class AppiumHooksTest < Test::Unit::TestCase
     $config.expects(:farm).returns(:local)
     $config.expects(:os_version).returns(nil)
     $config.expects(:os).returns('android')
-    $config.expects(:device_list).returns([])
+    $config.expects(:device_list).returns([]).twice()
 
     $logger.expects(:info).with('Inferred OS version to be 12.0')
     $config.expects(:os_version=).with(12.0)
@@ -181,7 +181,7 @@ class AppiumHooksTest < Test::Unit::TestCase
 
     $config.expects(:capabilities=).with(:caps)
     $config.expects(:appium_session_isolation).returns(false)
-    $config.expects(:device_list).returns([])
+    $config.expects(:device_list).returns([]).twice()
 
     $logger.expects(:error).with("Appium driver failed to start after 6 attempts in 60 seconds")
 
@@ -203,7 +203,7 @@ class AppiumHooksTest < Test::Unit::TestCase
     $config.expects(:capabilities=).with(:caps)
     $config.expects(:appium_session_isolation).returns(false)
     $config.expects(:farm).returns(:farm)
-    $config.expects(:device_list).returns([])
+    $config.expects(:device_list).returns([]).twice()
 
     Maze.expects(:driver=).with(driver_mock)
 


### PR DESCRIPTION
## Goal

Handle a `nil` device list, which happens when using `--farm=local` (because a `--device` option is not required).

## Changeset

Addition of a simple nil guard.

## Tests

Tested locally to verify that:
- A session can be successfully created
- Retries still occur if the driver cannot be started