### PR TITLE
Add Safari 16 on BrowserStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add steps for checking an event has a specific number of breadcrumbs, or no breadcrumbs at all [433](https://github.com/bugsnag/maze-runner/pull/433)
 - Simplify logger format [437](https://github.com/bugsnag/maze-runner/pull/437)
 - Add `--repeater` option [438](https://github.com/bugsnag/maze-runner/pull/438)
+- Add Safari 16 on BrowserStack [440](https://github.com/bugsnag/maze-runner/pull/440)
 
 ## Fixes
 

--- a/lib/maze/client/selenium/bs_browsers.yml
+++ b/lib/maze/client/selenium/bs_browsers.yml
@@ -72,6 +72,12 @@ safari_15:
   os: "OS X"
   osVersion: "Monterey"
 
+safari_16:
+  browserName: "Safari"
+  browserVersion: "16.0"
+  os: "OS X"
+  osVersion: "Monterey"
+
 iphone_6s:
   browserName: "iphone"
   device: "iPhone 6S"


### PR DESCRIPTION
## Goal

Add Safari 16 on BrowserStack.

## Tests

Tested on CI with a temporary commit in the pipeline, now removed.