### PR TITLE
Relax check on React Native notifier name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Fixes
+
+- Relax check on React Native Notifier name [432](https://github.com/bugsnag/maze-runner/pull/432)
+
 # 7.9.0 - 2022/12/07
 
 ## Enhancements

--- a/lib/features/steps/session_tracking_steps.rb
+++ b/lib/features/steps/session_tracking_steps.rb
@@ -36,7 +36,7 @@ Then('the session is valid for the session reporting API version {string} for th
     And the session "Content-Type" header equals "application/json"
     And the session "Bugsnag-Sent-At" header is a timestamp
 
-    And the session payload field "notifier.name" matches the regex "(Android|iOS) Bugsnag Notifier"
+    And the session payload field "notifier.name" matches the regex "(Bugsnag React Native|(Android|iOS) Bugsnag Notifier)"
     And the session payload field "notifier.url" is not null
     And the session payload field "notifier.version" is not null
 


### PR DESCRIPTION
## Goal

Prevent test flakes caused by the React Native notifier occasionally reporting its name as "Bugsnag React Native" in session requests.

## Design

The different name is due to an inherent race condition in the architecture of the RN notifier.  There is no negative impact impact on the Bugsnag system from the differing name, so we can simply relax the check.

## Tests

Tested locally with the RN test that uses it.