### PR TITLE
Generate and use a single UUID for for the application run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # TBD
 
+## Enhancements
+
+- Generate and use a single "run UUID" throughout the app [451](https://github.com/bugsnag/maze-runner/pull/451)
+
 ## Fixes
 
 - Only set `project` and `build` capabilities for BrowserStack [450](https://github.com/bugsnag/maze-runner/pull/450)

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -40,6 +40,11 @@ BeforeAll do
   # Record the local server starting time
   Maze.start_time = Time.now.strftime('%Y-%m-%d %H:%M:%S')
 
+  # Give each run of the tool a unique id
+  Maze.run_uuid = SecureRandom.uuid
+  $logger.info "UUID for this run: #{Maze.run_uuid}"
+
+
   # Start document server, if asked for
   Maze::DocumentServer.start unless Maze.config.document_server_root.nil?
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -10,7 +10,7 @@ module Maze
   VERSION = '7.11.0'
 
   class << self
-    attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry
+    attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :run_uuid
 
     def config
       @config ||= Maze::Configuration.new

--- a/lib/maze/client/appium.rb
+++ b/lib/maze/client/appium.rb
@@ -1,7 +1,7 @@
 module Maze
   module Client
     module Appium
-      def self.start(session_uuid)
+      def self.start
         client_class =
           case Maze.config.farm
           when :bb then BitBarClient
@@ -16,7 +16,7 @@ module Maze
           when :local then LocalClient
           end
 
-        client_class.new(session_uuid).tap(&:start_session)
+        client_class.new.tap(&:start_session)
       end
     end
   end

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -3,10 +3,6 @@ module Maze
     module Appium
       class BaseClient
 
-        def initialize(session_uuid)
-          @session_uuid = session_uuid
-        end
-
         def start_session
           prepare_session
 

--- a/lib/maze/client/appium/bs_client.rb
+++ b/lib/maze/client/appium/bs_client.rb
@@ -10,7 +10,7 @@ module Maze
                                                                         config.app
           if Maze.config.start_tunnel
             Maze::Client::BrowserStackClientUtils.start_local_tunnel config.bs_local,
-                                                                     @session_uuid,
+                                                                     Maze.run_uuid,
                                                                      config.access_key
           end
         end
@@ -33,7 +33,7 @@ module Maze
           end
           if Maze.config.start_tunnel
             capabilities['bstack:options']['local'] = 'true'
-            capabilities['bstack:options']['localIdentifier'] = @session_uuid
+            capabilities['bstack:options']['localIdentifier'] = Maze.run_uuid
           end
 
           capabilities
@@ -46,7 +46,7 @@ module Maze
             $logger.info "Running on device: #{udid}" unless udid.nil?
 
             # Log a link to the BrowserStack session search dashboard
-            url = "https://app-automate.browserstack.com/dashboard/v2/search?query=#{@session_uuid}&type=builds"
+            url = "https://app-automate.browserstack.com/dashboard/v2/search?query=#{Maze.run_uuid}&type=builds"
             if ENV['BUILDKITE']
               $logger.info Maze::LogUtil.linkify(url, 'BrowserStack session(s)')
             else
@@ -75,7 +75,7 @@ module Maze
           end
           {
             project: project,
-            build: @session_uuid
+            build: Maze.run_uuid
           }
         end
       end

--- a/lib/maze/client/appium/bs_legacy_client.rb
+++ b/lib/maze/client/appium/bs_legacy_client.rb
@@ -19,7 +19,7 @@ module Maze
             capabilities['disableAnimations'] = 'true'
           end
           if Maze.config.start_tunnel
-            capabilities['browserstack.localIdentifier'] = @session_uuid
+            capabilities['browserstack.localIdentifier'] = Maze.run_uuid
             capabilities['browserstack.local'] = 'true'
           end
 

--- a/lib/maze/client/bb_client_utils.rb
+++ b/lib/maze/client/bb_client_utils.rb
@@ -124,7 +124,6 @@ module Maze
           $logger.info 'Starting SBSecureTunnel'
           command = "#{sb_local} --username #{username} --authkey #{access_key} --acceptAllCerts " \
                   "--ready #{BB_READY_FILE} --kill #{BB_KILL_FILE}"
-          command << " --tunnelname #{tunnel_name}" unless tunnel_name.nil?
 
           output = start_tunnel_thread(command)
 

--- a/lib/maze/client/selenium.rb
+++ b/lib/maze/client/selenium.rb
@@ -1,7 +1,7 @@
 module Maze
   module Client
     module Selenium
-      def self.start(session_uuid)
+      def self.start
         client_class =
           case Maze.config.farm
           when :bb then BitBarClient
@@ -9,7 +9,7 @@ module Maze
           when :local then LocalClient
           end
 
-        client_class.new(session_uuid).tap(&:start_session)
+        client_class.new.tap(&:start_session)
       end
     end
   end

--- a/lib/maze/client/selenium/base_client.rb
+++ b/lib/maze/client/selenium/base_client.rb
@@ -2,10 +2,6 @@ module Maze
   module Client
     module Selenium
       class BaseClient
-        def initialize(session_uuid)
-          @session_uuid = session_uuid
-        end
-
         def start_session
           raise 'Method not implemented by this class'
         end

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -18,8 +18,7 @@ module Maze
 
           Maze::Client::BitBarClientUtils.start_local_tunnel config.sb_local,
                                                              config.username,
-                                                             config.access_key,
-                                                             Maze.run_uuid
+                                                             config.access_key
 
           # TODO This probably needs to be settable via an environment variable
           # selenium_url = 'https://us-west-desktop-hub.bitbar.com/wd/hub'

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -18,8 +18,8 @@ module Maze
 
           Maze::Client::BitBarClientUtils.start_local_tunnel config.sb_local,
                                                              config.username,
-                                                             config.access_key
-                                                             @session_uuid
+                                                             config.access_key,
+                                                             Maze.run_uuid
 
           # TODO This probably needs to be settable via an environment variable
           # selenium_url = 'https://us-west-desktop-hub.bitbar.com/wd/hub'

--- a/lib/maze/client/selenium/bs_client.rb
+++ b/lib/maze/client/selenium/bs_client.rb
@@ -14,7 +14,7 @@ module Maze
           if config.legacy_driver?
             capabilities = ::Selenium::WebDriver::Remote::Capabilities.new
             capabilities['browserstack.local'] = 'true'
-            capabilities['browserstack.localIdentifier'] = @session_uuid
+            capabilities['browserstack.localIdentifier'] = Maze.run_uuid
             capabilities['browserstack.console'] = 'errors'
 
             # Convert W3S capabilities to JSON-WP
@@ -31,7 +31,7 @@ module Maze
             capabilities = {
               'bstack:options' => {
                 'local' => 'true',
-                'localIdentifier' => @session_uuid
+                'localIdentifier' => Maze.run_uuid
               }
             }
             capabilities.deep_merge! browser
@@ -42,7 +42,7 @@ module Maze
 
           # Start the tunnel
           Maze::Client::BrowserStackClientUtils.start_local_tunnel config.bs_local,
-                                                                   @session_uuid,
+                                                                   Maze.run_uuid,
                                                                    config.access_key
 
           # Start the driver
@@ -74,13 +74,13 @@ module Maze
           end
           {
             project: project,
-            build: @session_uuid
+            build: Maze.run_uuid
           }
         end
 
         def log_session_info
           # Log a link to the BrowserStack session search dashboard
-          url = "https://automate.browserstack.com/dashboard/v2/search?query=#{@session_uuid}&type=builds"
+          url = "https://automate.browserstack.com/dashboard/v2/search?query=#{Maze.run_uuid}&type=builds"
           if ENV['BUILDKITE']
             $logger.info Maze::LogUtil.linkify url, 'BrowserStack session(s)'
           else

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -6,7 +6,7 @@ module Maze
       @client
 
       def before_all
-        @client = Maze::Client::Appium.start(SecureRandom.uuid)
+        @client = Maze::Client::Appium.start
       end
 
       # TODO: Refactor before and after method so that use of the driver is abstracted behind the relevant Appium client

--- a/lib/maze/hooks/browser_hooks.rb
+++ b/lib/maze/hooks/browser_hooks.rb
@@ -4,7 +4,7 @@ module Maze
     # Hooks for Browser mode use
     class BrowserHooks < InternalHooks
       def before_all
-        @client = Maze::Client::Selenium.start(SecureRandom.uuid)
+        @client = Maze::Client::Selenium.start
       end
 
       def at_exit

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -15,9 +15,6 @@ module Maze
     DEFAULT_STATUS_CODE = 200
 
     class << self
-      # @return [String] The UUID attached to all command requests for this session
-      attr_reader :command_uuid
-
       # Sets the response delay generator.
       #
       # @param generator [Maze::Generator] The new generator
@@ -176,9 +173,6 @@ module Maze
       # Starts the WEBrick server in a separate thread
       def start
         attempts = 0
-        $logger.info 'Starting mock server'
-        @command_uuid = SecureRandom.uuid
-        $logger.info "Fixture commands UUID: #{@command_uuid}"
         loop do
 
           @thread = Thread.new do

--- a/lib/maze/servlets/command_servlet.rb
+++ b/lib/maze/servlets/command_servlet.rb
@@ -23,7 +23,7 @@ module Maze
         else
           command = commands.current
           command_json = JSON.pretty_generate(command)
-          command[:uuid] = Maze::Server.command_uuid
+          command[:uuid] = Maze.run_uuid
           response.body = command_json
           response.status = 200
           commands.next

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -30,13 +30,6 @@ module Maze
     end
 
     def test_start_cleanily_configured_bind_address
-      # Expected logging calls
-      @logger_mock.expects(:info).with('Starting mock server')
-
-      # Pre-set securerandom output to avoid issues with generated UUIDs
-      gen_uuid = 'random_uuid'
-      SecureRandom.expects(:uuid).once.returns(gen_uuid)
-      @logger_mock.expects(:info).with("Fixture commands UUID: #{gen_uuid}")
 
       # Force synchronous execution
       Thread.expects(:new).yields
@@ -74,14 +67,8 @@ module Maze
 
     def test_start_on_retry
       # Expected logging calls
-      @logger_mock.expects(:info).with('Starting mock server')
       @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
       @logger_mock.expects(:info).with('Retrying in 5 seconds')
-
-      # Pre-set securerandom output to avoid issues with generated UUIDs
-      gen_uuid = 'random_uuid'
-      SecureRandom.expects(:uuid).once.returns(gen_uuid)
-      @logger_mock.expects(:info).with("Fixture commands UUID: #{gen_uuid}")
 
       # Force synchronous execution
       Thread.expects(:new).yields.twice
@@ -120,17 +107,11 @@ module Maze
 
     def test_start_fails
       # Expected logging calls
-      @logger_mock.expects(:info).with('Starting mock server')
       @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
       @logger_mock.expects(:info).with('Retrying in 5 seconds')
       @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
       @logger_mock.expects(:info).with('Retrying in 5 seconds')
       @logger_mock.expects(:warn).with('Failed to start mock server: uncaught throw "Failed to start"')
-
-      # Pre-set securerandom output to avoid issues with generated UUIDs
-      gen_uuid = 'random_uuid'
-      SecureRandom.expects(:uuid).once.returns(gen_uuid)
-      @logger_mock.expects(:info).with("Fixture commands UUID: #{gen_uuid}")
 
       # Force synchronous execution
       Thread.expects(:new).yields.times(3)


### PR DESCRIPTION
## Goal

Previously we were generating UUIDs in different part of the code for the Appium/Selenium session and for returning in `/command` messages.

This change unifies all of those under a single "run UUID".

## Design

Storing the UUID in the globally accessible `Maze.run_uuid` means that we can do away much of the previous plumbing.  It also means that the UUID returned in `/command`s will match that used for the BrowserStack session, which could be useful for analysis purposes.

## Changeset

- `Maze.run_uuid` added
- Generation of UUIDs collapsed to just one instance
- Various plumbing removed

## Tests

Covered by CI and I've performed some basic checks that the BrowserStack dashboard link are still correct.