### PR TITLE
Tweak config file path for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Push test fixture config file containing Maze Runner address for Appium tests [456](https://github.com/bugsnag/maze-runner/pull/456)
+- Push test fixture config file containing Maze Runner address for Appium tests [456](https://github.com/bugsnag/maze-runner/pull/456) [458](https://github.com/bugsnag/maze-runner/pull/458)
 
 # 7.12.0 - 2023/01/13
 

--- a/lib/maze/api/appium/file_manager.rb
+++ b/lib/maze/api/appium/file_manager.rb
@@ -17,7 +17,7 @@ module Maze
                  when 'ios'
                    "@#{@driver.app_id}/Documents/#{filename}"
                  when 'android'
-                   "/sdcard/Android/data/#{@driver.app_id}/#{filename}"
+                   "/sdcard/Android/data/#{@driver.app_id}/files/#{filename}"
                  end
 
           $logger.debug "Pushing file to '#{path}' with contents: #{contents}"


### PR DESCRIPTION
## Goal

Add `files` to the path for the fixture config file on Android.

## Tests

Tested with the Android fixture locally on both BB and BS.