### PR TITLE
Add step to allow setting a status code for specific connection types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 7.3.0 - 2022/10/17
 
-## Fixes
+## Enhancements
 
 - Add steps to enable specific status codes for given payload type [409](https://github.com/bugsnag/maze-runner/pull/409)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.3.0 - 2022/10/17
+
+## Fixes
+
+- Add steps to enable specific status codes for given payload type [409](https://github.com/bugsnag/maze-runner/pull/409)
+
 # 7.2.3 - 2022/10/11
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.2.3)
+    bugsnag-maze-runner (7.3.0)
       appium_lib (~> 12.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -102,14 +102,16 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
+    mini_portile2 (2.8.0)
     minitest (5.16.3)
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.13.8-x86_64-darwin)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
-    power_assert (2.0.1)
+    power_assert (2.0.2)
     props (1.2.0)
       iniparser (>= 0.1.0)
     racc (1.6.0)

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -23,6 +23,29 @@ When('I set the HTTP status code for the next request to {int}') do |status_code
   Maze::Server.status_code = status_code
 end
 
+# Steps the HTTP status code to be used for all subsequent requests for a given connection type
+#
+# @step_input http_verb [String] The type of request this code will be used for
+# @step_input status_code [Integer] The status code to return
+When('I set the HTTP status code for {string} requests to {int}') do |http_verb, status_code|
+  allowed_verbs = ['OPTIONS', 'GET', 'POST', 'PUT', 'UPDATE']
+  raise("Invalid HTTP verb: #{http_verb}") unless allowed_verbs.include?(http_verb)
+  Maze::Server.status_override_verb = http_verb
+  Maze::Server.status_code = status_code
+end
+
+# Steps the HTTP status code to be used for the next request for a given connection type
+#
+# @step_input http_verb [String] The type of request this code will be used for
+# @step_input status_code [Integer] The status code to return
+When('I set the HTTP status code for the next {string} request to {int}') do |http_verb, status_code|
+  allowed_verbs = ['OPTIONS', 'GET', 'POST', 'PUT', 'UPDATE']
+  raise("Invalid HTTP verb: #{http_verb}") unless allowed_verbs.include?(http_verb)
+  Maze::Server.status_override_verb = http_verb
+  Maze::Server.reset_status_code = true
+  Maze::Server.status_code = status_code
+end
+
 # Sets the response delay to be used for all subsequent requests
 #
 # @step_input response_delay_ms [Integer] The delay in milliseconds

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -28,7 +28,7 @@ end
 # @step_input http_verb [String] The type of request this code will be used for
 # @step_input status_code [Integer] The status code to return
 When('I set the HTTP status code for {string} requests to {int}') do |http_verb, status_code|
-  allowed_verbs = ['OPTIONS', 'GET', 'POST', 'PUT', 'UPDATE']
+  allowed_verbs = ['OPTIONS', 'GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'TRACE', 'PATCH', 'CONNECT']
   raise("Invalid HTTP verb: #{http_verb}") unless allowed_verbs.include?(http_verb)
   Maze::Server.status_override_verb = http_verb
   Maze::Server.status_code = status_code
@@ -39,7 +39,7 @@ end
 # @step_input http_verb [String] The type of request this code will be used for
 # @step_input status_code [Integer] The status code to return
 When('I set the HTTP status code for the next {string} request to {int}') do |http_verb, status_code|
-  allowed_verbs = ['OPTIONS', 'GET', 'POST', 'PUT', 'UPDATE']
+  allowed_verbs = ['OPTIONS', 'GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'TRACE', 'PATCH', 'CONNECT']
   raise("Invalid HTTP verb: #{http_verb}") unless allowed_verbs.include?(http_verb)
   Maze::Server.status_override_verb = http_verb
   Maze::Server.reset_status_code = true

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -95,6 +95,7 @@ After do |scenario|
   # Make sure we reset to HTTP 200 return status after each scenario
   Maze::Server.status_code = 200
   Maze::Server.reset_status_code = false
+  Maze::Server.status_override_verb = nil
 
   # Similarly for the response delay
   Maze::Server.response_delay_ms = 0

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.2.3'
+  VERSION = '7.3.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -14,6 +14,9 @@ module Maze
       # Allows overwriting of the server status code
       attr_writer :status_code
 
+      # Allows indicating a particular verb for the overwritten status code
+      attr_writer :status_override_verb
+
       # Dictates if the status code should be reset after use
       attr_writer :reset_status_code
 
@@ -29,9 +32,22 @@ module Maze
       # The intended HTTP status code on a successful request
       #
       # @return [Integer] The HTTP status code, defaults to 200
-      def status_code
-        code = @status_code ||= 200
-        @status_code = 200 if reset_status_code
+      def status_code(verb=nil)
+        if @status_override_verb
+          override_status = @status_override_verb.eql?(verb)
+        else
+          override_status = true
+        end
+
+        if override_status
+          code = @status_code ||= 200
+          if reset_status_code
+            @status_code = 200
+            @status_override_verb = nil
+          end
+        else
+          code = 200
+        end
         code
       end
 

--- a/lib/maze/servlets/command_servlet.rb
+++ b/lib/maze/servlets/command_servlet.rb
@@ -36,7 +36,7 @@ module Maze
         super
 
         response.header['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
-        response.status = Server.status_code
+        response.status = Server.status_code('OPTIONS')
       end
     end
   end

--- a/lib/maze/servlets/log_servlet.rb
+++ b/lib/maze/servlets/log_servlet.rb
@@ -27,7 +27,7 @@ module Maze
         @requests.add(hash)
 
         response.header['Access-Control-Allow-Origin'] = '*'
-        response.status = Server.status_code
+        response.status = Server.status_code('POST')
       rescue JSON::ParserError => e
         msg = "Unable to parse request as JSON: #{e.message}"
         $logger.error msg
@@ -57,7 +57,7 @@ module Maze
         super
 
         response.header['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
-        response.status = Server.status_code
+        response.status = Server.status_code('OPTIONS')
       end
     end
   end

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -58,7 +58,7 @@ module Maze
           sleep response_delay_ms / 1000.0
         end
         response.header['Access-Control-Allow-Origin'] = '*'
-        response.status = Server.status_code
+        response.status = Server.status_code('POST')
       rescue JSON::ParserError => e
         msg = "Unable to parse request as JSON: #{e.message}"
         if Maze.config.captured_invalid_requests.include? @request_type
@@ -96,7 +96,7 @@ module Maze
         super
 
         response.header['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
-        response.status = Server.status_code
+        response.status = Server.status_code('OPTIONS')
       end
 
       private

--- a/test/fixtures/http-response/features/scripts/send_verbed_requests.rb
+++ b/test/fixtures/http-response/features/scripts/send_verbed_requests.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'net/http'
+
+http = Net::HTTP.new('localhost', '9339')
+
+first_options_request = Net::HTTP::Options.new('/notify')
+first_options_response = http.request(first_options_request)
+
+first_post_request = Net::HTTP::Post.new('/notify')
+first_post_request['Content-Type'] = 'application/json'
+
+first_post_request.body = %({
+  "first_options_code": "#{first_options_response.code}"
+})
+
+first_post_response = http.request(first_post_request)
+
+second_options_request = Net::HTTP::Options.new('/notify')
+second_options_response = http.request(second_options_request)
+
+second_post_request = Net::HTTP::Post.new('/notify')
+second_post_request['Content-Type'] = 'application/json'
+
+second_post_request.body = %({
+  "first_options_code": "#{first_options_response.code}",
+  "first_post_code": "#{first_post_response.code}",
+  "second_options_code": "#{second_options_response.code}"
+})
+
+http.request(second_post_request)

--- a/test/fixtures/http-response/features/set_different_responses.feature
+++ b/test/fixtures/http-response/features/set_different_responses.feature
@@ -25,7 +25,7 @@ Feature: Setting different response codes
         And the error payload field "second_code" equals "400"
         And the error payload field "second_time" is greater than 3000
 
-    Scenario: Server response code can be set a single request (503)
+    Scenario: Server response code can be set for a single request (503)
         Given I set the HTTP status code for the next request to 503
         When I run the script "features/scripts/send_request.rb" using ruby synchronously
         And I wait to receive 3 errors
@@ -34,3 +34,23 @@ Feature: Setting different response codes
         And the error payload field "first_code" equals "503"
         And I discard the oldest error
         And the error payload field "second_code" equals "200"
+
+    Scenario: Server response code can be set for a specific conneciton type (504)
+        Given I set the HTTP status code for the next "OPTIONS" request to 504
+        When I run the script "features/scripts/send_verbed_requests.rb" using ruby synchronously
+        And I wait to receive 2 errors
+        Then the error payload field "first_options_code" equals "504"
+        And I discard the oldest error
+        And the error payload field "first_options_code" equals "504"
+        And the error payload field "first_post_code" equals "200"
+        And the error payload field "second_options_code" equals "200"
+
+    Scenario: Server response code can be set for all subsequent instances of a  specific conneciton type (505)
+        Given I set the HTTP status code for "OPTIONS" requests to 505
+        When I run the script "features/scripts/send_verbed_requests.rb" using ruby synchronously
+        And I wait to receive 2 errors
+        Then the error payload field "first_options_code" equals "505"
+        And I discard the oldest error
+        And the error payload field "first_options_code" equals "505"
+        And the error payload field "first_post_code" equals "200"
+        And the error payload field "second_options_code" equals "505"


### PR DESCRIPTION
## Goal

Allows a "verb" to be specified when setting an HTTP response, so we can make our tests involving `OPTIONS` requests more deterministic

## Tests

Expanded http_payload tests to cover the usage of the new steps.
