### PR TITLE
Add Android 13 and iOS 16 Beta on BrowserStack

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,7 +150,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: 'Browserstack app-automate test - Android 12 using Ruby 3'
+  - label: 'Browserstack app-automate test - Android 13 using Ruby 3'
     depends_on: "ci-image-ruby-3"
     plugins:
       docker-compose#v3.7.0:
@@ -166,7 +166,7 @@ steps:
       bundle exec maze-runner
       --app=app/build/outputs/apk/release/app-release.apk
       --farm=bs
-      --device=ANDROID_12_0
+      --device=ANDROID_13_0
     concurrency: 24
     concurrency_group: 'browserstack-app'
     concurrency_method: eager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 6.25.1 - 2022/09/08
+# 6.26.0 - 2022/09/08
+
+## Enhancements
+
+- Add support for Android 13 and iOS 16 Beta on BrowserStack [393](https://github.com/bugsnag/maze-runner/pull/393)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.25.1)
+    bugsnag-maze-runner (6.26.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.25.1'
+  VERSION = '6.26.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -83,6 +83,7 @@ module Maze
       def create_hash
         hash = {
           # Classic, non-specific devices for each Android version
+          'ANDROID_13_0' => make_android_hash('Google Pixel 6 Pro', '13.0'),
           'ANDROID_13_0_BETA' => make_android_hash('Google Pixel 6 Pro', '13 Beta'),
           'ANDROID_12_0' => make_android_hash('Google Pixel 5', '12.0'),
           'ANDROID_11_0' => make_android_hash('Google Pixel 4', '11.0'),
@@ -96,6 +97,7 @@ module Maze
           'ANDROID_4_4' => make_android_hash('Google Nexus 5', '4.4', APPIUM_1_9_1),
 
           # iOS devices
+          'IOS_16_BETA' => make_ios_hash('iPhone 12 Pro Max', '16 Beta'),
           'IOS_15' => make_ios_hash('iPhone 11 Pro', '15'),
           'IOS_14' => make_ios_hash('iPhone 11', '14'),
           'IOS_13' => make_ios_hash('iPhone 8', '13'),


### PR DESCRIPTION
## Goal

Add Android 13 and iOS 16 Beta on BrowserStack.

## Design

<!-- Why was this approach used? -->

## Documentation

<!-- Does the PR add or remove functionality?  Have the docs been considered? -->

## Changeset

<!-- What changed? -->

## Tests

<!-- How was it tested? -->
