### PR TITLE
Use correct capability for OS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.5.1 - 2022/11/01
+
+## Fixes
+
+- Correct setting of Maze.config.os_version in W3C mode [415](https://github.com/bugsnag/maze-runner/pull/415)
+
 # 7.5.0 - 2022/10/26
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.5.0)
+    bugsnag-maze-runner (7.5.1)
       appium_lib (~> 12.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.5.0'
+  VERSION = '7.5.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -65,7 +65,7 @@ module Maze
               if config.legacy_driver?
                 config.os_version = Maze::Client::Appium::BrowserStackDevices::DEVICE_HASH[config.device]['os_version'].to_f
               else
-                config.os_version = Maze::Client::Appium::BrowserStackDevices::DEVICE_HASH[config.device]['osVersion'].to_f
+                config.os_version = Maze::Client::Appium::BrowserStackDevices::DEVICE_HASH[config.device]['platformVersion'].to_f
               end
             end
             config.bs_local = Maze::Helper.expand_path(options[Maze::Option::BS_LOCAL])


### PR DESCRIPTION
## Goal

Correct the setting of `Maze.config.os_version` when using the w3c protocol on BrowserStack.

## Changeset

Correct the capability that we pull out for use at the OS version in config.

## Tests

Tested as part of updating bugsnag-android (OS version based `@skip`a were not working before this).