### PR TITLE
Ensure appium-lib-core is temporarily restricted to v5.4.0 in w3c mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.2.3 - 2022/10/11
+
+## Fixes
+
+- Ensure appium-lib-core is restricted to `5.4.*` while ongoing issues are present in `5.5.*` [408](https://github.com/bugsnag/maze-runner/pull/408)
+
 # 7.2.2 - 2022/10/10
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,9 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.2.2)
+    bugsnag-maze-runner (7.2.3)
       appium_lib (~> 12.0)
+      appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   else
     puts 'Bundling W3C drivers (Selenium 4/Appium 12)'
     spec.add_dependency 'appium_lib', '~> 12.0'
+    spec.add_dependency 'appium_lib_core', '~> 5.4.0'
     spec.add_dependency 'selenium-webdriver', '~> 4.0'
   end
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.2.2'
+  VERSION = '7.2.3'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry


### PR DESCRIPTION
## Goal

Appium-lib-core 5.5.0 has released, which has broken some core functionality of the notifier.  This change restricts our W3C running mode to appium-lib-core 5.4.*, which runs as expected.

Note - the appium-lib-core release does not effect legacy running.