### PR TITLE
Only write fixture config on modern mobiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.13.1 - 2023/01/24
+
+## Fixes
+
+- Only push test fixture config file on mobile and not in legacy mode [459](https://github.com/bugsnag/maze-runner/pull/459)
+
 # 7.13.0 - 2023/01/23
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.13.0)
+    bugsnag-maze-runner (7.13.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -124,7 +124,7 @@ GEM
     racc (1.6.2)
     rake (12.3.3)
     redcarpet (3.5.1)
-    regexp_parser (2.6.1)
+    regexp_parser (2.6.2)
     rexml (3.2.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.5.0)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.13.0'
+  VERSION = '7.13.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address, :run_uuid

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -94,10 +94,6 @@ module Maze
         end
 
         def start_scenario
-          # Write Maze's address to file and push to the device
-          Maze::Api::Appium::FileManager.new.write_app_file(JSON.generate({ maze_address: maze_address }),
-                                                            FIXTURE_CONFIG)
-
           # Launch the app on macOS
           Maze.driver.get(Maze.config.app) if Maze.config.os == 'macos'
         end

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -18,8 +18,15 @@ module Maze
           end
         end
 
-        def maze_address
-          Maze.public_address || "local:#{Maze.config.port}"
+        def start_scenario
+          unless Maze.config.legacy_driver?
+            # Write Maze's address to file and push to the device
+            maze_address = Maze.public_address || "local:#{Maze.config.port}"
+            Maze::Api::Appium::FileManager.new.write_app_file(JSON.generate({ maze_address: maze_address }),
+                                                              FIXTURE_CONFIG)
+          end
+
+          super
         end
 
         def device_capabilities

--- a/lib/maze/client/appium/bs_client.rb
+++ b/lib/maze/client/appium/bs_client.rb
@@ -15,8 +15,15 @@ module Maze
           end
         end
 
-        def maze_address
-          "bs-local.com:#{Maze.config.port}"
+        def start_scenario
+          unless Maze.config.legacy_driver?
+            # Write Maze's address to file and push to the device
+            maze_address = "bs-local.com:#{Maze.config.port}"
+            Maze::Api::Appium::FileManager.new.write_app_file(JSON.generate({ maze_address: maze_address }),
+                                                              FIXTURE_CONFIG)
+          end
+
+          super
         end
 
         def device_capabilities


### PR DESCRIPTION
## Goal

Fix a bug that caused tests to fail on macOS and older mobile OS versions.

## Design

The push_file mechanism used in #456 is only supported from Appium version 1.15.  This means it can't be used with older mobile versions (roughly and adequately equivalent to Maze Runner's legacy mode).  It is also not supported on macOS, although we don't need it to be.

The fix was to push the logic that makes the push_file call further down the class hierarchy, so that it only take effect on the BitBar and BrowserStack devices farms - and only when legacy mode is not being employed.

## Tests

Tested using a special branch of bugsnag-cocoa set to use these change.  See https://buildkite.com/bugsnag/bugsnag-cocoa/builds/6575#_.