### PR TITLE
Remove ambiguity from RequestList interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Remove assert_* methods no longer needed to avoid a breaking change [387](https://github.com/bugsnag/maze-runner/pull/387)
 - Fix support for BitBar to work with W3C capabilities [394](https://github.com/bugsnag/maze-runner/pull/394)
+- Fix `RequestList` interface to avoid ambiguity [398](https://github.com/bugsnag/maze-runner/pull/398)
 
 ## Removals
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,13 @@ The Appium and Selenium clients are upgraded to versions 12 and 4 respectively. 
 capabilities, although the changes for this will typically be encapsulated within Maze Runner.  The change is considered
 breaking as the earliest supported Appium version is now 1.15 (due to the library update).
 
+### RequestList interface change ###
+
+`RequestList.empty?` has been removed, as it was ambiguous whether it applied to all requests received, or just those 
+that had not been processed.  It also meant that in general `empty?` was not the same as `size == 0`.  
+
+`size` has also been renamed to `size_remaining` to avoid ambiguity.
+
 ## v5 to v6
 
 The version of Cucumber used by Maze Runner has been updated from 3.1.2 to 7.1.0:

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -12,11 +12,11 @@ def assert_received_requests(request_count, list, list_name)
   timeout = Maze.config.receive_requests_wait
   wait = Maze::Wait.new(timeout: timeout)
 
-  received = wait.until { list.size >= request_count }
+  received = wait.until { list.size_remaining >= request_count }
 
   unless received
     raise Test::Unit::AssertionFailedError.new <<-MESSAGE
-    Expected #{request_count} #{list_name} but received #{list.size} within the #{timeout}s timeout.
+    Expected #{request_count} #{list_name} but received #{list.size_remaining} within the #{timeout}s timeout.
     This could indicate that:
     - Bugsnag crashed with a fatal error.
     - Bugsnag did not make the requests that it should have done.
@@ -26,7 +26,7 @@ def assert_received_requests(request_count, list, list_name)
     MESSAGE
   end
 
-  Maze.check.equal(request_count, list.size, "#{list.size} #{list_name} received")
+  Maze.check.equal(request_count, list.size_remaining, "#{list.size_remaining} #{list_name} received")
 end
 
 #
@@ -59,7 +59,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 Then('I have received at least {int} {word}') do |min_received, request_type|
   list = Maze::Server.list_for(request_type)
-  Maze.check.operator(list.size, :>=, min_received, "Actually received #{list.size} #{request_type} requests")
+  Maze.check.operator(list.size_remaining, :>=, min_received, "Actually received #{list.size} #{request_type} requests")
 end
 
 # Assert that the test Server hasn't received any requests - of a specific, or any, type.
@@ -70,11 +70,11 @@ Then('I should receive no {word}') do |request_type|
   sleep Maze.config.receive_no_requests_wait
   if request_type == 'requests'
     # Assert that the test Server hasn't received any requests at all.
-    Maze.check.equal(0, Maze::Server.errors.size, "#{Maze::Server.errors.size} errors received")
-    Maze.check.equal(0, Maze::Server.sessions.size, "#{Maze::Server.sessions.size} sessions received")
+    Maze.check.equal(0, Maze::Server.errors.size_remaining, "#{Maze::Server.errors.size_remaining} errors received")
+    Maze.check.equal(0, Maze::Server.sessions.size_remaining, "#{Maze::Server.sessions.size_remaining} sessions received")
   else
     list = Maze::Server.list_for(request_type)
-    Maze.check.equal(0, list.size, "#{list.size} #{request_type} received")
+    Maze.check.equal(0, list.size_remaining, "#{list.size_remaining} #{request_type} received")
   end
 end
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -152,10 +152,10 @@ end
 
 def output_received_requests(request_type)
   request_queue = Maze::Server.list_for(request_type)
-  if request_queue.empty?
+  count = request_queue.size_all
+  if count == 0
     $logger.info "No #{request_type} received"
   else
-    count = request_queue.size_all
     $logger.info "#{count} #{request_type} were received:"
     request_queue.all.each.with_index(1) do |request, number|
       $stdout.puts "--- #{request_type} #{number} of #{count}"
@@ -227,7 +227,7 @@ end
 # and we need the logic in the other After hook to be performed.
 # Furthermore, this hook should appear after the general hook as they are executed in reverse order by Cucumber.
 After do |scenario|
-  unless Maze::Server.invalid_requests.empty?
+  unless Maze::Server.invalid_requests.size_all == 0
     msg = "#{Maze::Server.invalid_requests.size_all} invalid request(s) received during scenario"
     scenario.fail msg
   end

--- a/lib/maze/request_list.rb
+++ b/lib/maze/request_list.rb
@@ -10,12 +10,8 @@ module Maze
       @count = 0
     end
 
-    def empty?
-      @requests.empty?
-    end
-
     # The number of unprocessed/remaining requests in the list (not the total number actually held)
-    def size
+    def size_remaining
       @count
     end
 

--- a/lib/maze/servlets/command_servlet.rb
+++ b/lib/maze/servlets/command_servlet.rb
@@ -16,7 +16,7 @@ module Maze
         response.header['Access-Control-Allow-Origin'] = '*'
 
         commands = Maze::Server.commands
-        if commands.empty?
+        if commands.size_remaining == 0
           response.body = 'No commands to provide'
           response.status = 400
         else

--- a/test/request_list_test.rb
+++ b/test/request_list_test.rb
@@ -29,8 +29,7 @@ class RequestListTest < Test::Unit::TestCase
   def test_fresh_state
     list = Maze::RequestList.new
     assert_nil list.current
-    assert_empty list
-    assert_equal 0, list.size
+    assert_equal 0, list.size_remaining
     assert_equal [], list.all
   end
 
@@ -44,8 +43,7 @@ class RequestListTest < Test::Unit::TestCase
     list.add item2
 
     # Check current and state
-    assert_not_empty list
-    assert_equal 2, list.size
+    assert_equal 2, list.size_remaining
     assert_equal item1, list.current
     assert_not_equal item2, list.current
     assert_equal [item1, item2], list.all


### PR DESCRIPTION
## Goal

Remove ambiguity from RequestList interface.

## Documentation

UPGRADING.md updated.

## Changeset

`RequestList.empty?` has been removed, as it was ambiguous whether it applied to all requests received, or just those 
that had not been processed.  It also meant that in general `empty?` was not the same as `size == 0`.  

`size` has also been renamed to `size_remaining` to avoid ambiguity.

## Tests

Covered by CI and unit tests.