### PR TITLE
Fix support for BitBar (using W3C capabilities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Fixes
 
 - Remove assert_* methods no longer needed to avoid a breaking change [387](https://github.com/bugsnag/maze-runner/pull/387)
+- Fix support for BitBar to work with W3C capabilities [394](https://github.com/bugsnag/maze-runner/pull/394)
 
 ## Removals
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -63,6 +63,9 @@ require_relative '../lib/maze/plugins/bugsnag_reporting_plugin'
 require_relative '../lib/maze/plugins/cucumber_report_plugin'
 require_relative '../lib/maze/plugins/global_retry_plugin'
 
+# Require monkey-patches after everything else
+require_relative '../lib/utils/selenium_money_patch'
+
 # Encapsulates the MazeRunner entry point
 class MazeRunnerEntry
 

--- a/lib/maze/bitbar_devices.rb
+++ b/lib/maze/bitbar_devices.rb
@@ -40,7 +40,7 @@ module Maze
           'filter': "online_eq_true"
         }
         all_devices = call_bitbar_api(path, query, api_key)
-        $logger.info "all_devices: #{JSON.pretty_generate(all_devices)}"
+        $logger.debug "all_devices: #{JSON.pretty_generate(all_devices)}"
         filtered_devices = all_devices['data'].reject { |device| device['locked'] }
         if filtered_devices.empty?
           $logger.error 'There are no devices available'
@@ -61,7 +61,7 @@ module Maze
                             else
                               'UiAutomator2'
                             end
-          make_android_hash(device_name, nil, automation_name)
+          make_android_hash(device_name, automation_name)
         when 'ios'
           make_ios_hash(device_name)
         else
@@ -69,28 +69,26 @@ module Maze
         end
       end
 
-
-      def make_android_hash(device, appium_version = nil, automation_name = nil)
+      def make_android_hash(device, automation_name)
         hash = {
+          'automationName' => automation_name,
           'platformName' => 'Android',
           'deviceName' => 'Android Phone',
           'bitbar:options' => {
-            'device' => device,
-            # 'bitbar_target' => 'android',
+            'device' => device
           }
         }
-        # hash['bitbar_appiumVersion'] = appium_version if appium_version
-        # hash['appium:automationName'] = automation_name if automation_name
         hash.freeze
       end
 
       def make_ios_hash(device)
         {
-          'platformName' => 'iOS',
-          'bitbar_device' => device,
-          'bitbar_target' => 'ios',
+          'automationName' => 'XCUITest',
           'deviceName' => 'iPhone device',
-          'automationName' => 'XCUITest'
+          'platformName' => 'iOS',
+          'bitbar:options' => {
+            'device' => device
+          }
         }.freeze
       end
     end

--- a/lib/maze/bitbar_devices.rb
+++ b/lib/maze/bitbar_devices.rb
@@ -40,8 +40,15 @@ module Maze
           'filter': "online_eq_true"
         }
         all_devices = call_bitbar_api(path, query, api_key)
+        $logger.info "all_devices: #{JSON.pretty_generate(all_devices)}"
         filtered_devices = all_devices['data'].reject { |device| device['locked'] }
-        filtered_devices.first['displayName']
+        if filtered_devices.empty?
+          $logger.error 'There are no devices available'
+        else
+          selected = filtered_devices.first['displayName']
+          $logger.info "Selected #{selected} from #{filtered_devices.size} available device(s)"
+          selected
+        end
       end
 
       def get_device(device_group, platform, platform_version, api_key)

--- a/lib/maze/bitbar_devices.rb
+++ b/lib/maze/bitbar_devices.rb
@@ -49,7 +49,11 @@ module Maze
         device_name = get_filtered_device_name(device_group_id, api_key)
         case platform.downcase
         when 'android'
-          automation_name = 'UiAutomator1' if platform_version.start_with?('5')
+          automation_name = if platform_version.start_with?('5')
+                              'UiAutomator1'
+                            else
+                              'UiAutomator2'
+                            end
           make_android_hash(device_name, nil, automation_name)
         when 'ios'
           make_ios_hash(device_name)
@@ -58,15 +62,18 @@ module Maze
         end
       end
 
+
       def make_android_hash(device, appium_version = nil, automation_name = nil)
         hash = {
           'platformName' => 'Android',
-          'bitbar_device' => device,
-          'bitbar_target' => 'android',
-          'deviceName' => 'Android Phone'
+          'deviceName' => 'Android Phone',
+          'bitbar:options' => {
+            'device' => device,
+            # 'bitbar_target' => 'android',
+          }
         }
-        hash['bitbar_appiumVersion'] = appium_version if appium_version
-        hash['automationName'] = automation_name if automation_name
+        # hash['bitbar_appiumVersion'] = appium_version if appium_version
+        # hash['appium:automationName'] = automation_name if automation_name
         hash.freeze
       end
 

--- a/lib/maze/bitbar_utils.rb
+++ b/lib/maze/bitbar_utils.rb
@@ -40,7 +40,7 @@ module Maze
           begin
             response = JSON.parse res.body
             if response.key?('id')
-              app_uuid = response['id']
+              app_uuid = response['id'].to_s
               $logger.info "Uploaded app ID: #{app_uuid}"
               $logger.info 'You can use this ID to avoid uploading the same app more than once.'
             else

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -7,19 +7,68 @@ module Maze
       # @param device_type [String]
       def for_bitbar_device(bitbar_api_key, device_type, platform, platform_version, capabilities_option)
         capabilities = {
-          'bitbar_apiKey' => bitbar_api_key,
-          'bitbar_testrun' => "#{platform} #{platform_version}",
-          'bitbar_findDevice' => false,
-          'bitbar_testTimeout' => 7200,
           'disabledAnimations' => 'true',
-          'noReset' => 'true'
+          'noReset' => 'true',
+          'bitbar:options' => {
+            'apiKey' => bitbar_api_key,
+            'testrun' => "#{platform} #{platform_version}",
+            'findDevice' => false,
+            'testTimeout' => 7200,
+          }
         }
-        capabilities.merge! BitBarDevices.get_device(device_type, platform, platform_version, bitbar_api_key)
-        capabilities.merge! JSON.parse(capabilities_option)
+        capabilities.deep_merge! BitBarDevices.get_device(device_type, platform, platform_version, bitbar_api_key)
+        capabilities.deep_merge! JSON.parse(capabilities_option)
+
         capabilities
       end
 
-      # @param browser_type [String] A key from @see browsers_bb.yml
+
+
+      # selenium jsonwp
+      #
+      # capabilities = Selenium::WebDriver::Remote::Capabilities.new
+      # capabilities['platform'] = 'Linux'
+      # capabilities['osVersion'] = '18.04'
+      # capabilities['browserName'] = 'firefox'
+      # capabilities['version'] = '104'
+      # capabilities['resolution'] = '2560x1920'
+      # capabilities['bitbar_apiKey'] = '<insert your BitBar API key here>'
+
+# selenium w3c
+
+      # capabilities = Selenium::WebDriver::Remote::Capabilities.new
+      # 'platformName' => 'Linux',
+      # capabilities['browserName'] = 'firefox'
+      # capabilities['browserVersion'] = '104'
+      # capabilities['bitbar:options'] = {
+      #   'apiKey' = '<insert your BitBar API key here>'
+      # 'resolution' = '2560x1920'
+      # 'osVersion' = '18.04'
+      # }
+
+      # appium jsonwp
+      #
+      # desired_capabilities_cloud = {
+      #   'bitbar_apiKey' => '<insert your BitBar API key here>',
+      #   'bitbar_device' => 'Asus Google Nexus 7 2013 6.0.1',
+      #   'platformName' => 'Android',
+      #   'deviceName' => 'Android Phone',
+      #   'automationName' => 'Appium',
+      # }
+
+      # browserstack (w3c)
+      #
+      # 'platformName' => 'android',
+      #   'platformVersion' => version,
+      #   'deviceName' => device,
+      #   'autoGrantPermissions' => 'true',
+      #   'bstack:options' => {
+      #     "appiumVersion" => appium_version,
+      #   },
+
+
+
+# @param browser_type [String] A key from @see browsers_bb.yml
       # @param local_id [String] unique key for the SB tunnel instance
       # @param capabilities_option [String] extra capabilities provided on the command line
       def for_bitbar_browsers(browser_type, api_key, local_id, capabilities_option)

--- a/lib/maze/capabilities.rb
+++ b/lib/maze/capabilities.rb
@@ -22,53 +22,7 @@ module Maze
         capabilities
       end
 
-
-
-      # selenium jsonwp
-      #
-      # capabilities = Selenium::WebDriver::Remote::Capabilities.new
-      # capabilities['platform'] = 'Linux'
-      # capabilities['osVersion'] = '18.04'
-      # capabilities['browserName'] = 'firefox'
-      # capabilities['version'] = '104'
-      # capabilities['resolution'] = '2560x1920'
-      # capabilities['bitbar_apiKey'] = '<insert your BitBar API key here>'
-
-# selenium w3c
-
-      # capabilities = Selenium::WebDriver::Remote::Capabilities.new
-      # 'platformName' => 'Linux',
-      # capabilities['browserName'] = 'firefox'
-      # capabilities['browserVersion'] = '104'
-      # capabilities['bitbar:options'] = {
-      #   'apiKey' = '<insert your BitBar API key here>'
-      # 'resolution' = '2560x1920'
-      # 'osVersion' = '18.04'
-      # }
-
-      # appium jsonwp
-      #
-      # desired_capabilities_cloud = {
-      #   'bitbar_apiKey' => '<insert your BitBar API key here>',
-      #   'bitbar_device' => 'Asus Google Nexus 7 2013 6.0.1',
-      #   'platformName' => 'Android',
-      #   'deviceName' => 'Android Phone',
-      #   'automationName' => 'Appium',
-      # }
-
-      # browserstack (w3c)
-      #
-      # 'platformName' => 'android',
-      #   'platformVersion' => version,
-      #   'deviceName' => device,
-      #   'autoGrantPermissions' => 'true',
-      #   'bstack:options' => {
-      #     "appiumVersion" => appium_version,
-      #   },
-
-
-
-# @param browser_type [String] A key from @see browsers_bb.yml
+      # @param browser_type [String] A key from @see browsers_bb.yml
       # @param local_id [String] unique key for the SB tunnel instance
       # @param capabilities_option [String] extra capabilities provided on the command line
       def for_bitbar_browsers(browser_type, api_key, local_id, capabilities_option)

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -62,7 +62,7 @@ module Maze
           $logger.info "Appium driver started in #{(Time.now - time).to_i}s"
         rescue => error
           $logger.warn "Appium driver failed to start in #{(Time.now - time).to_i}s"
-          $logger.warn "#{error.class} occurred with message: #{error.message}"
+          $logger.warn "#{error.class} occurred with message: #{error.inspect}"
           raise error
         end
       end

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -62,7 +62,7 @@ module Maze
           $logger.info "Appium driver started in #{(Time.now - time).to_i}s"
         rescue => error
           $logger.warn "Appium driver failed to start in #{(Time.now - time).to_i}s"
-          $logger.warn "#{error.class} occurred with message: #{error.inspect}"
+          $logger.warn "#{error.class} occurred with message: #{error.message}"
           raise error
         end
       end

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -1,25 +1,4 @@
 # Contains logic for the Cucumber hooks when in Appium mode
-
-module Selenium
-  module WebDriver
-    module Error
-      class ServerError < StandardError
-        def initialize(response)
-          if response.is_a? String
-            super(response)
-          else
-            $logger.error "Server response: #{response.inspect}"
-            super("status code #{response.code}")
-          end
-        end
-      end # ServerError
-    end # Error
-  end # WebDriver
-end # Selenium
-
-
-
-
 module Maze
   module Hooks
     # Hooks for Appium mode use
@@ -143,7 +122,6 @@ module Maze
                                                               config.os_version,
                                                               config.capabilities_option
           capabilities['bitbar:options']['app'] = config.app
-          # capabilities['appium:bundleId'] = config.app_bundle_id
         end
 
         $logger.info "Capabilities: #{capabilities.inspect}"

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -1,4 +1,24 @@
 # Contains logic for the Cucumber hooks when in Appium mode
+
+module Selenium
+  module WebDriver
+    module Error
+      class ServerError < StandardError
+        def initialize(response)
+          if response.is_a? String
+            super(response)
+          else
+            super("the status code #{response.code}")
+          end
+        end
+      end # ServerError
+    end # Error
+  end # WebDriver
+end # Selenium
+
+
+
+
 module Maze
   module Hooks
     # Hooks for Appium mode use

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -124,9 +124,6 @@ module Maze
           capabilities['bitbar:options']['app'] = config.app
         end
 
-        $logger.info "Capabilities: #{capabilities.inspect}"
-
-
         capabilities
       end
 

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -8,7 +8,8 @@ module Selenium
           if response.is_a? String
             super(response)
           else
-            super("the status code #{response.code}")
+            $logger.error "Server response: #{response.inspect}"
+            super("status code #{response.code}")
           end
         end
       end # ServerError

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -121,9 +121,13 @@ module Maze
                                                               config.os,
                                                               config.os_version,
                                                               config.capabilities_option
-          capabilities['bitbar_app'] = config.app
-          capabilities['bundleId'] = config.app_bundle_id
+          capabilities['bitbar:options']['app'] = config.app
+          # capabilities['appium:bundleId'] = config.app_bundle_id
         end
+
+        $logger.info "Capabilities: #{capabilities.inspect}"
+
+
         capabilities
       end
 

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -92,7 +92,7 @@ module Maze
             config.os = options[Maze::Option::OS]
             config.os_version = options[Maze::Option::OS_VERSION]
             config.sb_local = Maze::Helper.expand_path(options[Maze::Option::SB_LOCAL])
-            config.appium_server_url = 'https://appium.bitbar.com/wd/hub'
+            config.appium_server_url = 'https://us-west-mobile-hub.bitbar.com/wd/hub'
             config.app_bundle_id = options[Maze::Option::APP_BUNDLE_ID]
           when :local then
             if options[Maze::Option::BROWSER]

--- a/lib/utils/selenium_money_patch.rb
+++ b/lib/utils/selenium_money_patch.rb
@@ -1,0 +1,17 @@
+# Log the full response so we see more than just the error code
+module Selenium
+  module WebDriver
+    module Error
+      class ServerError < StandardError
+        def initialize(response)
+          if response.is_a? String
+            super(response)
+          else
+            $logger.error "Server response: #{response.inspect}"
+            super("status code #{response.code}")
+          end
+        end
+      end # ServerError
+    end # Error
+  end # WebDriver
+end # Selenium


### PR DESCRIPTION
## Goal

Fix support for BitBar in Maze v7, where W3C capabilities are now mandatory (having upgraded appium_lib to v12).

## Design

To some extent the release of v7 was a little hasty, as we hadn't had the chance to retest and fix the BitBar integration.  This PR brings BitBar back as an option. 

## Changeset

- Capabilities updated to be W3C compliant
- Various tweaks to improve logging
- BitBar Appium server URL change to US, as our dedicated devices are located there

## Tests

Tested locally:
- Android - successfully ran a single smoke test scenario several times.
- iOS - capabilities appear to be in order, but the server is complaining that the app (the Id given for the uploaded IPA) cannot be found.  Have raised with the BitBar team.