### PR TITLE
Bump Bitbar browser versions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -238,7 +238,7 @@ steps:
     concurrency: 2
     concurrency_group: 'browserstack'
 
-  - label: 'BitBar web browser test - Firefox v104'
+  - label: 'BitBar web browser test - Firefox v107'
     depends_on: "ci-image-ruby-2-7"
     timeout_in_minutes: 10
     plugins:
@@ -249,7 +249,7 @@ steps:
     command: >-
       bundle exec maze-runner
       --farm=bb
-      --browser=firefox_104
+      --browser=firefox_107
     env:
       RUBY_VERSION: "2.7"
     concurrency: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-# TBD
+# 7.9.0 - 2022/12/07
 
 ## Enhancements
 
 - Use `docker compose` instead of `docker-compose` [429](https://github.com/bugsnag/maze-runner/pull/429)
+- Bump Bitbar browsers to those currently available [430](https://github.com/bugsnag/maze-runner/pull/430)
+  - Firefox 102 to 107
+  - Chrome 103 to 108
+  - Edge 101 to 106
 
 # 7.8.0 - 2022/12/05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Firefox 102 to 107
   - Chrome 103 to 108
   - Edge 101 to 106
+  - Safari 15 to 16
 
 # 7.8.0 - 2022/12/05
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,9 +9,9 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.8.0)
-      appium_lib (~> 12.0)
-      appium_lib_core (~> 5.5.0)
+    bugsnag-maze-runner (7.9.0)
+      appium_lib (~> 12.0.0)
+      appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
@@ -42,7 +42,7 @@ GEM
     appium_lib_core (5.4.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 4.2, < 4.6)
-    bugsnag (6.24.2)
+    bugsnag (6.25.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (4.1.0)
@@ -118,7 +118,7 @@ GEM
     props (1.2.0)
       iniparser (>= 0.1.0)
     public_suffix (5.0.0)
-    racc (1.6.0)
+    racc (1.6.1)
     rake (12.3.3)
     redcarpet (3.5.1)
     rexml (3.2.5)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.8.0'
+  VERSION = '7.9.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/client/selenium/bb_browsers.yml
+++ b/lib/maze/client/selenium/bb_browsers.yml
@@ -1,57 +1,64 @@
-chrome_97:
-  platform: 'Windows'
-  osVersion: '10'
-  browserName: 'chrome'
-  version: '97'
-  resolution: '1920x1080'
-
-chrome_98:
-  platform: 'Windows'
-  osVersion: '10'
-  browserName: 'chrome'
-  version: '98'
-  resolution: '1920x1080'
-
-chrome_99:
-  platform: 'Windows'
-  osVersion: '10'
-  browserName: 'chrome'
-  version: '99'
-  resolution: '1920x1080'
-
-chrome_102:
+chrome_108:
   platform: 'Windows'
   osVersion: '11'
   browserName: 'chrome'
-  version: '102'
+  version: '108'
   resolution: '1920x1080'
 
-firefox_96:
+chrome_107:
   platform: 'Windows'
-  osVersion: '10'
-  browserName: 'firefox'
-  version: '96'
+  osVersion: '11'
+  browserName: 'chrome'
+  version: '107'
   resolution: '1920x1080'
 
-firefox_97:
+chrome_106:
   platform: 'Windows'
-  osVersion: '10'
-  browserName: 'firefox'
-  version: '97'
+  osVersion: '11'
+  browserName: 'chrome'
+  version: '106'
   resolution: '1920x1080'
 
-firefox_98:
+chrome_105:
   platform: 'Windows'
-  osVersion: '10'
-  browserName: 'firefox'
-  version: '98'
+  osVersion: '11'
+  browserName: 'chrome'
+  version: '105'
   resolution: '1920x1080'
 
-firefox_101:
+chrome_104:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'chrome'
+  version: '104'
+  resolution: '1920x1080'
+
+chrome_103:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'chrome'
+  version: '103'
+  resolution: '1920x1080'
+
+firefox_107:
   platform: 'Windows'
   osVersion: '11'
   browserName: 'firefox'
-  version: '101'
+  version: '107'
+  resolution: '1920x1080'
+
+firefox_106:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'firefox'
+  version: '106'
+  resolution: '1920x1080'
+
+firefox_105:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'firefox'
+  version: '105'
   resolution: '1920x1080'
 
 firefox_104:
@@ -61,6 +68,20 @@ firefox_104:
   version: '104'
   resolution: '1920x1080'
 
+firefox_103:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'firefox'
+  version: '103'
+  resolution: '1920x1080'
+
+firefox_102:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'firefox'
+  version: '102'
+  resolution: '1920x1080'
+
 ie_11:
   platform: 'Windows'
   osVersion: '10'
@@ -68,18 +89,32 @@ ie_11:
   version: '11'
   resolution: '1920x1080'
 
-edge_97:
+edge_106:
   platform: 'Windows'
-  osVersion: '10'
+  osVersion: '11'
   browserName: 'MicrosoftEdge'
-  version: '97'
+  version: '106'
   resolution: '1920x1080'
 
-edge_98:
+edge_105:
   platform: 'Windows'
-  osVersion: '10'
+  osVersion: '11'
   browserName: 'MicrosoftEdge'
-  version: '98'
+  version: '105'
+  resolution: '1920x1080'
+
+edge_104:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'MicrosoftEdge'
+  version: '104'
+  resolution: '1920x1080'
+
+edge_103:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'MicrosoftEdge'
+  version: '103'
   resolution: '1920x1080'
 
 edge_102:
@@ -87,6 +122,13 @@ edge_102:
   osVersion: '11'
   browserName: 'MicrosoftEdge'
   version: '102'
+  resolution: '1920x1080'
+
+edge_101:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'MicrosoftEdge'
+  version: '101'
   resolution: '1920x1080'
 
 safari_15:

--- a/lib/maze/client/selenium/bb_browsers.yml
+++ b/lib/maze/client/selenium/bb_browsers.yml
@@ -131,6 +131,13 @@ edge_101:
   version: '101'
   resolution: '1920x1080'
 
+safari_16:
+  platform: 'macOS'
+  osVersion: '13'
+  browserName: 'safari'
+  version: '16'
+  resolution: '2560x1920'
+
 safari_15:
   platform: 'macOS'
   osVersion: '12'


### PR DESCRIPTION
## Goal

Bump Bitbar browser versions to those currently available:

<img width="469" alt="image" src="https://user-images.githubusercontent.com/5239394/206192561-5fe47723-8355-4973-a54a-e23066e6215c.png">

## Documentation

This is a quick fix after some browsers we depend on slipped off of Bitbar.  In future we will implement a "latest" based option.

## Tests

Partially covered by CI and I've run a test on every option locally.