### PR TITLE
Use 'docker compose' not 'docker-compose'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Enhancements
+
+- Use `docker compose` instead of `docker-compose` [429](https://github.com/bugsnag/maze-runner/pull/429)
+
 # 7.8.0 - 2022/12/05
 
 ## Enhancements

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -3,9 +3,24 @@ ARG RUBY_VERSION
 FROM ruby:${RUBY_VERSION}-bullseye as ci-base
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y apt-utils docker-compose wget unzip bash bundler \
+    apt-get install -y apt-utils wget unzip bash bundler \
                        # Needed for symbolication
-                       llvm-11
+                       llvm-11 \
+                       # Needed to install docker compose
+                       ca-certificates \
+                       curl \
+                       gnupg \
+                       lsb-release
+
+# https://docs.docker.com/engine/install/ubuntu/#set-up-the-repository
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# install docker & docker compose
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
 RUN ruby -v
 

--- a/lib/maze/docker.rb
+++ b/lib/maze/docker.rb
@@ -91,7 +91,7 @@ module Maze
       def get_docker_compose_command(command)
         project_name = compose_project_name.nil? ? '' : "-p #{compose_project_name}"
 
-        "docker-compose #{project_name} -f #{COMPOSE_FILENAME} #{command}"
+        "docker compose #{project_name} -f #{COMPOSE_FILENAME} #{command}"
       end
 
       def run_docker_compose_command(command, success_codes: nil)


### PR DESCRIPTION
## Goal

`docker compose` (with a space) is v2 of the docker compose CLI. Currently Maze Runner uses `docker-compose`, which is now out of date and doesn't implement some commands (e.g. `docker compose cp`)

This is supposed to be backwards compatible, so we now always run docker compose commands with `docker compose`