### PR TITLE
Allow --device to specify a BitBar device name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Enhancements
  
-- Add link to BitBar dashboard for each Appium session. [470](https://github.com/bugsnag/maze-runner/pull/470)
-- Set Appium capabilities for the BitBar dashboard. [471](https://github.com/bugsnag/maze-runner/pull/471)
-- Clean exit for user readable errors. [474](https://github.com/bugsnag/maze-runner/pull/474)
+- Add link to BitBar dashboard for each Appium session [470](https://github.com/bugsnag/maze-runner/pull/470)
+- Set Appium capabilities for the BitBar dashboard [471](https://github.com/bugsnag/maze-runner/pull/471)
+- Clean exit for user readable errors [474](https://github.com/bugsnag/maze-runner/pull/474)
+- Allow `--device` to specify a device (rather than device group) on BitBar [475](https://github.com/bugsnag/maze-runner/pull/475)
 
 ## Fixes
 

--- a/docs/Device_Mode.md
+++ b/docs/Device_Mode.md
@@ -41,7 +41,7 @@ bundle exec maze-runner features/smoke_tests    \
                         --fail-fast
 ```
 
-In the case of BitBar, the `--device` option maps directly to the name of a device group configured in the BitBar dashboard.
+In the case of BitBar, the `--device` option maps directly to the name of either a device, or a device group configured in the BitBar dashboard.
 
 ## Appium client modes
 

--- a/lib/maze/client/bb_api_client.rb
+++ b/lib/maze/client/bb_api_client.rb
@@ -2,7 +2,8 @@ module Maze
   # Utils supporting the BitBar device farm integration
   module Client
     class BitBarApiClient
-      BASE_BITBAR_API_URI = 'https://cloud.bitbar.com/api/v2/me'
+      BASE_URI = 'https://cloud.bitbar.com/api'
+      USER_SPECIFIC_URI = "#{BASE_URI}/v2/me"
 
       # Get the id of a device group given its name
       def get_device_group_id(device_group_name)
@@ -10,11 +11,11 @@ module Maze
           'filter': "displayName_eq_#{device_group_name}"
         }
         device_groups = query_api('device-groups', query)
-        if device_groups['data'].size != 1
-          $logger.error "Expected exactly one group with name #{device_group_name}, found #{device_groups['data'].size}"
-          raise "Failed to find a device group named '#{device_group_name}'"
+        if device_groups['data'].nil? || device_groups['data'].size == 0
+          nil
+        else
+          device_groups['data'][0]['id']
         end
-        device_groups['data'][0]['id']
       end
 
       def find_device_in_group(device_group_id)
@@ -27,6 +28,27 @@ module Maze
         $logger.debug "All available devices in group #{device_group_id}: #{JSON.pretty_generate(all_devices)}"
         filtered_devices = all_devices['data'].reject { |device| device['locked'] }
         return filtered_devices.size, filtered_devices.sample
+      end
+
+      def find_device(device_name)
+        path = "devices"
+        query = {
+          'filter': "displayName_eq_#{device_name};online_eq_true",
+        }
+        all_devices = query_api(path, query, BASE_URI)['data']
+        if all_devices.size == 0
+          Maze::Helper.error_exit "No devices found with name '#{device_name}'"
+        else
+          $logger.debug "All available devices with name #{device_name}: #{JSON.pretty_generate(all_devices)}"
+          filtered_devices = all_devices.reject { |device| device['locked'] }
+          if filtered_devices.size == 0
+            Maze::Helper.error_exit "None of the #{all_devices.size} devices with name '#{device_name}' are currently available"
+          else
+            $logger.info "#{filtered_devices.size} of #{all_devices.size} devices with name '#{device_name}' are available"
+          end
+
+          return filtered_devices.sample
+        end
       end
 
       def get_device_session_ui_link(session_id)
@@ -44,12 +66,12 @@ module Maze
       private
 
       # Queries the BitBar REST API
-      def query_api(path, query=nil)
+      def query_api(path, query=nil, uri=USER_SPECIFIC_URI)
         if query
           encoded_query = URI.encode_www_form(query)
-          uri = URI("#{BASE_BITBAR_API_URI}/#{path}?#{encoded_query}")
+          uri = URI("#{uri}/#{path}?#{encoded_query}")
         else
-          uri = URI("#{BASE_BITBAR_API_URI}/#{path}")
+          uri = URI("#{uri}/#{path}")
         end
         request = Net::HTTP::Get.new(uri)
         request.basic_auth(Maze.config.access_key, '')


### PR DESCRIPTION
## Goal

Let `--device` specify a device, rather than just a device group, name on BitBar.

## Design

The main approach for using devices on BitBar is to provide a device group name, e.g. `ANDROID_10`.  We're finding that some test scenarios behave differently on specific devices, so this change makes it possible for the `--device` option to also specify a particular device.

## Documentation

Existing docs tweaked.

## Changeset

- New BitBar REST api method added and existing routines refactored 
- Device allocation logic updated to look for a device if no device group with the name if found

## Tests

Device group use (the primary use) covered by CI.  Specific device use tested locally, e.g:

```
$ bundle exec maze-runner --farm=bb --device='Google Pixel 4 -US' ...
[17:05:19]  INFO: Starting SBSecureTunnel
[17:05:21]  INFO: 1 of 3 devices with name 'Google Pixel 4 -US' are available
[17:05:21]  INFO: Selected device: Google Pixel 4 -US (android 10)
```