### PR TITLE
Refactor response delay steps to use Maze::Generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Allow HTTP response codes to be set for a series of requests [424](https://github.com/bugsnag/maze-runner/pull/424)
 - Allow sampling probability header to be set for a series of requests [426](https://github.com/bugsnag/maze-runner/pull/426)
 
+## Refactor
+
+- Refactor response delay steps to use `Maze::Generator` [427](https://github.com/bugsnag/maze-runner/pull/427)
+
 # 7.6.0 - 2022/11/11
 
 ## Enhancements

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -70,6 +70,20 @@ When('I set the sampling probability for the next traces to {string}') do |statu
   Maze::Server.set_sampling_probability_generator(create_defaulting_generator(codes, Maze::Server::DEFAULT_SAMPLING_PROBABILITY))
 end
 
+# Sets the response delay to be used for all subsequent requests
+#
+# @step_input response_delay_ms [Integer] The delay in milliseconds
+When('I set the response delay to {int} milliseconds') do |response_delay_ms|
+  Maze::Server.set_response_delay_generator(Maze::Generator.new [response_delay_ms].cycle)
+end
+
+# Sets the response delay to be used for the next request
+#
+# @step_input delay [Integer] The delay in milliseconds
+When('I set the response delay for the next request to {int} milliseconds') do |delay|
+  Maze::Server.set_response_delay_generator(create_defaulting_generator([delay], Maze::Server::DEFAULT_RESPONSE_DELAY))
+end
+
 def create_defaulting_generator(codes, default)
   enumerator = Enumerator.new do |yielder|
     codes.each do |code|
@@ -83,20 +97,6 @@ def create_defaulting_generator(codes, default)
   Maze::Generator.new enumerator
 end
 
-# Sets the response delay to be used for all subsequent requests
-#
-# @step_input response_delay_ms [Integer] The delay in milliseconds
-When('I set the response delay to {int} milliseconds') do |response_delay_ms|
-  Maze::Server.response_delay_ms = response_delay_ms
-end
-
-# Sets the response delay to be used for the next request
-#
-# @step_input delay [Integer] The delay in milliseconds
-When('I set the response delay for the next request to {int} milliseconds') do |delay|
-  Maze::Server.reset_response_delay = true
-  Maze::Server.response_delay_ms = delay
-end
 
 # Attempts to open a URL.
 #

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -45,6 +45,7 @@ BeforeAll do
 
   # Start mock server
   Maze::Server.start
+  Maze::Server.set_response_delay_generator(Maze::Generator.new [Maze::Server::DEFAULT_RESPONSE_DELAY].cycle)
   Maze::Server.set_sampling_probability_generator(Maze::Generator.new [Maze::Server::DEFAULT_SAMPLING_PROBABILITY].cycle)
   Maze::Server.set_status_code_generator(Maze::Generator.new [Maze::Server::DEFAULT_STATUS_CODE].cycle)
 

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -10,18 +10,21 @@ module Maze
   # Receives and stores requests through a WEBrick HTTPServer
   class Server
     ALLOWED_HTTP_VERBS = %w[OPTIONS GET POST PUT DELETE HEAD TRACE PATCH CONNECT]
+    DEFAULT_RESPONSE_DELAY = 0
     DEFAULT_SAMPLING_PROBABILITY = 1
     DEFAULT_STATUS_CODE = 200
 
     class << self
-      # Allows a delay in milliseconds before responding to HTTP requests to be set
-      attr_writer :response_delay_ms
-
-      # Dictates if the response delay should be reset after use
-      attr_writer :reset_response_delay
-
       # @return [String] The UUID attached to all command requests for this session
       attr_reader :command_uuid
+
+      # Sets the response delay generator.
+      #
+      # @param generator [Maze::Generator] The new generator
+      def set_response_delay_generator(generator)
+        @response_delay_generator&.close
+        @response_delay_generator = generator
+      end
 
       # Sets the sampling probability generator.
       #
@@ -65,13 +68,7 @@ module Maze
       end
 
       def response_delay_ms
-        delay = @response_delay_ms ||= 0
-        @response_delay_ms = 0 if reset_response_delay
-        delay
-      end
-
-      def reset_response_delay
-        @reset_response_delay ||= false
+        @response_delay_generator.next
       end
 
       # Provides dynamic access to request lists by name
@@ -240,11 +237,11 @@ module Maze
 
       def reset!
         # Reset generators
+        set_response_delay_generator(Maze::Generator.new [DEFAULT_RESPONSE_DELAY].cycle)
         set_status_code_generator(Maze::Generator.new [DEFAULT_STATUS_CODE].cycle)
         set_sampling_probability_generator(Maze::Generator.new [DEFAULT_SAMPLING_PROBABILITY].cycle)
 
-        @response_delay_ms = 0
-        @reset_response_delay = false
+        # Clear request lists
         errors.clear
         sessions.clear
         builds.clear
@@ -257,6 +254,7 @@ module Maze
 
       private
 
+      attr_writer :response_delay_generator
       attr_writer :sampling_probability_generator
     end
   end


### PR DESCRIPTION
## Goal

Refactor the response delay steps to use Maze::Generator, meaning that all the steps in `network_steps.rb` use a consistent approach (and code in `Maze::Server` etc is consistent as a result).

## Design

I considered adding a new step for controlling the response delay over a series of requests, but decided there was no need for this and adding it was potentially only creating a maintenance burden for ourselves.

## Tests

Covered by existing e2e tests.