### PR TITLE
Stop BitBar tunnel and release account on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 7.1.0 - TBD
+# 7.1.0 - 2022/09/30
 
 ## Enhancements
 
@@ -11,6 +11,7 @@
 - Remove assert_* methods no longer needed to avoid a breaking change [387](https://github.com/bugsnag/maze-runner/pull/387)
 - Fix support for BitBar to work with W3C capabilities [394](https://github.com/bugsnag/maze-runner/pull/394)
 - Fix `RequestList` interface to avoid ambiguity [398](https://github.com/bugsnag/maze-runner/pull/398)
+- Release BitBar account and stop tunnel on exit [401](https://github.com/bugsnag/maze-runner/pull/401)
 
 ## Removals
 

--- a/lib/maze/client/bb_client_utils.rb
+++ b/lib/maze/client/bb_client_utils.rb
@@ -101,6 +101,7 @@ module Maze
         # Informs the test-management-service that in-use account id is no longer in use
         # @param tms_uri [String] The URI of the test-management-service
         def release_account(tms_uri)
+          $logger.info "Release account #{@account_id}"
           uri = URI("#{tms_uri}/account/release?account_id=#{@account_id}")
           request = Net::HTTP::Get.new(uri)
           request['Authorization'] = Maze.config.tms_token

--- a/lib/maze/hooks/browser_hooks.rb
+++ b/lib/maze/hooks/browser_hooks.rb
@@ -62,7 +62,11 @@ module Maze
       end
 
       def at_exit
-        if Maze.config.farm == :bs
+        case Maze.config.farm
+        when :bb
+          Maze::Client::BitBarClientUtils.stop_local_tunnel
+          Maze::Client::BitBarClientUtils.release_account(Maze.config.tms_uri) if ENV['BUILDKITE']
+        when :bs
           Maze::Client::BrowserStackClientUtils.stop_local_tunnel
           Maze.driver.driver_quit
         end


### PR DESCRIPTION
## Goal

Clear up resources after a BitBar Browser session - release the user from the TMS and stopping the secure tunnel.

## Tests

Covered by CI.