### PR TITLE
Add steps to assert an event has _x_ breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fixes
 
 - Relax check on React Native Notifier name [432](https://github.com/bugsnag/maze-runner/pull/432)
+- Add missing assertion against the breadcrumb name in "the event has a {string} breadcrumb named {string}" step [435](https://github.com/bugsnag/maze-runner/pull/435)
 
 # 7.9.0 - 2022/12/07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `--tunnel` (and `--no-tunnel`) option [431](https://github.com/bugsnag/maze-runner/pull/431)
 - Add support for running `docker compose exec` commands [425](https://github.com/bugsnag/maze-runner/pull/425)
+- Add steps for checking an event has a specific number of breadcrumbs, or no breadcrumbs at all [433](https://github.com/bugsnag/maze-runner/pull/433)
 
 ## Fixes
 

--- a/lib/features/steps/breadcrumb_steps.rb
+++ b/lib/features/steps/breadcrumb_steps.rb
@@ -1,5 +1,30 @@
 # @!group Breadcrumb steps
 
+# Tests whether the first event entry contains the specified number of breadcrumbs.
+#
+# @step_input expected [Integer] The expected number of breadcrumbs
+Then("the event has {int} breadcrumb(s)") do |expected|
+  breadcrumbs = Maze::Server.errors.current[:body]['events'].first['breadcrumbs']
+
+  Maze.check.equal(
+    expected,
+    breadcrumbs.length,
+    "Expected event to have '#{expected}' breadcrumbs, but got: #{breadcrumbs}"
+  )
+end
+
+# Tests whether the first event entry contains no breadcrumbs.
+Then("the event has no breadcrumbs") do
+  breadcrumbs = Maze::Server.errors.current[:body]['events'].first['breadcrumbs']
+
+  Maze.check.true(
+    # some notifiers may omit breadcrumbs entirely when empty, otherwise it should
+    # be an empty array
+    breadcrumbs.nil? || breadcrumbs.empty?,
+    "Expected event not to have breadcrumbs, but got: #{breadcrumbs}"
+  )
+end
+
 # Tests whether the first event entry contains a specific breadcrumb with a type and name.
 #
 # @step_input type [String] The expected breadcrumb's type

--- a/lib/features/steps/breadcrumb_steps.rb
+++ b/lib/features/steps/breadcrumb_steps.rb
@@ -8,7 +8,7 @@ Then("the event has {int} breadcrumb(s)") do |expected|
 
   Maze.check.equal(
     expected,
-    breadcrumbs.length,
+    breadcrumbs&.length || 0,
     "Expected event to have '#{expected}' breadcrumbs, but got: #{breadcrumbs}"
   )
 end

--- a/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
@@ -4,23 +4,39 @@ Feature: Breadcrumb helper steps
         When I send a "breadcrumbs"-type request
         Then I wait to receive an error
         And the event has a "process" breadcrumb named "foo"
+        And the event has 3 breadcrumbs
 
     Scenario: The payload contains a breadcrumb with a type and message
         When I send a "breadcrumbs"-type request
         Then I wait to receive an error
         And the event has a "process" breadcrumb with message "Foobar"
+        And the event has 3 breadcrumbs
 
     Scenario: The payload does not contain a type of breadcrumb
         When I send a "breadcrumbs"-type request
         Then I wait to receive an error
         And the event does not have a "request" breadcrumb
+        And the event has 3 breadcrumbs
 
     Scenario: The payload does not contain a type of breadcrumb with a particular message
         When I send a "breadcrumbs"-type request
         Then I wait to receive an error
         And the event does not have a "process" breadcrumb with message "Barfoo"
+        And the event has 3 breadcrumbs
 
     Scenario: The payload has a breadcrumb which matches a JSON fixture
         When I send a "breadcrumbs"-type request
         Then I wait to receive an error
         And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/breadcrumb_match.json"
+        And the event has 3 breadcrumbs
+
+    Scenario: The payload has no breadcrumbs
+        Given I send a "handled"-type request
+        When I wait to receive an error
+        Then the event has no breadcrumbs
+
+    Scenario: The payload has 1 breadcrumb
+        Given I send a "breadcrumb"-type request
+        When I wait to receive an error
+        Then the event has a "process" breadcrumb named "foo"
+        And the event has 1 breadcrumb

--- a/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/breadcrumb_json_fixtures.feature
@@ -34,6 +34,7 @@ Feature: Breadcrumb helper steps
         Given I send a "handled"-type request
         When I wait to receive an error
         Then the event has no breadcrumbs
+        Then the event has 0 breadcrumbs
 
     Scenario: The payload has 1 breadcrumb
         Given I send a "breadcrumb"-type request

--- a/test/fixtures/payload-helpers/features/support/send_request.rb
+++ b/test/fixtures/payload-helpers/features/support/send_request.rb
@@ -204,6 +204,22 @@ def send_request(request_type, mock_api_port = 9339)
         ]
       }
     },
+    'breadcrumb' => {
+      'headers' => {},
+      'body' => {
+        'events' => [
+          {
+            'breadcrumbs' => [
+              {
+                'type' => 'process',
+                'name' => 'foo',
+                'timestamp' => '2019-11-26T10:15:46Z',
+              },
+            ]
+          }
+        ]
+      }
+    },
     'breadcrumbs' => {
       'headers' => {},
       'body' => {


### PR DESCRIPTION
## Goal

Adds two steps to allow tests to be more precise when dealing with breadcrumbs:

> the event has {int} breadcrumb(s)

> the event has no breadcrumbs

The current steps only allow checking if a breadcrumb exists at all, but not e.g. if it's the only instance of that breadcrumb. Context for this is wanting to check that breadcrumbs are cleared in between running queued jobs in Laravel, but other repos that manually clear breadcrumbs may also find this useful (e.g. Python)