### PR TITLE
Remove support for Google Pixel running Android 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Add error code handling for pipeline management [406](https://github.com/bugsnag/maze-runner/pull/406)
 - Add step `I wait to receive at least {int} {word}` [411](https://github.com/bugsnag/maze-runner/pull/411)
 
+## Removals
+
+- Remove support for Google Pixel-8.0 on BrowserStack (deprecated by them) [412](https://github.com/bugsnag/maze-runner/pull/412)
+  
 # 7.3.0 - 2022/10/17
 
 ## Enhancements

--- a/lib/maze/client/appium/bs_devices.rb
+++ b/lib/maze/client/appium/bs_devices.rb
@@ -106,7 +106,6 @@ module Maze
             add_android 'Samsung Galaxy J7 Prime', '8.1', hash                # ANDROID_8_1_SAMSUNG_GALAXY_J7_PRIME
             add_android 'Samsung Galaxy Tab S4', '8.1', hash                  # ANDROID_8_1_SAMSUNG_GALAXY_TAB_S4
             add_android 'Samsung Galaxy Tab S3', '8.0', hash                  # ANDROID_8_0_SAMSUNG_GALAXY_TAB_S3
-            add_android 'Google Pixel', '8.0', hash                           # ANDROID_8_0_GOOGLE_PIXEL
             add_android 'Google Pixel 2', '8.0', hash                         # ANDROID_8_0_GOOGLE_PIXEL_2
             add_android 'Samsung Galaxy S9', '8.0', hash                      # ANDROID_8_0_SAMSUNG_GALAXY_S9
             add_android 'Samsung Galaxy S9 Plus', '8.0', hash                 # ANDROID_8_0_SAMSUNG_GALAXY_S9_PLUS


### PR DESCRIPTION
Remove support for Google Pixel running Android 8 - it has been deprecated by BrowserStack.
