### PR TITLE
Simplify logger's format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `--tunnel` (and `--no-tunnel`) option [431](https://github.com/bugsnag/maze-runner/pull/431)
 - Add support for running `docker compose exec` commands [425](https://github.com/bugsnag/maze-runner/pull/425)
 - Add steps for checking an event has a specific number of breadcrumbs, or no breadcrumbs at all [433](https://github.com/bugsnag/maze-runner/pull/433)
+- Simplify logger format [437](https://github.com/bugsnag/maze-runner/pull/437)
 
 ## Fixes
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -31,10 +31,7 @@ A list of codes that will automatically be set for errors can be found in [the E
 
 ### Logging
 
-Maze-runner contains a Ruby logger connected to `STDOUT` that will attempt to log several events that occur during the 
-testing life-cycle.  By default, the logger is set to report `INFO` level events or higher, but will log `DEBUG` level 
-events if the `VERBOSE` or `DEBUG` flags are set.  If the `QUIET` flag is set it will instead log at the `ERROR` level 
-and above.
+Maze-runner contains a Ruby logger connected to `STDOUT` that will attempt to log several events that occur during the  testing life-cycle.  By default, the logger is set to report `INFO` level events or higher, but will log `DEBUG` level events if the `VERBOSE` or `DEBUG` flags are set.  If the `QUIET` flag is set it will instead log at the `ERROR` level and above.
 
 | Log Level | Event | Information |
 |-----------|-------|-------------|
@@ -46,6 +43,42 @@ and above.
 | `WARN` | A Selenium `StaleElementReferenceError` occurs | The error information |
 | `WARN` | A run command fails | The output from the command |
 | `FATAL` | The webserver is not running at the start of a test | Error notification before exiting |
+
+#### Customising the logger
+
+##### `datetime_format`
+
+The default log format shows the current time in the format: 'HOUR:MINUTE:SECOND', e.g. "12:30:45"
+
+This can be customised by setting the logger's `datetime_format` attribute, for example to include the current date in log messages:
+
+```ruby
+Maze::Logger.instance.datetime_format = '%Y-%m-%d %H:%M:%S'
+```
+
+The format string must be compatible with [Ruby's `Time.strftime` method](https://rubyapi.org/3.1/o/time#method-i-strftime)
+
+##### `formatter`
+
+The default log formatter outputs lines with the current time (dimmed), log level and the message. For example:
+
+```
+\e[2m[03:04:05]\e[0m DEBUG: an example of a debug message
+\e[2m[06:07:08]\e[0m  INFO: this is some information
+\e[2m[09:10:11]\e[0m  WARN: a warning
+```
+
+This can be customised by setting the logger's `formatter` attribute, for example:
+
+```ruby
+Maze::Logger.instance.formatter = proc do |severity, time, progname, message|
+  "Logging a #{severity} message: '#{message}' at #{time.strftime('%Y-%m-%d %H:%M:%S')}\n"
+end
+```
+
+See [Ruby's `Logger#formatter` documentation for more information](https://rubyapi.org/3.1/o/logger#formatter)
+
+Note: Maze Runner does not set the `progname`, so it will always be `nil` in a formatter proc unless it is set elsewhere
 
 ### Known issues
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     minitest (5.16.3)
     mocha (1.13.0)
     multi_test (0.1.2)
+    nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
@@ -138,6 +140,7 @@ GEM
       props (>= 1.1.2)
       rubyzip (>= 1.0.0)
     thor (1.0.1)
+    timecop (0.9.6)
     tomlrb (2.0.3)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -153,6 +156,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-19
   x86_64-darwin-20
 
@@ -162,6 +166,7 @@ DEPENDENCIES
   markdown (~> 1.2)
   mocha (~> 1.13.0)
   redcarpet (~> 3.5)
+  timecop (~> 0.9.6)
   yard (~> 0.9.1)
   yard-cucumber!
 

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -49,4 +49,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha', '~> 1.13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'yard', '~> 0.9.1'
+  spec.add_development_dependency 'timecop', '~> 0.9.6'
 end

--- a/lib/maze/logger.rb
+++ b/lib/maze/logger.rb
@@ -7,8 +7,8 @@ require 'singleton'
 module Maze
   # A logger, with level configured according to the environment
   class Logger < Logger
-
     include Singleton
+
     def initialize
       if ENV['VERBOSE'] || ENV['DEBUG']
         super(STDOUT, level: Logger::DEBUG)
@@ -17,7 +17,12 @@ module Maze
       else
         super(STDOUT, level: Logger::INFO)
       end
-      self.datetime_format = '%Y-%m-%d %H:%M:%S'
+
+      self.formatter = proc do |severity, time, _name, message|
+        formatted_time = time.strftime('%H:%M:%S')
+
+        "\e[2m[#{formatted_time}]\e[0m #{severity.rjust(5)}: #{message}\n"
+      end
     end
   end
 

--- a/lib/maze/logger.rb
+++ b/lib/maze/logger.rb
@@ -9,6 +9,8 @@ module Maze
   class Logger < Logger
     include Singleton
 
+    attr_accessor :datetime_format
+
     def initialize
       if ENV['VERBOSE'] || ENV['DEBUG']
         super(STDOUT, level: Logger::DEBUG)
@@ -18,8 +20,10 @@ module Maze
         super(STDOUT, level: Logger::INFO)
       end
 
+      @datetime_format = '%H:%M:%S'
+
       @formatter = proc do |severity, time, _name, message|
-        formatted_time = time.strftime('%H:%M:%S')
+        formatted_time = time.strftime(@datetime_format)
 
         "\e[2m[#{formatted_time}]\e[0m #{severity.rjust(5)}: #{message}\n"
       end

--- a/lib/maze/logger.rb
+++ b/lib/maze/logger.rb
@@ -18,7 +18,7 @@ module Maze
         super(STDOUT, level: Logger::INFO)
       end
 
-      self.formatter = proc do |severity, time, _name, message|
+      @formatter = proc do |severity, time, _name, message|
         formatted_time = time.strftime('%H:%M:%S')
 
         "\e[2m[#{formatted_time}]\e[0m #{severity.rjust(5)}: #{message}\n"

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../lib/maze/logger'
+
+class LoggerTest < Test::Unit::TestCase
+  def setup
+    reset_logger!
+  end
+
+  def teardown
+    reset_logger!
+  end
+
+  def test_it_logs_messages
+    io = StringIO.new
+
+    logger = Maze::Logger.instance
+    logger.level = Logger::DEBUG
+    logger.reopen(io)
+
+    io.rewind
+    assert_empty(io.read)
+
+    Timecop.freeze(Time.utc(2023, 1, 2, 3, 4, 5)) { logger.debug('hello') }
+    Timecop.freeze(Time.utc(2023, 1, 2, 6, 7, 8)) { logger.info('hello') }
+    Timecop.freeze(Time.utc(2023, 1, 2, 9, 10, 11)) { logger.warn('hello') }
+    Timecop.freeze(Time.utc(2023, 1, 2, 12, 13, 14)) { logger.error('hello') }
+    Timecop.freeze(Time.utc(2023, 1, 2, 15, 16, 17)) { logger.fatal('hello') }
+    Timecop.freeze(Time.utc(2023, 1, 2, 18, 19, 20)) { logger.unknown('hello') }
+
+    expected = [
+      "\e[2m[03:04:05]\e[0m DEBUG: hello\n",
+      "\e[2m[06:07:08]\e[0m  INFO: hello\n",
+      "\e[2m[09:10:11]\e[0m  WARN: hello\n",
+      "\e[2m[12:13:14]\e[0m ERROR: hello\n",
+      "\e[2m[15:16:17]\e[0m FATAL: hello\n",
+      "\e[2m[18:19:20]\e[0m   ANY: hello\n",
+    ]
+
+    io.rewind
+    assert_equal(expected, io.readlines)
+  end
+
+  def test_the_formater_can_be_changed
+    io = StringIO.new
+
+    logger = Maze::Logger.instance
+    logger.level = Logger::DEBUG
+    logger.reopen(io)
+
+    io.rewind
+    assert_empty(io.read)
+
+    Timecop.freeze(Time.utc(2023, 1, 2, 3, 4, 5)) { logger.debug('hello') }
+    Timecop.freeze(Time.utc(2023, 1, 2, 6, 7, 8)) { logger.info('hello') }
+    Timecop.freeze(Time.utc(2023, 1, 2, 9, 10, 11)) { logger.warn('hello') }
+
+    logger.formatter = proc do |*args|
+      args.map(&:inspect).join(" ~ ") + "\n"
+    end
+
+    Timecop.freeze(Time.utc(2023, 1, 2, 12, 13, 14)) { logger.error('hello') }
+    Timecop.freeze(Time.utc(2023, 3, 4, 15, 16, 17)) { logger.fatal('hello') }
+    Timecop.freeze(Time.utc(2023, 5, 6, 18, 19, 20)) { logger.unknown('hello') }
+
+    expected = [
+      "\e[2m[03:04:05]\e[0m DEBUG: hello\n",
+      "\e[2m[06:07:08]\e[0m  INFO: hello\n",
+      "\e[2m[09:10:11]\e[0m  WARN: hello\n",
+      "\"ERROR\" ~ 2023-01-02 12:13:14 UTC ~ nil ~ \"hello\"\n",
+      "\"FATAL\" ~ 2023-03-04 15:16:17 UTC ~ nil ~ \"hello\"\n",
+      "\"ANY\" ~ 2023-05-06 18:19:20 UTC ~ nil ~ \"hello\"\n"
+    ]
+
+    io.rewind
+    assert_equal(expected, io.readlines)
+  end
+
+  private
+
+  def reset_logger!
+    @initial_formatter ||= Maze::Logger.instance.formatter
+    @initial_datetime_format ||= Maze::Logger.instance.datetime_format
+
+    Maze::Logger.instance.formatter = @initial_formatter
+    Maze::Logger.instance.datetime_format = @initial_datetime_format
+  end
+end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -42,6 +42,39 @@ class LoggerTest < Test::Unit::TestCase
     assert_equal(expected, io.readlines)
   end
 
+  def test_the_datetime_format_can_be_changed
+    io = StringIO.new
+
+    logger = Maze::Logger.instance
+    logger.level = Logger::DEBUG
+    logger.reopen(io)
+
+    io.rewind
+    assert_empty(io.read)
+
+    Timecop.freeze(Time.utc(2023, 1, 2, 3, 4, 5)) { logger.debug('hello') }
+    Timecop.freeze(Time.utc(2023, 1, 2, 6, 7, 8)) { logger.info('hello') }
+    Timecop.freeze(Time.utc(2023, 1, 2, 9, 10, 11)) { logger.warn('hello') }
+
+    logger.datetime_format = '%Y-%m-%d %H:%M:%S'
+
+    Timecop.freeze(Time.utc(2023, 1, 2, 12, 13, 14)) { logger.error('hello') }
+    Timecop.freeze(Time.utc(2023, 3, 4, 15, 16, 17)) { logger.fatal('hello') }
+    Timecop.freeze(Time.utc(2023, 5, 6, 18, 19, 20)) { logger.unknown('hello') }
+
+    expected = [
+      "\e[2m[03:04:05]\e[0m DEBUG: hello\n",
+      "\e[2m[06:07:08]\e[0m  INFO: hello\n",
+      "\e[2m[09:10:11]\e[0m  WARN: hello\n",
+      "\e[2m[2023-01-02 12:13:14]\e[0m ERROR: hello\n",
+      "\e[2m[2023-03-04 15:16:17]\e[0m FATAL: hello\n",
+      "\e[2m[2023-05-06 18:19:20]\e[0m   ANY: hello\n",
+    ]
+
+    io.rewind
+    assert_equal(expected, io.readlines)
+  end
+
   def test_the_formater_can_be_changed
     io = StringIO.new
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,12 @@
 
 require 'test/unit'
 require 'mocha/test_unit'
+require 'timecop'
+
+# Safe mode forces you to use Timecop with the block syntax since it always puts
+# time back the way it was
+# If you are running in safe mode and use Timecop without the block syntax
+# `Timecop::SafeModeException` will be raised to tell the user they are not
+# being safe.
+# https://github.com/travisjeffery/timecop#timecopsafe_mode
+Timecop.safe_mode = true


### PR DESCRIPTION
## Goal

This PR simplifies the default format of Maze Runner's logger, from this:

```
I, [2022-12-12 13:03:10 #98309]  INFO -- : Maze Runner v7.9.0
I, [2022-12-12 13:03:10 #98309]  INFO -- : No test report will be delivered for this run
I, [2022-12-12 13:03:10 #98309]  INFO -- : Running in command mode
I, [2022-12-12 13:03:10 #98309]  INFO -- : Starting mock server
I, [2022-12-12 13:03:10 #98309]  INFO -- : Fixture commands UUID: 083181b5-3cc9-4b51-a671-4562692fc1cd
I, [2022-12-12 13:03:10 #98309]  INFO -- : WEBrick 1.7.0
I, [2022-12-12 13:03:10 #98309]  INFO -- : ruby 3.1.2 (2022-04-12) [arm64-darwin21]
D, [2022-12-12 13:03:10 #98309] DEBUG -- : #<WEBrick::HTTPServlet::ProcHandler:0x00000001064ccd48 @proc=#<Proc:0x00000001064ccdc0 /Users/joe.haines/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/maze-runner-cfb264281029/lib/maze/server.rb:194>> is mounted on /.
D, [2022-12-12 13:03:10 #98309] DEBUG -- : Maze::Servlets::Servlet is mounted on /notify.
D, [2022-12-12 13:03:10 #98309] DEBUG -- : Maze::Servlets::Servlet is mounted on /sessions.
D, [2022-12-12 13:03:10 #98309] DEBUG -- : Maze::Servlets::Servlet is mounted on /builds.
D, [2022-12-12 13:03:10 #98309] DEBUG -- : Maze::Servlets::Servlet is mounted on /uploads.
D, [2022-12-12 13:03:10 #98309] DEBUG -- : Maze::Servlets::Servlet is mounted on /sourcemap.
D, [2022-12-12 13:03:10 #98309] DEBUG -- : Maze::Servlets::TraceServlet is mounted on /traces.
D, [2022-12-12 13:03:10 #98309] DEBUG -- : Maze::Servlets::Servlet is mounted on /react-native-source-map.
D, [2022-12-12 13:03:10 #98309] DEBUG -- : Maze::Servlets::CommandServlet is mounted on /command.
D, [2022-12-12 13:03:10 #98309] DEBUG -- : Maze::Servlets::LogServlet is mounted on /logs.
I, [2022-12-12 13:03:10 #98309]  INFO -- : WEBrick::HTTPServer#start: pid=98309 port=9339
```

to this:

```
[13:48:55]  INFO: Maze Runner v7.9.0
[13:48:55]  INFO: No test report will be delivered for this run
[13:48:55]  INFO: Running in command mode
[13:48:55]  INFO: Starting mock server
[13:48:55]  INFO: Fixture commands UUID: 99008ae6-52e9-4569-9346-4ab38896a2ea
[13:48:55]  INFO: WEBrick 1.7.0
[13:48:55]  INFO: ruby 3.1.2 (2022-04-12) [arm64-darwin21]
[13:48:55] DEBUG: #<WEBrick::HTTPServlet::ProcHandler:0x00000001079f7ad8 @proc=#<Proc:0x00000001079f7b50 /Users/joe.haines/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/maze-runner-cfb264281029/lib/maze/server.rb:194>> is mounted on /.
[13:48:55] DEBUG: Maze::Servlets::Servlet is mounted on /notify.
[13:48:55] DEBUG: Maze::Servlets::Servlet is mounted on /sessions.
[13:48:55] DEBUG: Maze::Servlets::Servlet is mounted on /builds.
[13:48:55] DEBUG: Maze::Servlets::Servlet is mounted on /uploads.
[13:48:55] DEBUG: Maze::Servlets::Servlet is mounted on /sourcemap.
[13:48:55] DEBUG: Maze::Servlets::TraceServlet is mounted on /traces.
[13:48:55] DEBUG: Maze::Servlets::Servlet is mounted on /react-native-source-map.
[13:48:55] DEBUG: Maze::Servlets::CommandServlet is mounted on /command.
[13:48:55] DEBUG: Maze::Servlets::LogServlet is mounted on /logs.
[13:48:55]  INFO: WEBrick::HTTPServer#start: pid=4222 port=9339
```

This makes reading the logged messages much easier, since the content starts closer to the start of the line and longer messages are less likely to wrap