### PR TITLE
Add BitBar device tests to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -188,7 +188,7 @@ steps:
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:
           - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli-legacy
-      artifacts#v1.3.0:
+      artifacts#v1.9.0:
         upload: test/fixtures/android-appium-test/maze_output/**/*
     env:
       RUBY_VERSION: "2.7"
@@ -214,7 +214,7 @@ steps:
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:
           - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
-      artifacts#v1.3.0:
+      artifacts#v1.9.0:
         upload: test/fixtures/android-appium-test/maze_output/**/*
     env:
       RUBY_VERSION: "3"
@@ -273,6 +273,31 @@ steps:
       RUBY_VERSION: "2.7"
     concurrency: 2
     concurrency_group: 'bitbar-web'
+
+  - label: 'BitBar app-automate - Android 10'
+    timeout_in_minutes: 20
+    depends_on:
+      - "appium-test-fixture"
+      - "push-branch-cli-legacy"
+    plugins:
+      artifacts#v1.5.0:
+        download: "test/fixtures/android-appium-test/app/build/outputs/apk/release/app-release.apk"
+      docker-compose#v4.7.0:
+        pull: android-appium-test
+        run: android-appium-test
+        service-ports: true
+        command:
+          - "--app=build/outputs/apk/release/app-release.apk"
+          - "--farm=bb"
+          - "--device=ANDROID_10"
+        image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+      artifacts#v1.9.0:
+        upload: test/fixtures/android-appium-test/maze_output/**/*
+    env:
+      RUBY_VERSION: "3"
+    concurrency: 24
+    concurrency_group: 'BrowserStack-app'
+    concurrency_method: eager
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -166,6 +166,10 @@ steps:
       RUBY_VERSION: "3"
     command: 'bundle exec maze-runner -e features/fixtures'
 
+  #
+  # BrowserStack tests
+  #
+
   - label: 'BrowserStack app-automate - Android 7 - JWP'
     timeout_in_minutes: 20
     depends_on:
@@ -189,11 +193,8 @@ steps:
     env:
       RUBY_VERSION: "2.7"
     concurrency: 24
-    concurrency_group: 'browserstack-app'
+    concurrency_group: 'BrowserStack-app'
     concurrency_method: eager
-    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
-    soft_fail:
-      - exit_status: 1
 
   - label: 'BrowserStack app-automate - Android 13 - W3C'
     timeout_in_minutes: 20
@@ -218,10 +219,10 @@ steps:
     env:
       RUBY_VERSION: "3"
     concurrency: 24
-    concurrency_group: 'browserstack-app'
+    concurrency_group: 'BrowserStack-app'
     concurrency_method: eager
 
-  - label: 'Browserstack web browser test - Legacy driver'
+  - label: 'BrowserStack web browser test - Legacy driver'
     depends_on: "push-branch-cli-legacy"
     timeout_in_minutes: 10
     plugins:
@@ -233,9 +234,9 @@ steps:
           - "--farm=bs"
           - "--browser=firefox_latest"
     concurrency: 2
-    concurrency_group: 'browserstack'
+    concurrency_group: 'BrowserStack'
 
-  - label: 'Browserstack web browser test - Latest Firefox'
+  - label: 'BrowserStack web browser test - Latest Firefox'
     depends_on: "push-branch-cli"
     timeout_in_minutes: 10
     plugins:
@@ -248,7 +249,11 @@ steps:
           - "--farm=bs"
           - "--browser=firefox_latest"
     concurrency: 2
-    concurrency_group: 'browserstack'
+    concurrency_group: 'BrowserStack'
+
+  #
+  # BitBar tests
+  #
 
   - label: 'BitBar web browser test - Firefox v107'
     depends_on: "push-branch-cli"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -193,7 +193,7 @@ steps:
     env:
       RUBY_VERSION: "2.7"
     concurrency: 24
-    concurrency_group: 'BrowserStack-app'
+    concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
   - label: 'BrowserStack app-automate - Android 13 - W3C'
@@ -219,7 +219,7 @@ steps:
     env:
       RUBY_VERSION: "3"
     concurrency: 24
-    concurrency_group: 'BrowserStack-app'
+    concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
   - label: 'BrowserStack web browser test - Legacy driver'
@@ -233,8 +233,9 @@ steps:
         command:
           - "--farm=bs"
           - "--browser=firefox_latest"
-    concurrency: 2
-    concurrency_group: 'BrowserStack'
+    concurrency: 5
+    concurrency_group: 'bitbar-android-10'
+    concurrency_method: eager
 
   - label: 'BrowserStack web browser test - Latest Firefox'
     depends_on: "push-branch-cli"
@@ -249,7 +250,8 @@ steps:
           - "--farm=bs"
           - "--browser=firefox_latest"
     concurrency: 2
-    concurrency_group: 'BrowserStack'
+    concurrency_group: 'browserstack'
+    concurrency_method: eager
 
   #
   # BitBar tests
@@ -271,8 +273,9 @@ steps:
           - "--aws-public-ip"
     env:
       RUBY_VERSION: "2.7"
-    concurrency: 2
+    concurrency: 5
     concurrency_group: 'bitbar-web'
+    concurrency_method: eager
 
   - label: 'BitBar app-automate - Android 10'
     timeout_in_minutes: 20
@@ -283,8 +286,8 @@ steps:
       artifacts#v1.5.0:
         download: "test/fixtures/android-appium-test/app/build/outputs/apk/release/app-release.apk"
       docker-compose#v4.7.0:
-        pull: android-appium-test
-        run: android-appium-test
+        pull: android-appium-test-bitbar
+        run: android-appium-test-bitbar
         service-ports: true
         command:
           - "--app=build/outputs/apk/release/app-release.apk"
@@ -295,8 +298,8 @@ steps:
         upload: test/fixtures/android-appium-test/maze_output/**/*
     env:
       RUBY_VERSION: "3"
-    concurrency: 24
-    concurrency_group: 'BrowserStack-app'
+    concurrency: 5
+    concurrency_group: 'bitbar-android-10'
     concurrency_method: eager
 
   - wait

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
     env_file: $DOCKER_ENV_FILE
     volumes:
       - ./test/fixtures/android-appium-test/app/build:/app/build
+      - ./test/fixtures/android-appium-test/features:/app/features
       - ./test/fixtures/android-appium-test/maze-output:/app/maze-output
 
   android-appium-test-legacy:
@@ -104,6 +105,7 @@ services:
     env_file: $DOCKER_ENV_FILE
     volumes:
       - ./test/fixtures/android-appium-test/app/build:/app/build
+      - ./test/fixtures/android-appium-test/features:/app/features
       - ./test/fixtures/android-appium-test/maze-output:/app/maze-output
 
   ios-appium-test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,40 @@ services:
       - ./test/fixtures/android-appium-test/features:/app/features
       - ./test/fixtures/android-appium-test/maze-output:/app/maze-output
 
+  android-appium-test-bitbar:
+    build:
+      context: test/fixtures/android-appium-test
+      dockerfile: Dockerfile.w3c
+      args:
+        BRANCH_NAME:
+        RUBY_VERSION:
+    extra_hosts:
+      - "maze-local:127.0.0.1"
+    environment:
+      BRANCH_NAME:
+      BUILDKITE:
+      BUILDKITE_BRANCH:
+      BUILDKITE_BUILD_CREATOR:
+      BUILDKITE_BUILD_NUMBER:
+      BUILDKITE_BUILD_URL:
+      BUILDKITE_LABEL:
+      BUILDKITE_MESSAGE:
+      BUILDKITE_PIPELINE_NAME:
+      BUILDKITE_REPO:
+      BUILDKITE_RETRY_COUNT:
+      BUILDKITE_STEP_KEY:
+      BITBAR_USERNAME:
+      BITBAR_ACCESS_KEY:
+      MAZE_BUGSNAG_API_KEY:
+      MAZE_TMS_URI:
+    env_file: $DOCKER_ENV_FILE
+    ports:
+      - "9000-9499:9339"
+    volumes:
+      - ./test/fixtures/android-appium-test/app/build:/app/build
+      - ./test/fixtures/android-appium-test/features:/app/features
+      - ./test/fixtures/android-appium-test/maze-output:/app/maze-output
+
   android-appium-test-legacy:
     build:
       context: test/fixtures/android-appium-test

--- a/test/fixtures/android-appium-test/Dockerfile.legacy
+++ b/test/fixtures/android-appium-test/Dockerfile.legacy
@@ -1,5 +1,4 @@
 ARG BRANCH_NAME
 FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli-legacy AS browserstack-app-automate
 
-COPY . /app
 WORKDIR /app

--- a/test/fixtures/android-appium-test/Dockerfile.w3c
+++ b/test/fixtures/android-appium-test/Dockerfile.w3c
@@ -1,5 +1,4 @@
 ARG BRANCH_NAME
 FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli AS browserstack-app-automate
 
-COPY . /app
 WORKDIR /app


### PR DESCRIPTION
## Goal

Guard against obvious regression of Maze Runner's support for the BitBar device farm by running a basic set up tests on CI (as we already do for BrowserStack).

## Design

For now the step will use BitBar with the secure tunnel enabled.  If this proves to be problematic we can change it to use the AWS public IPs (as we are for our notifier repos).

## Changeset

I've also changed the Docker image used to run the tests so it just uses a volume to access the `features` folder rather than copying everything into it.  Steps that took 8 minutes to run now take 1!

## Tests

Covered by CI.