### PR TITLE
Add support for iOS 16 on BrowserStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.27.0 - 2022/11/11
+
+## Enhancements
+
+- Add support for iOS 16 on BrowserStack [421](https://github.com/bugsnag/maze-runner/pull/421)
+
 # 6.26.1 - 2022/09/14
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (6.26.1)
+    bugsnag-maze-runner (6.27.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -104,11 +104,11 @@ GEM
     minitest (5.16.2)
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.13.8-x86_64-darwin)
+    nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
-    power_assert (2.0.1)
+    power_assert (2.0.2)
     props (1.2.0)
       iniparser (>= 0.1.0)
     racc (1.6.0)
@@ -121,7 +121,7 @@ GEM
       rubyzip (>= 1.2.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
-    test-unit (3.5.3)
+    test-unit (3.5.5)
       power_assert
     textutils (1.4.0)
       activesupport

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '6.26.1'
+  VERSION = '6.27.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/browser_stack_devices.rb
+++ b/lib/maze/browser_stack_devices.rb
@@ -97,7 +97,7 @@ module Maze
           'ANDROID_4_4' => make_android_hash('Google Nexus 5', '4.4', APPIUM_1_9_1),
 
           # iOS devices
-          'IOS_16_BETA' => make_ios_hash('iPhone 12 Pro Max', '16 Beta'),
+          'IOS_16' => make_ios_hash('iPhone 14', '16'),
           'IOS_15' => make_ios_hash('iPhone 11 Pro', '15'),
           'IOS_14' => make_ios_hash('iPhone 11', '14'),
           'IOS_13' => make_ios_hash('iPhone 8', '13'),


### PR DESCRIPTION
## Goal

Add support for iOS 16 on BrowserStack

## Tests

Basic use tested locally using `bugsnag-cocoa`.