### PR TITLE
Add Cucumber step to sort received requests by field key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.2.0 - 2022/10/03
+
+## Enhancements
+
+- Add step to sort received requests by specific field [402](https://github.com/bugsnag/maze-runner/pull/402)
+
 # 7.1.0 - 2022/09/30
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.1.0)
+    bugsnag-maze-runner (7.2.0)
       appium_lib (~> 12.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -35,9 +35,9 @@ GEM
       appium_lib_core (~> 5.0)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (>= 1.1, < 3.0)
-    appium_lib_core (5.3.0)
+    appium_lib_core (5.4.0)
       faye-websocket (~> 0.11.0)
-      selenium-webdriver (~> 4.2, < 4.5)
+      selenium-webdriver (~> 4.2, < 4.6)
     bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
@@ -116,7 +116,7 @@ GEM
     redcarpet (3.5.1)
     rexml (3.2.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.4.0)
+    selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -52,6 +52,15 @@ Then('I wait to receive {int} {word}') do |request_count, request_type|
   list.sort_by_sent_at! request_count
 end
 
+# Sorts the remaining requests in a list by the field path given.
+#
+# @step_input request_type [String] The type of request (error, session, build, etc)
+# @step_input field_path [String] The field to sort by
+Then('I sort the {word} by the payload field {string}') do |request_type, field_path|
+  list = Maze::Server.list_for(request_type)
+  list.sort_by! field_path
+end
+
 # Verify that at least a certain amount of requests have been received
 # This step is only intended for use in stress tests
 #

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.1.0'
+  VERSION = '7.2.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/request_list.rb
+++ b/lib/maze/request_list.rb
@@ -74,5 +74,19 @@ module Maze
       sub_list.sort_by! { |r| DateTime.parse(r[:request][header]) }
       sub_list.each_with_index { |r, i| @requests[@current + i] = r }
     end
+
+    # Sorts the remaining elements of the list by the field given, if present in all of those elements
+    def sort_by!(key_path)
+      list = remaining
+
+      # Key path must be present in all requests
+      # return if @requests.any? do |r|
+      #   Maze::Helper.read_key_path(r[:body], key_path).nil?
+      # end
+
+      # Sort the list and overwrite in the main list
+      list.sort_by! { |r| Maze::Helper.read_key_path(r[:body], key_path) }
+      list.each_with_index { |r, i| @requests[@current + i] = r }
+    end
   end
 end

--- a/lib/maze/request_list.rb
+++ b/lib/maze/request_list.rb
@@ -79,11 +79,6 @@ module Maze
     def sort_by!(key_path)
       list = remaining
 
-      # Key path must be present in all requests
-      # return if @requests.any? do |r|
-      #   Maze::Helper.read_key_path(r[:body], key_path).nil?
-      # end
-
       # Sort the list and overwrite in the main list
       list.sort_by! { |r| Maze::Helper.read_key_path(r[:body], key_path) }
       list.each_with_index { |r, i| @requests[@current + i] = r }

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 module Maze
   module Servlets
 

--- a/test/fixtures/comparison/features/value_checks.feature
+++ b/test/fixtures/comparison/features/value_checks.feature
@@ -2,8 +2,24 @@ Feature: Checks on value types
 
   Scenario: Checks on values of different types
     When I send a "values"-type request
-    Then I wait to receive 1 error
-    And the error payload field "values.uuid" is a UUID
+    And I wait to receive 1 error
+
+    Then the error payload field "values.uuid" is a UUID
     And the error payload field "values.number" is a number
     And the error payload field "values.integer" is an integer
     And the error payload field "values.date" is a date
+
+  Scenario: Verify that multiple requests can be sorted by field
+    When I send a "ordered 1"-type request
+    And I wait to receive 1 error
+    And I send a "ordered 2"-type request
+    # Now 2 errors in total
+    And I wait to receive 2 errors
+
+    Then the error payload field "bar" equals "b"
+    And I sort the errors by the payload field "bar"
+
+    Then the error payload field "bar" equals "a"
+    And I discard the oldest error
+
+    Then the error payload field "bar" equals "b"

--- a/test/request_list_test.rb
+++ b/test/request_list_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require_relative '../lib/maze/helper'
 require_relative '../lib/maze/request_list'
 
 # noinspection RubyNilAnalysis
@@ -157,7 +158,7 @@ class RequestListTest < Test::Unit::TestCase
     assert_equal [request2, request3, request1], list.remaining
   end
 
-  def test_sort_by_missing header
+  def test_sort_by_missing_header
     time1 = '2021-02-21T15:00:00.001Z'
     time2 = '2021-02-21T15:00:00.000Z'
 
@@ -219,5 +220,29 @@ class RequestListTest < Test::Unit::TestCase
     list.sort_by_sent_at! 2
 
     assert_equal [request3, request2, request4, request5], list.remaining
+  end
+
+  def test_sort_by_key_path
+    request1 = build_item 1
+    request2 = build_item 2
+    request3 = build_item 3
+
+    request1[:body] = {'animals' => [{'name' => 'zebra'}]}
+    request2[:body] = {'animals' => [{'name' => 'water buffalo'}]}
+    request3[:body] = {'animals' => [{'name' => 'yak'}]}
+
+    list = Maze::RequestList.new
+    list.add build_item 1
+    list.add request1
+    list.add request2
+    list.add request3
+    list.next
+
+    list.sort_by! 'animals.0.name'
+    assert_equal request2, list.current
+    list.next
+    assert_equal request3, list.current
+    list.next
+    assert_equal request1, list.current
   end
 end


### PR DESCRIPTION
## Goal

Add a Cucumber step to allow received requests to be sorted by a given field key.  E.g:
```
I sort the errors by the payload field "events.0.exceptions.0.message"
```

## Design

In the `I wait to receive {int} {word}` step,  Maze Runner will sort the requests by `Bugsnag-Sent-At` header to deal with occasional race conditions.  However, this isn't always sufficient if a notifier is sending 

## Changeset

New Cucumber step powered by a new method on the `RequestList` class.

## Tests

New e2e test added to CI.