### PR TITLE
Add support for iOS 16 on BrowserStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,11 @@
-# 7.TDB (integration/performance)
+# 7.6.0- - 2022/11/11
 
 ## Enhancements
 
 - Add `/trace` endpoint [402](https://github.com/bugsnag/maze-runner/pull/402)
 - Add steps to set sampling probably response header [419](https://github.com/bugsnag/maze-runner/pull/419)
-
-
-##############################
-
-
-# TBD - Next release
-
-## Enhancements
-
 - Log device UDID on BrowserStack [418](https://github.com/bugsnag/maze-runner/pull/418)
+- Add support for iOS 16 on BrowserStack [422](https://github.com/bugsnag/maze-runner/pull/422)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.5.1)
+    bugsnag-maze-runner (7.6.0)
       appium_lib (~> 12.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.5.1'
+  VERSION = '7.6.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/client/appium/bs_devices.rb
+++ b/lib/maze/client/appium/bs_devices.rb
@@ -124,6 +124,10 @@ module Maze
             add_android 'Samsung Galaxy Tab 4', '4.4', hash                   # ANDROID_4_4_SAMSUNG_GALAXY_TAB_4
 
             # Specific iOS devices
+            add_ios 'iPhone 14 Plus', '16.0', hash                            # IOS_16_0_IPHONE_14_PLUS
+            add_ios 'iPhone 14 Pro', '16.0', hash                             # IOS_16_0_IPHONE_14_PRO
+            add_ios 'iPhone 14 Pro Max', '16.0', hash                         # IOS_16_0_IPHONE_14_PRO_MAX
+
             add_ios 'iPhone 8 Plus', '11.0', hash                             # IOS_11_0_IPHONE_8_PLUS
             add_ios 'iPhone X', '11.0', hash                                  # IOS_11_0_IPHONE_X
             add_ios 'iPhone SE', '11.0', hash                                 # IOS_11_0_IPHONE_SE

--- a/lib/maze/client/appium/bs_devices.rb
+++ b/lib/maze/client/appium/bs_devices.rb
@@ -84,7 +84,7 @@ module Maze
               'ANDROID_4_4' => make_android_hash('Google Nexus 5', '4.4'),
 
               # iOS devices
-              'IOS_16_BETA' => make_ios_hash('iPhone 12 Pro Max', '16 Beta'),
+              'IOS_16' => make_ios_hash('iPhone 14', '16'),
               'IOS_15' => make_ios_hash('iPhone 11 Pro', '15'),
               'IOS_14' => make_ios_hash('iPhone 11', '14'),
               'IOS_13' => make_ios_hash('iPhone 8', '13'),


### PR DESCRIPTION
## Goal

Add support for iOS 16 on BrowserStack.

## Tests

Tested that all new devices work with BrowserStack, using the symbolic names mentioned in the comments.