### PR TITLE
Only set build and project capabilities for BrowserStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Fixes
+
+- Only set `project` and `build` capabilities for BrowserStack [450](https://github.com/bugsnag/maze-runner/pull/450)
+
 # 7.11.0 - 2023/01/06
 
 ## Enhancements

--- a/lib/maze/client/appium/bs_legacy_client.rb
+++ b/lib/maze/client/appium/bs_legacy_client.rb
@@ -13,6 +13,7 @@ module Maze
           device_caps = Maze::Client::Appium::BrowserStackDevices::DEVICE_HASH[config.device]
           capabilities.deep_merge! device_caps
           capabilities.deep_merge! JSON.parse(config.capabilities_option)
+          capabilities.merge! project_name_capabilities
           capabilities['browserstack.appium_version'] = config.appium_version unless config.appium_version.nil?
           unless device_caps['platformName'] == 'android' && device_caps['platformVersion'].to_i <= 6
             capabilities['disableAnimations'] = 'true'

--- a/lib/maze/client/selenium/bs_client.rb
+++ b/lib/maze/client/selenium/bs_client.rb
@@ -6,7 +6,6 @@ module Maze
       class BrowserStackClient < BaseClient
         def start_session
           # Set up the capabilities
-          tunnel_id = SecureRandom.uuid
           browsers = YAML.safe_load(File.read("#{__dir__}/bs_browsers.yml"))
 
           config = Maze.config
@@ -15,7 +14,7 @@ module Maze
           if config.legacy_driver?
             capabilities = ::Selenium::WebDriver::Remote::Capabilities.new
             capabilities['browserstack.local'] = 'true'
-            capabilities['browserstack.localIdentifier'] = tunnel_id
+            capabilities['browserstack.localIdentifier'] = @session_uuid
             capabilities['browserstack.console'] = 'errors'
 
             # Convert W3S capabilities to JSON-WP
@@ -26,22 +25,24 @@ module Maze
             capabilities['os_version'] = browser['osVersion']
 
             capabilities.merge! JSON.parse(config.capabilities_option)
+            capabilities.merge! project_name_capabilities
             config.capabilities = capabilities
           else
             capabilities = {
               'bstack:options' => {
                 'local' => 'true',
-                'localIdentifier' => tunnel_id
+                'localIdentifier' => @session_uuid
               }
             }
             capabilities.deep_merge! browser
             capabilities.deep_merge! JSON.parse(config.capabilities_option)
+            capabilities.merge! project_name_capabilities
             config.capabilities = ::Selenium::WebDriver::Remote::Capabilities.new capabilities
           end
 
           # Start the tunnel
           Maze::Client::BrowserStackClientUtils.start_local_tunnel config.bs_local,
-                                                                   tunnel_id,
+                                                                   @session_uuid,
                                                                    config.access_key
 
           # Start the driver
@@ -60,10 +61,26 @@ module Maze
 
         private
 
+        # Determines and returns sensible project and build capabilities
+        #
+        # @return [Hash] A hash containing the 'project' and 'build' capabilities
+        def project_name_capabilities
+          # Default to values for running locally
+          project = 'local'
+
+          if ENV['BUILDKITE']
+            # Project
+            project = ENV['BUILDKITE_PIPELINE_NAME']
+          end
+          {
+            project: project,
+            build: @session_uuid
+          }
+        end
+
         def log_session_info
           # Log a link to the BrowserStack session search dashboard
-          build = Maze.driver.capabilities[:build]
-          url = "https://automate.browserstack.com/dashboard/v2/search?query=#{build}&type=builds"
+          url = "https://automate.browserstack.com/dashboard/v2/search?query=#{@session_uuid}&type=builds"
           if ENV['BUILDKITE']
             $logger.info Maze::LogUtil.linkify url, 'BrowserStack session(s)'
           else

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -29,12 +29,10 @@ module Maze
       # @param locator [Symbol] the primary locator strategy Appium should use to find elements
       def initialize(server_url, capabilities, locator = :id)
         # Sets up identifiers for ease of connecting jobs
-        name_capabilities = project_name_capabilities
         capabilities ||= {}
 
         @element_locator = locator
         @capabilities = capabilities
-        @capabilities.merge! name_capabilities
 
         # Timers
         @find_element_timer = Maze.timers.add 'Appium - find element'
@@ -48,10 +46,6 @@ module Maze
             server_url: server_url
           }
         }, true)
-
-        $logger.info 'Appium driver initialized for:'
-        $logger.info "    project : #{name_capabilities[:project]}"
-        $logger.info "    build   : #{name_capabilities[:build]}"
       end
 
       # Starts the Appium driver
@@ -190,24 +184,6 @@ module Maze
       def reset_with_timeout(timeout = 0.1)
         sleep(timeout)
         reset
-      end
-
-      # Determines and returns sensible project, build, and name capabilities
-      #
-      # @return [Hash] A hash containing the 'project' and 'build' capabilities
-      def project_name_capabilities
-        # Default to values for running locally
-        project = 'local'
-        build = SecureRandom.uuid
-
-        if ENV['BUILDKITE']
-          # Project
-          project = ENV['BUILDKITE_PIPELINE_NAME']
-        end
-        {
-          project: project,
-          build: build
-        }
       end
 
       def device_info

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -12,7 +12,6 @@ module Maze
 
       def initialize(driver_for, selenium_url=nil, capabilities=nil)
         capabilities ||= {}
-        capabilities.merge! project_name_capabilities
         @capabilities = capabilities
         @driver_for = driver_for
         @selenium_url = selenium_url
@@ -59,24 +58,6 @@ module Maze
         return false
       }
         JAVASCRIPT
-      end
-
-      # Determines and returns sensible project and build capabilities
-      #
-      # @return [Hash] A hash containing the 'project' and 'build' capabilities
-      def project_name_capabilities
-        # Default to values for running locally
-        project = 'local'
-        build = SecureRandom.uuid
-
-        if ENV['BUILDKITE']
-          # Project
-          project = ENV['BUILDKITE_PIPELINE_NAME']
-        end
-        {
-          project: project,
-          build: build
-        }
       end
 
       # Restarts the underlying-driver in the case an unrecoverable error occurs

--- a/test/appium_driver_test.rb
+++ b/test/appium_driver_test.rb
@@ -241,30 +241,6 @@ class AppiumDriverTest < Test::Unit::TestCase
     driver.clear_and_send_keys_to_element('test_text_entry', 'Test_text')
   end
 
-  def test_project_name_capabilities_local
-    # BUILDKITE environment variable is cleared in setup
-    start_logger_mock
-    driver = Maze::Driver::Appium.new SERVER_URL, @capabilities, :accessibility_id
-    hash = driver.project_name_capabilities
-
-    assert_equal 'local', hash[:project]
-    assert_match UUID_REGEX, hash[:build]
-  end
-
-  def test_project_name_capabilities_browser_stack
-    start_logger_mock
-
-    pipeline = 'Android Bugsnag Notifier'
-    driver = Maze::Driver::Appium.new SERVER_URL, @capabilities, :accessibility_id
-
-    ENV['BUILDKITE'] = 'true'
-    ENV['BUILDKITE_PIPELINE_NAME'] = pipeline
-    hash = driver.project_name_capabilities
-
-    assert_equal pipeline, hash[:project]
-    assert_match UUID_REGEX, hash[:build]
-  end
-
   def test_start_driver_success
     logger = start_logger_mock
 

--- a/test/appium_driver_test.rb
+++ b/test/appium_driver_test.rb
@@ -22,9 +22,6 @@ class AppiumDriverTest < Test::Unit::TestCase
   def start_logger_mock
     logger_mock = mock('logger')
     $logger = logger_mock
-    logger_mock.expects(:info).with('Appium driver initialized for:').once
-    logger_mock.expects(:info).with('    project : local').once
-    logger_mock.expects(:info).with(regexp_matches(/^\s{4}build\s{3}:\s\S{36}$/))
     logger_mock
   end
 


### PR DESCRIPTION
## Goal

Avoid problems setting information in the BitBar dashboard caused by setting the `project` and `build` capabilities.

## Design

BitBar have their own capability, `bitbar_project`,for setting the project name in the dashboard, but it doesn't take effect if these capabilities are set.  This PR pushes the logic for setting the capabilities into the BrowserStack client rather than apply them for all device farms.

## Tests

The main thing this change risked breaking was the links to the BrowserStack dashboard that we log at the start of each session.  I've run both browser and device sessions locally, in both legacy and w3c modes to check those.  I've also checked the links created on Buildkite.