### PR TITLE
Add --tunnel option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # TBD
 
+## Enhancements
+
+- Add `--tunnel` (and `--no-tunnel`) option [431](https://github.com/bugsnag/maze-runner/pull/431)
+
 ## Fixes
 
 - Relax check on React Native Notifier name [432](https://github.com/bugsnag/maze-runner/pull/432)

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -11,9 +11,11 @@ module Maze
           end
           config.app = Maze::Client::BitBarClientUtils.upload_app config.access_key,
                                                                   config.app
-          Maze::Client::BitBarClientUtils.start_local_tunnel config.sb_local,
-                                                             config.username,
-                                                             config.access_key
+          if Maze.config.start_tunnel
+            Maze::Client::BitBarClientUtils.start_local_tunnel config.sb_local,
+                                                               config.username,
+                                                               config.access_key
+          end
         end
 
         def device_capabilities
@@ -44,7 +46,9 @@ module Maze
 
         def stop_session
           super
-          Maze::Client::BitBarClientUtils.stop_local_tunnel
+          if Maze.config.start_tunnel
+            Maze::Client::BitBarClientUtils.stop_local_tunnel
+          end
           Maze::Client::BitBarClientUtils.release_account(Maze.config.tms_uri) if ENV['BUILDKITE']
         end
       end

--- a/lib/maze/client/appium/bs_client.rb
+++ b/lib/maze/client/appium/bs_client.rb
@@ -8,9 +8,11 @@ module Maze
           config.app = Maze::Client::BrowserStackClientUtils.upload_app config.username,
                                                                         config.access_key,
                                                                         config.app
-          Maze::Client::BrowserStackClientUtils.start_local_tunnel config.bs_local,
-                                                                   @session_uuid,
-                                                                   config.access_key
+          if Maze.config.start_tunnel
+            Maze::Client::BrowserStackClientUtils.start_local_tunnel config.bs_local,
+                                                                     @session_uuid,
+                                                                     config.access_key
+          end
         end
 
         def device_capabilities
@@ -53,7 +55,7 @@ module Maze
 
         def stop_session
           super
-          Maze::Client::BrowserStackClientUtils.stop_local_tunnel
+          Maze::Client::BrowserStackClientUtils.stop_local_tunnel if Maze.config.start_tunnel
         end
       end
     end

--- a/lib/maze/client/appium/bs_client.rb
+++ b/lib/maze/client/appium/bs_client.rb
@@ -19,12 +19,9 @@ module Maze
           config = Maze.config
           capabilities = {
             'app' => config.app,
-            'bstack:options' => {
-              'local' => 'true',
-              'localIdentifier' => @session_uuid
-            },
             'deviceOrientation' => 'portrait',
-            'noReset' => 'true'
+            'noReset' => 'true',
+            'bstack:options' => {}
           }
           device_caps = Maze::Client::Appium::BrowserStackDevices::DEVICE_HASH[config.device]
           capabilities.deep_merge! device_caps
@@ -33,6 +30,11 @@ module Maze
           unless device_caps['platformName'] == 'android' && device_caps['platformVersion'].to_i <= 6
             capabilities['bstack:options']['disableAnimations'] = 'true'
           end
+          if Maze.config.start_tunnel
+            capabilities['bstack:options']['local'] = 'true'
+            capabilities['bstack:options']['localIdentifier'] = @session_uuid
+          end
+
           capabilities
         end
 

--- a/lib/maze/client/appium/bs_legacy_client.rb
+++ b/lib/maze/client/appium/bs_legacy_client.rb
@@ -7,8 +7,6 @@ module Maze
           capabilities = {
             'app' => config.app,
             'browserstack.console' => 'errors',
-            'browserstack.localIdentifier' => @session_uuid,
-            'browserstack.local' => 'true',
             'deviceOrientation' => 'portrait',
             'noReset' => 'true'
           }
@@ -19,6 +17,11 @@ module Maze
           unless device_caps['platformName'] == 'android' && device_caps['platformVersion'].to_i <= 6
             capabilities['disableAnimations'] = 'true'
           end
+          if Maze.config.start_tunnel
+            capabilities['browserstack.localIdentifier'] = @session_uuid
+            capabilities['browserstack.local'] = 'true'
+          end
+
           capabilities
         end
       end

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -86,6 +86,9 @@ module Maze
     # :none (Cucumber-driven testing with no devices)
     attr_accessor :farm
 
+    # Whether the device farm secure tunnel should be started
+    attr_accessor :start_tunnel
+
     #
     # Device farm specific configuration
     #

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -10,25 +10,25 @@ module Maze
 
     # Server options
     BIND_ADDRESS = 'bind-address'
-    PORT = 'port'
     NULL_PORT = 'null-port'
+    PORT = 'port'
 
     # Appium options
-    FARM = 'farm'
-    APP = 'app'
     A11Y_LOCATOR = 'a11y-locator'
+    APP = 'app'
     CAPABILITIES = 'capabilities'
+    FARM = 'farm'
 
     # Generic device farm options
-    USERNAME = 'username'
     ACCESS_KEY = 'access-key'
+    APP_BUNDLE_ID = 'app-bundle-id'
     APPIUM_VERSION = 'appium-version'
-    DEVICE = 'device'
     BROWSER = 'browser'
+    DEVICE = 'device'
+    LIST_DEVICES = 'list-devices'
     OS = 'os'
     OS_VERSION = 'os-version'
-    LIST_DEVICES = 'list-devices'
-    APP_BUNDLE_ID = 'app-bundle-id'
+    USERNAME = 'username'
 
     # BitBar options
     SB_LOCAL = 'sb-local'
@@ -41,19 +41,19 @@ module Maze
     TMS_TOKEN = 'tms-token'
 
     # Local-only options
-    APPIUM_SERVER = 'appium-server'
-    START_APPIUM = 'start-appium'
     APPIUM_LOGFILE = 'appium-logfile'
+    APPIUM_SERVER = 'appium-server'
     APPLE_TEAM_ID = 'apple-team-id'
+    START_APPIUM = 'start-appium'
     UDID = 'udid'
 
     # Logging options
+    ALWAYS_LOG = 'always-log'
     FILE_LOG = 'file-log'
     LOG_REQUESTS = 'log-requests'
-    ALWAYS_LOG = 'always-log'
 
     # Runtime options
-    ENABLE_RETRIES = 'enable-retries'
     ENABLE_BUGSNAG = 'enable-bugsnag'
+    ENABLE_RETRIES = 'enable-retries'
   end
 end

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -28,6 +28,7 @@ module Maze
     LIST_DEVICES = 'list-devices'
     OS = 'os'
     OS_VERSION = 'os-version'
+    TUNNEL = 'tunnel'
     USERNAME = 'username'
 
     # BitBar options

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -106,6 +106,9 @@ module Maze
             opt Option::APP_BUNDLE_ID,
                 'The bundle identifier of the test application',
                 type: :string
+            opt Option::TUNNEL,
+                'Start the device farm secure tunnel',
+                default: true
 
             # SmartBear-only options
             opt Option::SB_LOCAL,

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -47,6 +47,7 @@ module Maze
           config.locator = options[Maze::Option::A11Y_LOCATOR] ? :accessibility_id : :id
           config.capabilities_option = options[Maze::Option::CAPABILITIES]
           config.legacy_driver = !ENV['USE_LEGACY_DRIVER'].nil?
+          config.start_tunnel = options[Maze::Option::TUNNEL]
 
           # Farm specific options
           case config.farm

--- a/test/option/parser_test.rb
+++ b/test/option/parser_test.rb
@@ -38,6 +38,7 @@ class ParserTest < Test::Unit::TestCase
     assert_nil(options[Maze::Option::USERNAME])
     assert_nil(options[Maze::Option::ACCESS_KEY])
     assert_nil(options[Maze::Option::APPIUM_VERSION])
+    assert_true(options[Maze::Option::TUNNEL])
 
     # Local-only options
     assert_nil(options[Maze::Option::OS])
@@ -81,6 +82,7 @@ class ParserTest < Test::Unit::TestCase
       --udid=ARG_UDID
       --log-requests
       --no-file-log
+      --no-tunnel
     ]
     options = Maze::Option::Parser.parse args
 
@@ -97,6 +99,7 @@ class ParserTest < Test::Unit::TestCase
     assert_equal('ARG_USERNAME', options[Maze::Option::USERNAME])
     assert_equal('ARG_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])
     assert_equal('ARG_APPIUM_VERSION', options[Maze::Option::APPIUM_VERSION])
+    assert_false(options[Maze::Option::TUNNEL])
 
     # Local-only options
     assert_equal('ARG_OS', options[Maze::Option::OS])

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -90,6 +90,7 @@ class ProcessorTest < Test::Unit::TestCase
     assert_nil config.capabilities
 
     assert_true config.file_log
+    assert_true config.start_tunnel
     assert_false config.log_requests
     assert_false config.always_log
   end


### PR DESCRIPTION
## Goal

Allow users to not use the secure tunnels provided by BrowserStack/Bitbar.

## Design

Adds a `--tunnel` (and `-no-tunnel` by virtue of it being a boolean).

There are some deployment environments where the secure tunnel is not required.  Not starting it saves some time and removes something potentially breakable from the equation, reducing flakes overall.

## Tests

Default case is covered by CI and I've updated the unit tests for the command line option processing.  I've also performed some extra testing locally to ensure that the `--no-tunnel` option can be used with BrowserStack in both W3C and JWP modes of operations (which did uncover a bug - the capabilities should not be set in this case).