### PR TITLE
Log device UDID on BrowserStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # TBD
 
+## Enhancements
+
+- Log device UDID on BrowserStack [418](https://github.com/bugsnag/maze-runner/pull/418)
+
 ## Fixes
 
 - Provide more intuitive message for Maze.check.match failures [417](https://github.com/bugsnag/maze-runner/pull/417)

--- a/lib/maze/client/appium/bs_client.rb
+++ b/lib/maze/client/appium/bs_client.rb
@@ -36,6 +36,10 @@ module Maze
 
         def log_session_info
           if Maze.config.device || Maze.config.browser
+            # Log device id
+            udid = Maze.driver.session_capabilities['udid']
+            $logger.info "Running on device: #{udid}" unless udid.nil?
+
             # Log a link to the BrowserStack session search dashboard
             build = Maze.driver.capabilities[:build]
             url = "https://app-automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"


### PR DESCRIPTION
## Goal

Log the device ID after connecting to a device on BrowserStack.

## Tests

Tested locally with both Android and iOS devices. 