### PR TITLE
Add support for 'docker compose exec' commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Add `--tunnel` (and `--no-tunnel`) option [431](https://github.com/bugsnag/maze-runner/pull/431)
+- Add support for running `docker compose exec` commands [425](https://github.com/bugsnag/maze-runner/pull/425)
 
 ## Fixes
 

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -97,6 +97,14 @@ When('I run the service {string} with the command') do |service, command|
   Maze::Docker.start_service(service, command: one_line_cmd)
 end
 
+When('I execute the command {string} in the service {string}') do |command, service|
+  Maze::Docker.exec(service, command)
+end
+
+When('I execute the command {string} in the service {string} in the background') do |command, service|
+  Maze::Docker.exec(service, command, detach: true)
+end
+
 # Allows validation of the last exit code of the last run docker-compose command.
 # Will fail if no commands have been run.
 #

--- a/lib/maze/docker.rb
+++ b/lib/maze/docker.rb
@@ -54,6 +54,21 @@ module Maze
         @services_started = true
       end
 
+      # Execute a command in an already running docker container. Use {start_service}
+      # to build and run the service before calling this method
+      #
+      # This is equivalent to the Docker Compose 'exec' command:
+      # https://docs.docker.com/engine/reference/commandline/compose_exec/
+      #
+      # @param service [String] The name of the service. This must already be running
+      # @param command [String] The command to run
+      # @param detach [Boolean] Optional. Whether to run detached
+      def exec(service, command, detach: false)
+        flags = detach ? " --detach" : ""
+
+        run_docker_compose_command("exec #{flags} #{service} /bin/sh -c '#{command}'")
+      end
+
       # Kills a running service
       #
       # @param service [String] The name of the service to kill

--- a/test/fixtures/docker-app/features/fixtures/docker-compose.yml
+++ b/test/fixtures/docker-app/features/fixtures/docker-compose.yml
@@ -10,6 +10,11 @@ services:
       context: interactive
     restart: "no"
 
+  sleepy:
+    build:
+      context: sleepy
+    restart: "no"
+
 networks:
   default:
     name: ${NETWORK_NAME:-core-maze-runner}

--- a/test/fixtures/docker-app/features/fixtures/sleepy/Dockerfile
+++ b/test/fixtures/docker-app/features/fixtures/sleepy/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu
+
+CMD sleep infinity

--- a/test/fixtures/docker-app/features/run_docker_services.feature
+++ b/test/fixtures/docker-app/features/run_docker_services.feature
@@ -104,3 +104,14 @@ Feature: Running docker services and commands
         Then the last interactive command exit code is 127
         When I input "(exit 0)" interactively
         Then the last interactive command exited successfully
+
+    Scenario: Commands can be run with docker compose exec
+        Given I start the service "sleepy"
+        When I execute the command "echo hi there" in the service "sleepy"
+        Then the last run docker command output "hi there"
+
+    Scenario: Commands can be run with docker compose exec in the background
+        Given I start the service "sleepy"
+        When I execute the command "echo hello friend > greeting.txt" in the service "sleepy" in the background
+        And I execute the command "sleep 2 ; cat greeting.txt" in the service "sleepy"
+        Then the last run docker command output "hello friend"


### PR DESCRIPTION
## Goal

Add support for running `docker compose exec` in tests, which allows running commands in already running containers

I've added two new steps as well:

> I execute the command {string} in the service {string}
> I execute the command {string} in the service {string} in the background

Where "in the background" means "pass the `--detach` option"