### PR TITLE
Add negative breadcrumb type and message step with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.8.0 - TBD
+
+## Enhancements
+
+- Add additional step for breadcrumb tests, and refactor old steps for consistency [428](https://github.com/bugsnag/maze-runner/pull/428)
+
 # 7.7.0 - 2022/11/30
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.7.0)
+    bugsnag-maze-runner (7.8.0)
       appium_lib (~> 12.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/features/steps/breadcrumb_steps.rb
+++ b/lib/features/steps/breadcrumb_steps.rb
@@ -39,6 +39,20 @@ Then('the event does not have a {string} breadcrumb') do |type|
   raise("Breadcrumb with type: #{type} matched") if found
 end
 
+# Test whether the first event entry does not contain a breadcrumb with a specific type and message.
+# Used for confirming filtering of breadcrumbs
+#
+# @step_input type [String] The type of the breadcrumb expected to be absent
+# @step_input message [String] The message of the breadcrumb expected to be absent
+Then('the event does not have a {string} breadcrumb with message {string}') do |type, message|
+  value = Maze::Server.errors.current[:body]['events'].first['breadcrumbs']
+  found = false
+  value.each do |crumb|
+    found = true if crumb['type'] == type && crumb['metaData'] && crumb['metaData']['message'] == message
+  end
+  raise("Breadcrumb with type: #{type} and message: #{message} matched") if found
+end
+
 # Tests whether any breadcrumb matches a given JSON fixture.  This follows all the usual rules for JSON fixture matching.
 #
 # @step_input json_fixture [String] A path to the JSON fixture to compare against

--- a/lib/features/steps/breadcrumb_steps.rb
+++ b/lib/features/steps/breadcrumb_steps.rb
@@ -7,9 +7,7 @@
 Then('the event has a {string} breadcrumb named {string}') do |type, name|
   value = Maze::Server.errors.current[:body]['events'].first['breadcrumbs']
   found = false
-  value.each do |crumb|
-    found = true if crumb['type'] == type and crumb['name'] == name
-  end
+  found = value.any? { |crumb| crumb['type'] == type }
   raise("No breadcrumb matched: #{value}") unless found
 end
 
@@ -19,10 +17,7 @@ end
 # @step_input message [String] The expected breadcrumb's message
 Then('the event has a {string} breadcrumb with message {string}') do |type, message|
   value = Maze::Server.errors.current[:body]['events'].first['breadcrumbs']
-  found = false
-  value.each do |crumb|
-    found = true if crumb['type'] == type && crumb['metaData'] && crumb['metaData']['message'] == message
-  end
+  found = value.any? { |crumb| crumb['type'] == type && crumb['metaData'] && crumb['metaData']['message'] == message }
   raise("No breadcrumb matched: #{value}") unless found
 end
 
@@ -32,10 +27,7 @@ end
 # @step_input type [String] The type of breadcrumb expected to not be present
 Then('the event does not have a {string} breadcrumb') do |type|
   value = Maze::Server.errors.current[:body]['events'].first['breadcrumbs']
-  found = false
-  value.each do |crumb|
-    found = true if crumb['type'] == type
-  end
+  found = value.any? { |crumb| crumb['type'] == type  }
   raise("Breadcrumb with type: #{type} matched") if found
 end
 
@@ -46,10 +38,7 @@ end
 # @step_input message [String] The message of the breadcrumb expected to be absent
 Then('the event does not have a {string} breadcrumb with message {string}') do |type, message|
   value = Maze::Server.errors.current[:body]['events'].first['breadcrumbs']
-  found = false
-  value.each do |crumb|
-    found = true if crumb['type'] == type && crumb['metaData'] && crumb['metaData']['message'] == message
-  end
+  found = value.any? { |crumb| crumb['type'] == type && crumb['metaData'] && crumb['metaData']['message'] == message }
   raise("Breadcrumb with type: #{type} and message: #{message} matched") if found
 end
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.7.0'
+  VERSION = '7.8.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
@@ -15,6 +15,11 @@ Feature: Breadcrumb helper steps
         Then I wait to receive an error
         And the event does not have a "request" breadcrumb
 
+    Scenario: The payload does not contain a type of breadcrumb with a particular message
+        When I send a "breadcrumbs"-type request
+        Then I wait to receive an error
+        And the event does not have a "process" breadcrumb with message "Barfoo"
+
     Scenario: The payload has a breadcrumb which matches a JSON fixture
         When I send a "breadcrumbs"-type request
         Then I wait to receive an error

--- a/test/fixtures/payload-helpers/features/support/send_request.rb
+++ b/test/fixtures/payload-helpers/features/support/send_request.rb
@@ -227,6 +227,14 @@ def send_request(request_type, mock_api_port = 9339)
                   'b' => 2,
                   'c' => 3
                 }
+              },
+              {
+                'type' => 'testing',
+                'name' => 'bar',
+                'timestamp' => '2019-11-26T10:18:23Z',
+                'metaData' => {
+                  'message' => "Barfoo"
+                }
               }
             ]
           }


### PR DESCRIPTION
## Goal

Enables us to verify that a breadcrumb with a specific message isn't present, even if a breadcrumb with the same type is present.

Added tests to verify positive conditions, and manually verified the step catches when the breadcrumb is present.