### PR TITLE
Correct logic for span step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.18.1 - 2023/02/21
+
+## Fixes
+ 
+- Correct logic for step `a span field {string} matches the regex {string}` [476](https://github.com/bugsnag/maze-runner/pull/476)
+
 # 7.18.0 - 2023/02/10
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.18.0)
+    bugsnag-maze-runner (7.18.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -115,7 +115,7 @@ GEM
     minitest (5.16.3)
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.14.1-x86_64-darwin)
+    nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/lib/features/steps/trace_steps.rb
+++ b/lib/features/steps/trace_steps.rb
@@ -149,8 +149,10 @@ Then('a span field {string} equals {string}') do |key, expected|
 end
 
 Then('a span field {string} matches the regex {string}') do |attribute, pattern|
+  regex = Regexp.new pattern
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
-  selected_attributes = spans.map { |span| Maze.check.match pattern, span[attribute] }
+  selected_attributes = spans.select { |span| regex.match? span[attribute] }
+
   Maze.check.false(selected_attributes.empty?)
 end
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.18.0'
+  VERSION = '7.18.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address, :run_uuid


### PR DESCRIPTION
## Goal

Corrects the logic for step `a span field {string} matches the regex {string}`.

## Design

It should select the items that match, rather than barf on the first entry that does not.

## Tests

Tested locally against the branch of `bugsnag-cocoa-performance` that discovered the bug.