### PR TITLE
Add traces endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.TDB (integration/performance)
+
+## Enhancements
+
+- Add `/trace` endpoint [402](https://github.com/bugsnag/maze-runner/pull/402)
+
 # 7.1.0 - 2022/09/30
 
 ## Enhancements

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -143,6 +143,7 @@ ensure
   Maze::Server.builds.clear
   Maze::Server.uploads.clear
   Maze::Server.sourcemaps.clear
+  Maze::Server.traces.clear
   Maze::Server.logs.clear
   Maze::Server.invalid_requests.clear
   Maze::Runner.environment.clear
@@ -175,7 +176,7 @@ def write_requests(scenario)
 
   FileUtils.makedirs(path)
 
-  request_types = %w[errors sessions builds uploads logs sourcemaps invalid]
+  request_types = %w[errors sessions builds uploads logs sourcemaps traces invalid]
 
   request_types.each do |request_type|
     list = Maze::Server.list_for(request_type).all

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -182,7 +182,7 @@ module Maze
             server.mount '/builds', Servlets::Servlet, :builds
             server.mount '/uploads', Servlets::Servlet, :uploads
             server.mount '/sourcemap', Servlets::Servlet, :sourcemaps
-            server.mount '/trace', Servlets::Servlet, :traces
+            server.mount '/traces', Servlets::Servlet, :traces
             server.mount '/react-native-source-map', Servlets::Servlet, :sourcemaps
             server.mount '/command', Servlets::CommandServlet
             server.mount '/logs', Servlets::LogServlet

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -64,6 +64,8 @@ module Maze
           builds
         when 'log', 'logs'
           logs
+        when 'trace', 'traces'
+          traces
         when 'upload', 'uploads'
           uploads
         when 'sourcemap', 'sourcemaps'
@@ -87,6 +89,13 @@ module Maze
       # @return [RequestList] Received error requests
       def sessions
         @sessions ||= RequestList.new
+      end
+
+      # A list of trace requests received
+      #
+      # @return [RequestList] Received error requests
+      def traces
+        @traces ||= RequestList.new
       end
 
       # A list of build requests received
@@ -173,6 +182,7 @@ module Maze
             server.mount '/builds', Servlets::Servlet, :builds
             server.mount '/uploads', Servlets::Servlet, :uploads
             server.mount '/sourcemap', Servlets::Servlet, :sourcemaps
+            server.mount '/trace', Servlets::Servlet, :traces
             server.mount '/react-native-source-map', Servlets::Servlet, :sourcemaps
             server.mount '/command', Servlets::CommandServlet
             server.mount '/logs', Servlets::LogServlet

--- a/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
@@ -10,6 +10,11 @@ Feature: Testing helper methods respond correctly
         Then I wait to receive a session
         And the session is valid for the session reporting API version "1.0" for the "Maze-runner" notifier
 
+    Scenario: The request body matches an expected session payload
+        When I send a "trace"-type request
+        Then I wait to receive a trace
+        And the trace payload field "trace-value-2" equals "two"
+
     Scenario: The request body is correct for an unhandled payload
         When I send a "unhandled"-type request
         Then I wait to receive an error

--- a/test/fixtures/payload-helpers/features/scripts/send_request.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_request.sh
@@ -9,6 +9,8 @@ endpoint = if ENV['request_type'] == 'session'
              '/sessions'
            elsif ENV['request_type'] == 'build'
              '/builds'
+           elsif ENV['request_type'] == 'trace'
+             '/trace'
            else
              '/notify'
            end
@@ -56,6 +58,22 @@ templates = {
       },
       'app' => 'not null',
       'device' => 'not null'
+    }
+  },
+  'trace' => {
+    'headers' => {
+      'Bugsnag-Api-Key' => ENV['BUGSNAG_API_KEY'],
+      'Bugsnag-Payload-Version' => '1.0',
+      'Bugsnag-Sent-At' => Time.now().iso8601(3)
+    },
+    'body' => {
+      'notifier' => {
+        'name' => 'Maze-runner',
+        'url' => 'not null',
+        'version' => '4.4.4'
+      },
+      'trace-value-1' => 'one',
+      'trace-value-2' => 'two'
     }
   },
   'unhandled' => {

--- a/test/fixtures/payload-helpers/features/scripts/send_request.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_request.sh
@@ -10,7 +10,7 @@ endpoint = if ENV['request_type'] == 'session'
            elsif ENV['request_type'] == 'build'
              '/builds'
            elsif ENV['request_type'] == 'trace'
-             '/trace'
+             '/traces'
            else
              '/notify'
            end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -43,6 +43,7 @@ module Maze
       mock_http_server.expects(:mount).with('/builds', any_parameters).once
       mock_http_server.expects(:mount).with('/uploads', any_parameters).once
       mock_http_server.expects(:mount).with('/sourcemap', any_parameters).once
+      mock_http_server.expects(:mount).with('/trace', any_parameters).once
       mock_http_server.expects(:mount).with('/react-native-source-map', any_parameters).once
       mock_http_server.expects(:mount).with('/command', any_parameters).once
       mock_http_server.expects(:mount).with('/logs', any_parameters).once
@@ -92,6 +93,7 @@ module Maze
       mock_http_server.expects(:mount).with('/builds', any_parameters).once
       mock_http_server.expects(:mount).with('/uploads', any_parameters).once
       mock_http_server.expects(:mount).with('/sourcemap', any_parameters).once
+      mock_http_server.expects(:mount).with('/trace', any_parameters).once
       mock_http_server.expects(:mount).with('/react-native-source-map', any_parameters).once
       mock_http_server.expects(:mount).with('/logs', any_parameters).once
       mock_http_server.expects(:mount).with('/command', any_parameters).once

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -43,7 +43,7 @@ module Maze
       mock_http_server.expects(:mount).with('/builds', any_parameters).once
       mock_http_server.expects(:mount).with('/uploads', any_parameters).once
       mock_http_server.expects(:mount).with('/sourcemap', any_parameters).once
-      mock_http_server.expects(:mount).with('/trace', any_parameters).once
+      mock_http_server.expects(:mount).with('/traces', any_parameters).once
       mock_http_server.expects(:mount).with('/react-native-source-map', any_parameters).once
       mock_http_server.expects(:mount).with('/command', any_parameters).once
       mock_http_server.expects(:mount).with('/logs', any_parameters).once
@@ -93,7 +93,7 @@ module Maze
       mock_http_server.expects(:mount).with('/builds', any_parameters).once
       mock_http_server.expects(:mount).with('/uploads', any_parameters).once
       mock_http_server.expects(:mount).with('/sourcemap', any_parameters).once
-      mock_http_server.expects(:mount).with('/trace', any_parameters).once
+      mock_http_server.expects(:mount).with('/traces', any_parameters).once
       mock_http_server.expects(:mount).with('/react-native-source-map', any_parameters).once
       mock_http_server.expects(:mount).with('/logs', any_parameters).once
       mock_http_server.expects(:mount).with('/command', any_parameters).once


### PR DESCRIPTION
## Goal

Adds a new end for receiving trace requests, on `/traces`.

## Design

Follows the same approach as existing endpoints, e.g. #213.

A future PR will introduce JSON schema based validation of requests received on the endpoint.

## Changeset

New end point and tests.

## Tests

Unit tests updated and new e2e test added to CI.