### PR TITLE
Fix step 'I have received at least {int} {word}'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.10.2 - TDB
+
+## Fixes
+
+- Fix error in step `I have received at least {int} {word}` [442](https://github.com/bugsnag/maze-runner/pull/442)
+
 # 7.10.1 - 2022/12/15
 
 ## Fixes

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -107,7 +107,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 Then('I have received at least {int} {word}') do |min_received, request_type|
   list = Maze::Server.list_for(request_type)
-  Maze.check.operator(list.size_remaining, :>=, min_received, "Actually received #{list.size} #{request_type} requests")
+  Maze.check.operator(list.size_remaining, :>=, min_received, "Actually received #{list.size_remaining} #{request_type} requests")
 end
 
 # Assert that the test Server hasn't received any requests - of a specific, or any, type.

--- a/test/fixtures/comparison/features/value_checks.feature
+++ b/test/fixtures/comparison/features/value_checks.feature
@@ -3,6 +3,7 @@ Feature: Checks on value types
   Scenario: Checks on values of different types
     When I send a "values"-type request
     And I wait to receive 1 error
+    And I have received at least 1 error
 
     Then the error payload field "values.uuid" is a UUID
     And the error payload field "values.number" is a number


### PR DESCRIPTION
## Goal

Fixes the step `I have received at least {int} {word}`.

## Design

A bug crept into the implementation of this in the v7 uplift (`RequestList` no longer has a `size` method). 

## Tests

Step added to tests on CI.