### PR TITLE
Add step to check for a minimum number of requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# TBD
+# 7.4.0 - 2022/10/20
 
 ## Enhancements
 
 - Add error code handling for pipeline management [406](https://github.com/bugsnag/maze-runner/pull/406)
+- Add step `I wait to receive at least {int} {word}` [411](https://github.com/bugsnag/maze-runner/pull/411)
 
 # 7.3.0 - 2022/10/17
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.3.0'
+  VERSION = '7.4.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/test/fixtures/comparison/features/test_across_requests.feature
+++ b/test/fixtures/comparison/features/test_across_requests.feature
@@ -4,6 +4,7 @@ Feature: Comparing elements from one payload to another
         When I send a "equal"-type request
         And I send a "equal"-type request
         Then I wait to receive 2 errors
+        And I wait to receive at least 1 error
         And the error payload field "animals.0" is stored as the value "animal_zero"
         And I discard the oldest error
         And the error payload field "animals.0" equals the stored value "animal_zero"


### PR DESCRIPTION
## Goal

Provide a step for check for a minimum number of requests (rather than a precise amount).

## Design

Sometimes a scenario doesn't care if extra requests are sent (e.g. due to automation quirks that leads to multiple app launches).  This new step provides more flexibility.

## Tests

Step added to existing CI test.