### PR TITLE
Update Android test fixture to read Maze Address from disk

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -265,6 +265,8 @@ steps:
     depends_on: "push-branch-cli"
     timeout_in_minutes: 10
     plugins:
+      artifacts#v1.9.0:
+        upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
         pull: browser-tests
         run: browser-tests
@@ -288,8 +290,9 @@ steps:
       - "appium-test-fixture"
       - "push-branch-cli"
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.0:
         download: "test/fixtures/android-appium-test/app/build/outputs/apk/release/app-release.apk"
+        upload: test/fixtures/android-appium-test/maze_output/**/*
       docker-compose#v4.7.0:
         pull: android-appium-test-bitbar
         run: android-appium-test-bitbar
@@ -302,8 +305,6 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
-      artifacts#v1.9.0:
-        upload: test/fixtures/android-appium-test/maze_output/**/*
     env:
       RUBY_VERSION: "3"
     concurrency: 5

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -114,7 +114,7 @@ steps:
           push:
             - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli-legacy
 
-  - label: 'No-device tests with Ruby 2.7'
+  - label: 'No-device tests with Ruby 2.7 - batch 1'
     timeout_in_minutes: 30
     depends_on: "ci-image-ruby-2-7"
     plugins:
@@ -128,6 +128,14 @@ steps:
           run: cli-tests
       - docker-compose#v4.7.0:
           run: http-response-tests
+    env:
+      RUBY_VERSION: "2.7"
+    command: 'bundle exec maze-runner -e features/fixtures'
+
+  - label: 'No-device tests with Ruby 2.7 - batch 2'
+    timeout_in_minutes: 30
+    depends_on: "ci-image-ruby-2-7"
+    plugins:
       - docker-compose#v4.7.0:
           run: payload-helper-tests
       - docker-compose#v4.7.0:
@@ -140,7 +148,7 @@ steps:
       RUBY_VERSION: "2.7"
     command: 'bundle exec maze-runner -e features/fixtures'
 
-  - label: 'No-device tests with Ruby 3'
+  - label: 'No-device tests with Ruby 3 - batch 1'
     timeout_in_minutes: 30
     depends_on: "ci-image-ruby-3"
     plugins:
@@ -154,6 +162,14 @@ steps:
           run: cli-tests
       - docker-compose#v4.7.0:
           run: http-response-tests
+    env:
+      RUBY_VERSION: "3"
+    command: 'bundle exec maze-runner -e features/fixtures'
+
+  - label: 'No-device tests with Ruby 3 - batch 2'
+    timeout_in_minutes: 30
+    depends_on: "ci-image-ruby-3"
+    plugins:
       - docker-compose#v4.7.0:
           run: payload-helper-tests
       - docker-compose#v4.7.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -299,6 +299,8 @@ steps:
           - "--farm=bb"
           - "--device=ANDROID_10"
           - "--fail-fast"
+          - "--no-tunnel"
+          - "--aws-public-ip"
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
       artifacts#v1.9.0:
         upload: test/fixtures/android-appium-test/maze_output/**/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     volumes:
       - ./test/fixtures/android-appium-test/app/build:/app/build
       - ./test/fixtures/android-appium-test/features:/app/features
-      - ./test/fixtures/android-appium-test/maze-output:/app/maze-output
+      - ./test/fixtures/android-appium-test/maze_output:/app/maze_output
 
   android-appium-test-bitbar:
     build:
@@ -106,7 +106,7 @@ services:
     volumes:
       - ./test/fixtures/android-appium-test/app/build:/app/build
       - ./test/fixtures/android-appium-test/features:/app/features
-      - ./test/fixtures/android-appium-test/maze-output:/app/maze-output
+      - ./test/fixtures/android-appium-test/maze_output:/app/maze_output
       - /var/run/docker.sock:/var/run/docker.sock
 
   android-appium-test-legacy:
@@ -142,7 +142,7 @@ services:
     volumes:
       - ./test/fixtures/android-appium-test/app/build:/app/build
       - ./test/fixtures/android-appium-test/features:/app/features
-      - ./test/fixtures/android-appium-test/maze-output:/app/maze-output
+      - ./test/fixtures/android-appium-test/maze_output:/app/maze_output
 
   ios-appium-test:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       - ./test/fixtures/android-appium-test/app/build:/app/build
       - ./test/fixtures/android-appium-test/features:/app/features
       - ./test/fixtures/android-appium-test/maze-output:/app/maze-output
+      - /var/run/docker.sock:/var/run/docker.sock
 
   android-appium-test-legacy:
     build:

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -56,7 +56,7 @@ module Maze
           $logger.info 'Appium session(s) created:'
           @session_ids.each do |id|
             link = api_client.get_device_session_ui_link(id)
-            $logger.info Maze::LogUtil.linkify(link, id) if link
+            $logger.info Maze::LogUtil.linkify(link, "BitBar session: #{id}") if link
           end
         end
 

--- a/test/fixtures/android-appium-test/app/build.gradle
+++ b/test/fixtures/android-appium-test/app/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation "com.bugsnag:bugsnag-android:5.10.1"
+    implementation "com.bugsnag:bugsnag-android:5.28.4"
     implementation "com.android.support:appcompat-v7:26.1.0"
     implementation "com.android.support.constraint:constraint-layout:1.0.2"
     testImplementation "junit:junit:4.12"

--- a/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -35,7 +35,9 @@ class MainActivity : AppCompatActivity() {
         button = findViewById<Button>(R.id.run_command)
         button.setOnClickListener {
             thread(start = true) {
-                val command = URL("http://maze-local:9339/command").readText()
+                if (mazeAddress == null) setMazeRunnerAddress()
+
+                val command = URL("http://$mazeAddress/command").readText()
                 val jsonObject = JSONTokener(command).nextValue() as JSONObject
                 val metadata = jsonObject.getString("metadata")
 
@@ -60,6 +62,7 @@ class MainActivity : AppCompatActivity() {
         while (System.currentTimeMillis() < pollEnd) {
             if (configFile.exists()) {
                 val fileContents = configFile.readText()
+                log("fixture_config.json contents: ${fileContents}")
                 val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
                 mazeAddress = getStringSafely(fixtureConfig, "maze_address")
                 if (!mazeAddress.isNullOrBlank()) {

--- a/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -19,6 +19,7 @@ const val CONFIG_FILE_TIMEOUT = 30000
 
 class MainActivity : AppCompatActivity() {
 
+    var bugsnagStarted: Boolean = false
     var mazeAddress: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,6 +27,8 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         var button = findViewById<Button>(R.id.trigger_error)
         button.setOnClickListener {
+            if (!bugsnagStarted) startBugsnag()
+
             val metadata = findViewById<EditText>(R.id.metadata).text.toString()
             val text = if (metadata == "") "HandledException!" else metadata
             Bugsnag.notify(Exception(text))
@@ -35,7 +38,7 @@ class MainActivity : AppCompatActivity() {
         button = findViewById<Button>(R.id.run_command)
         button.setOnClickListener {
             thread(start = true) {
-                if (mazeAddress == null) setMazeRunnerAddress()
+                if (!bugsnagStarted) startBugsnag()
 
                 val command = URL("http://$mazeAddress/command").readText()
                 val jsonObject = JSONTokener(command).nextValue() as JSONObject
@@ -48,7 +51,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        startBugsnag()
     }
 
     private fun setMazeRunnerAddress() {
@@ -91,7 +93,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun startBugsnag() {
-        if (mazeAddress == null) setMazeRunnerAddress()
+        setMazeRunnerAddress()
+
         val config = Configuration("12312312312312312312312312312312")
         config.autoTrackSessions = false
         config.setEndpoints(EndpointConfiguration("http://$mazeAddress/notify", "http://$mazeAddress/sessions"))

--- a/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -15,7 +15,7 @@ import kotlin.concurrent.thread
 import org.json.JSONObject
 import org.json.JSONTokener
 
-const val CONFIG_FILE_TIMEOUT = 5000
+const val CONFIG_FILE_TIMEOUT = 30000
 
 class MainActivity : AppCompatActivity() {
 

--- a/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.bugsnag.android.mazerunner
 
 import android.os.Build
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
@@ -54,6 +56,13 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setMazeRunnerAddress() {
+
+        // Assume we are using the legacy driver (which means a config file is not pushed) below Android 8
+        if (VERSION.SDK_INT < VERSION_CODES.O) {
+            mazeAddress = "bs-local.com:9339"
+            return
+        }
+
         val context = getApplicationContext()
         val externalFilesDir = context.getExternalFilesDir(null)
         val configFile = File(externalFilesDir, "fixture_config.json")

--- a/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -7,13 +7,19 @@ import android.util.Log
 import android.widget.Button
 import android.widget.EditText
 import com.bugsnag.android.*
+import java.io.File
 import java.lang.Exception
+import java.lang.Thread
 import java.net.URL
 import kotlin.concurrent.thread
 import org.json.JSONObject
 import org.json.JSONTokener
 
+const val CONFIG_FILE_TIMEOUT = 5000
+
 class MainActivity : AppCompatActivity() {
+
+    var mazeAddress: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,10 +49,49 @@ class MainActivity : AppCompatActivity() {
         startBugsnag()
     }
 
+    private fun setMazeRunnerAddress() {
+        val context = getApplicationContext()
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        log("Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    log("Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+
+        // Assume we are running in legacy mode on BrowserStack
+        if (mazeAddress.isNullOrBlank()) {
+            log("Failed to read Maze Runner address from config file, reverting to legacy BrowserStack address")
+            mazeAddress = "bs-local.com:9339"
+        }
+    }
+
+    // As per JSONObject.getString but returns and empty string rather than throwing if not present
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+    private fun log(msg: String) {
+        Log.d("BugsnagMazeRunner", msg)
+    }
+
     private fun startBugsnag() {
+        if (mazeAddress == null) setMazeRunnerAddress()
         val config = Configuration("12312312312312312312312312312312")
         config.autoTrackSessions = false
-        config.setEndpoints(EndpointConfiguration("http://maze-local:9339/notify", "http://maze-local:9339/sessions"))
+        config.setEndpoints(EndpointConfiguration("http://$mazeAddress/notify", "http://$mazeAddress/sessions"))
         config.addOnError(OnErrorCallback { event ->
             event.addMetadata("test", "boolean_false", false)
             event.addMetadata("test", "boolean_true", true)
@@ -59,5 +104,4 @@ class MainActivity : AppCompatActivity() {
 
         Bugsnag.start(this, config)
     }
-
 }


### PR DESCRIPTION
## Goal

Update the e2e test fixture for Android to read the Maze Runner address from disk and use the AWS public IP when running on BitBar.

## Design

The BitBar secure tunnel is very flaky and was causing frustration in Maze Runner builds.  This change means we're using the same approach for BitBar as bugsnag-android will.

## Changeset

I've also bumped the version of the Android notifier used by the fixture, as it was quite out of date.

## Tests

Covered by CI.