### PR TITLE
Gracious exit for human-readable errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  
 - Add link to BitBar dashboard for each Appium session. [470](https://github.com/bugsnag/maze-runner/pull/470)
 - Set Appium capabilities for the BitBar dashboard. [471](https://github.com/bugsnag/maze-runner/pull/471)
+- Clean exit for user readable errors. [474](https://github.com/bugsnag/maze-runner/pull/474)
 
 ## Fixes
 

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -18,7 +18,7 @@ module Maze
             group_count, device = api_client.find_device_in_group(device_group_id)
             if device.nil?
               # TODO: Retry rather than fail, see PLAT-7377
-              raise 'There are no devices available'
+              Maze::Helper.error_exit 'There are no devices available'
             else
               $logger.info "#{group_count} device(s) currently available in group '#{device_group_name}'"
             end

--- a/lib/maze/helper.rb
+++ b/lib/maze/helper.rb
@@ -101,10 +101,15 @@ module Maze
           os = os&.downcase
         end
 
-
         raise('Unable to determine the current platform') if os.nil?
 
         os
+      end
+
+      # Logs the given message and exits the program with a failure status
+      def error_exit(message)
+        $logger.error message
+        exit false
       end
 
       # Returns the name of the scenario to


### PR DESCRIPTION
## Goal

Provide a basic mechanism for exiting cleanly after logging a user-friendly error message.

## Design

Until now, Maze Runner has rather lazily `raise`d errors in order to terminate the current run.  Whilst this is appropriate for some cases, it is very unfriendly to users in many situations, as a large stack trace typically obfuscates the root cause of termination.  This change provides a basic mechanism for terminating the process cleanly when all that's needed is a simple message to the user.

## Tests

Tested locally by adding a temporary line of code to force the failure condition.