### PR TITLE
Ensure String patterns behave as expected when calling Maze.check.match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.2.2 - 2022/10/07
+
+## Fixes
+
+- Ensure `String` patterns behave as expected when calling `Maze.check.match` [406](https://github.com/bugsnag/maze-runner/pull/406)
+
 # 7.2.1 - 2022/10/05
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 7.2.2 - 2022/10/07
+# 7.2.2 - 2022/10/10
 
 ## Fixes
 
-- Ensure `String` patterns behave as expected when calling `Maze.check.match` [406](https://github.com/bugsnag/maze-runner/pull/406)
+- Ensure `String` patterns behave as expected when calling `Maze.check.match` [407](https://github.com/bugsnag/maze-runner/pull/407)
 
 # 7.2.1 - 2022/10/05
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.2.1)
+    bugsnag-maze-runner (7.2.2)
       appium_lib (~> 12.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.2.1'
+  VERSION = '7.2.2'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/checks/assert_check.rb
+++ b/lib/maze/checks/assert_check.rb
@@ -24,7 +24,12 @@ module Maze
       end
 
       def match(pattern, string, message = nil)
-        assert_match(pattern, string, message)
+        regexp = if pattern.class == Regexp
+                   pattern
+                 else
+                   Regexp.new(pattern)
+                 end
+        assert_match(regexp, string, message)
       end
 
       def equal(expected, act, message = nil)

--- a/test/checks/assert_check_test.rb
+++ b/test/checks/assert_check_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../../lib/maze/checks/assert_check'
+
+class AssertCheckTest < Test::Unit::TestCase
+  # Strings are interpreted as regexes
+  def test_match_string
+    pattern = "Hello,*"
+    value = "Hello, World"
+    check = Maze::Checks::AssertCheck.new
+    check.match pattern, value
+  end
+
+  # Rexexp objects can be passed directly to match
+  def test_match_regexp
+    pattern = /Hello,*/
+    value = "Hello, World"
+    check = Maze::Checks::AssertCheck.new
+    check.match pattern, value
+  end
+end


### PR DESCRIPTION
## Goal

Ensure String patterns behave as expected when calling Maze.check.match.

## Design

It's infuriating when you write a new Cucumber step that uses `Maze.check.match` and forget to convert the pattern into a `Rexexp` option.  It's completely unobvious to a developer when it seems it should just work - this change means you can pass either a `String` or `Rexexp` object.

## Tests

New unit test added.