### PR TITLE
Set capabilities needed for iOS devices on BitBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TDB
+
+## Fixes
+
+- Set capabilities needed for iOS devices on BitBar (with Appium 1.22) [466](https://github.com/bugsnag/maze-runner/pull/466)
+
 # 7.17.0 - 2023/01/31
 
 ## Enhancements

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -57,12 +57,12 @@ module Maze
             query = {
               'filter': "displayName_eq_#{device_group_name}"
             }
-            devices = query_api('device-groups', query)
-            if devices['data'].size != 1
-              $logger.error "Expected exactly one group with name #{device_group_name}, found #{devices.size}"
+            device_groups = query_api('device-groups', query)
+            if device_groups['data'].size != 1
+              $logger.error "Expected exactly one group with name #{device_group_name}, found #{devices['data'].size}"
               raise "Failed to find a device group named '#{device_group_name}'"
             end
-            devices['data'][0]['id']
+            device_groups['data'][0]['id']
           end
 
           def find_device_in_group(device_group_id)

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -97,6 +97,7 @@ module Maze
               'platformName' => 'Android',
               'deviceName' => 'Android Phone',
               'bitbar:options' => {
+                'waitForQuiescence' => false,
                 'device' => device
               }
             }
@@ -109,6 +110,8 @@ module Maze
               'deviceName' => 'iPhone device',
               'platformName' => 'iOS',
               'bitbar:options' => {
+                'noReset' => 'true',
+                'shouldTerminateApp' => 'true',
                 'device' => device
               }
             }.freeze

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -97,7 +97,6 @@ module Maze
               'platformName' => 'Android',
               'deviceName' => 'Android Phone',
               'bitbar:options' => {
-                'waitForQuiescence' => false,
                 'device' => device
               }
             }


### PR DESCRIPTION
## Goal

Sets a couple of capabilities needed for our Cocoa e2e tests to generally function on BitBar (using Appium 1.22).

## Changeset

I also took the opportunity to rename a variable, to make it more clear as to what we're querying in the BitBar API.

## Tests

Tested on a dev branch of bugsnag-cocoa.