### PR TITLE
Temporary soft fail on Android 7

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -191,6 +191,9 @@ steps:
     concurrency: 24
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
+    soft_fail:
+      - exit_status: 1
 
   - label: 'BrowserStack app-automate - Android 13 - W3C'
     timeout_in_minutes: 20


### PR DESCRIPTION
## Goal

Allows tests on Android 7 to soft fail whilst the secure tunnel outage at BrowserStack is resolved.

Once the outage is resolved and the job starts running again we should remove the soft fail.

## Testing

Covered by CI.