### PR TITLE
Ensure device lists are re-acquired and accessed randomly when appium driver is being initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Associate `--device` with device groups on BitBar and remove the need to provide `--os`/`--os-version` options. [465](https://github.com/bugsnag/maze-runner/pull/465)
+- Acquire device capabilities each time a driver start is attempted. Add Randomness to device selection to reduce likelihood of race conditions. [467](https://github.com/bugsnag/maze-runner/pull/467)
 
 # 7.16.0 - 2023/01/30
 

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -36,15 +36,14 @@ module Maze
           retry_failure = config.device_list.nil? || config.device_list.empty?
           until Maze.driver
             begin
-              config.capabilities = device_capabilities
-
-              $logger.info 'Creating Appium driver instance'
-              driver = Maze::Driver::Appium.new config.appium_server_url,
-                                                config.capabilities,
-                                                config.locator
-
               start_driver_closure = Proc.new do
                 begin
+                  config.capabilities = device_capabilities
+
+                  $logger.info 'Creating Appium driver instance'
+                  driver = Maze::Driver::Appium.new config.appium_server_url,
+                                                    config.capabilities,
+                                                    config.locator
                   driver.start_driver
                   true
                 rescue => start_error

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -34,6 +34,7 @@ module Maze
 
         def start_driver(config)
           retry_failure = config.device_list.nil? || config.device_list.empty?
+          driver = nil
           until Maze.driver
             begin
               start_driver_closure = Proc.new do

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -74,7 +74,7 @@ module Maze
 
             $logger.debug "All available devices in group #{device_group_id}: #{JSON.pretty_generate(all_devices)}"
             filtered_devices = all_devices['data'].reject { |device| device['locked'] }
-            return filtered_devices.size, filtered_devices.first
+            return filtered_devices.size, filtered_devices.sample
           end
 
           # Queries the BitBar REST API


### PR DESCRIPTION
## Goal

Effects two BitBar device acquisition factors to improve stability:
- Reduces the chance of multiple tests simultaneously attempting to acquire the same device by having them randomly select a device from the requested list of devices
- When the device isn't available, instead of retrying with the same device (which previously worked with BrowserStack due to accessing an entire device pool) the logic will now re-acquire the device list, avoiding repeating the same failure multiple times.

## Tests

Unit tests were attempted to be implemented, but proved un-suitable for this change set.  Any appium tests should prove suitable to verify the proper outcome.
