### PR TITLE
Do not let BitBar Appium sessions timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.14.2 - 2023/01/27
+
+## Fixes
+
+- Set `newCommandTimout` to 0 for BitBar Appium sessions [462](https://github.com/bugsnag/maze-runner/pull/462)
+
 # 7.14.1 - 2023/01/26
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.14.1)
+    bugsnag-maze-runner (7.14.2)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.14.1'
+  VERSION = '7.14.2'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address, :run_uuid

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -35,11 +35,14 @@ module Maze
             'disabledAnimations' => 'true',
             'noReset' => 'true',
             'bitbar:options' => {
+              # Some capabilities probably belong in the top level
+              # of the hash, but BitBar picks them up from here.
               'apiKey' => config.access_key,
               'app' => config.app,
               'testrun' => "#{config.os} #{config.os_version}",
               'findDevice' => false,
               'testTimeout' => 7200,
+              'newCommandTimeout' => 0
             }
           }
           capabilities['appiumVersion'] = config.appium_version unless config.appium_version.nil?


### PR DESCRIPTION
## Goal

Prevent BitBar Appium sessions from timing out.

## Design

By default, Appium sessions on BitBar will time out after 60 seconds of no Appium actively.  This frequently happens in "normal" condition for our tests (it fail be a test failure case, but we don't want to lose the whole Appium session because of it).

This change stops BitBar sessions from timing out at all due to lack of activity.

## Changeset

New capability added.  Technically I think it should go in the top level of the hash, but this doesn't get picked up by BitBar.  I've therefore added a note in case the behaviour changes over time.

## Tests

Tested locally using a simple scenarios that just sleeps for 70 seconds.