### PR TITLE
Correct capability for Safari 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.10.1 - 2022/12/15
+
+## Fixes
+
+- Correct capabilities for Safari 16 on BrowserStack [441](https://github.com/bugsnag/maze-runner/pull/441)
+
 # 7.10.0 - 2022/12/15
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.10.0)
+    bugsnag-maze-runner (7.10.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -134,7 +134,7 @@ GEM
       websocket (~> 1.0)
     sys-uname (1.2.2)
       ffi (~> 1.1)
-    test-unit (3.5.5)
+    test-unit (3.5.7)
       power_assert
     textutils (1.4.0)
       activesupport

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.10.0'
+  VERSION = '7.10.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry

--- a/lib/maze/client/selenium/bs_browsers.yml
+++ b/lib/maze/client/selenium/bs_browsers.yml
@@ -76,7 +76,7 @@ safari_16:
   browserName: "Safari"
   browserVersion: "16.0"
   os: "OS X"
-  osVersion: "Monterey"
+  osVersion: "Ventura"
 
 iphone_6s:
   browserName: "iphone"


### PR DESCRIPTION
## Goal

Fixes the addition of Safari in #440 .  Unfortunately I changed the BitBar step in the pipeline rather than BrowserStack, meaning that I did not exercise the new functionality at all.

## Tests

Now tested properly with a temp commit:
https://buildkite.com/bugsnag/maze-runner/builds/2828