### PR TITLE
Add a step to assert no spans were received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.14.0 - 2023/01/25
+
+## Enhancements
+
+- Added a step to assert that no spans have been received [460](https://github.com/bugsnag/maze-runner/pull/460)
+
 # 7.13.1 - 2023/01/24
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.13.1)
+    bugsnag-maze-runner (7.14.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/features/steps/trace_steps.rb
+++ b/lib/features/steps/trace_steps.rb
@@ -15,6 +15,11 @@ When('I receive and discard the initial p-value request') do
   }
 end
 
+Then('I should have received no spans') do
+  sleep Maze.config.receive_no_requests_wait
+  Maze.check.equal spans_from_request_list(Maze::Server.list_for('traces')).size, 0
+end
+
 Then('the trace payload field {string} bool attribute {string} is true') do |field, attribute|
   check_attribute_equal field, attribute, 'boolValue', true
 end

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.13.1'
+  VERSION = '7.14.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address, :run_uuid


### PR DESCRIPTION
## Goal
Add a step to assert that no spans have been received, regardless of the number of traces sent (ie: only empty traces were sent). This is required to ensure that client-side sampling is working as expected.

## Tests
Tested locally with a dependant feature.