### PR TITLE
Add --list-devices option for BitBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Add --list-devices option for BitBar device groups []()
+- Add --list-devices option for BitBar device groups [480](https://github.com/bugsnag/maze-runner/pull/480)
 
 # 7.19.0 - 2023/02/22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Enhancements
+
+- Add --list-devices option for BitBar device groups []()
+
 # 7.19.0 - 2023/02/22
 
 ## Enhancements

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -128,10 +128,16 @@ class MazeRunnerEntry
     options = Maze::Option::Parser.parse args
 
     if options[Maze::Option::LIST_DEVICES]
-      case options[Maze::Option::FARM]
+      case options[Maze::Option::FARM].to_sym
       when :bs
         Maze::Client::Appium::BrowserStackDevices.list_devices('ios')
         Maze::Client::Appium::BrowserStackDevices.list_devices('android')
+      when :bb
+        unless options[Maze::Option::ACCESS_KEY]
+          puts 'Listing BitBar device groups available requires a valid access key'
+          exit 1
+        end
+        Maze::Client::Appium::BitBarDevices.list_device_groups(options[Maze::Option::ACCESS_KEY])
       else
         Maze::Client::Appium::BrowserStackDevices.list_devices('ios')
         Maze::Client::Appium::BrowserStackDevices.list_devices('android')

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -50,7 +50,7 @@ module Maze
         end
 
         def log_run_outro
-          api_client = BitBarApiClient.new
+          api_client = BitBarApiClient.new(Maze.config.access_key)
 
           $logger.info 'Appium session(s) created:'
           @session_ids.each do |id|

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -12,7 +12,7 @@ module Maze
           # @param device_or_group_name [String] Name of the device, or device group for which to find an available device
           # @return Capabilities hash for the available device
           def get_available_device(device_or_group_name)
-            api_client = BitBarApiClient.new
+            api_client = BitBarApiClient.new(Maze.config.access_key)
             device_group_id = api_client.get_device_group_id(device_or_group_name)
             if device_group_id
               # Device group found - find a free device in it
@@ -52,6 +52,23 @@ module Maze
               make_ios_hash(device_name)
             else
               throw "Invalid device platform specified #{platform}"
+            end
+          end
+
+          def list_device_groups(access_key)
+            api_client = BitBarApiClient.new(access_key)
+            device_groups = api_client.get_device_group_list
+            unless device_groups['data']
+              puts 'There are no device groups available for the given user access key'
+              exit 0
+            end
+            puts "BitBar device groups available:"
+            device_groups['data'].each do |group|
+              puts '------------------------------'
+              puts "Group name   : #{group['displayName']}"
+              puts "Group ID     : #{group['id']}"
+              puts "OS           : #{group['osType']}"
+              puts "Device count : #{group['deviceCount']}"
             end
           end
 

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -58,15 +58,14 @@ module Maze
           def list_device_groups(access_key)
             api_client = BitBarApiClient.new(access_key)
             device_groups = api_client.get_device_group_list
-            unless device_groups['data']
+            unless device_groups['data'] && !device_groups['data'].empty?
               puts 'There are no device groups available for the given user access key'
               exit 0
             end
             puts "BitBar device groups available:"
-            device_groups['data'].each do |group|
+            device_groups['data'].sort_by{|g| g['displayName']}.each do |group|
               puts '------------------------------'
               puts "Group name   : #{group['displayName']}"
-              puts "Group ID     : #{group['id']}"
               puts "OS           : #{group['osType']}"
               puts "Device count : #{group['deviceCount']}"
             end

--- a/lib/maze/client/bb_api_client.rb
+++ b/lib/maze/client/bb_api_client.rb
@@ -5,6 +5,15 @@ module Maze
       BASE_URI = 'https://cloud.bitbar.com/api'
       USER_SPECIFIC_URI = "#{BASE_URI}/v2/me"
 
+      def initialize(access_key)
+        @access_key = access_key
+      end
+
+      # Get a formatted list of all available device groups
+      def get_device_group_list
+        query_api('device-groups')
+      end
+
       # Get the id of a device group given its name
       def get_device_group_id(device_group_name)
         query = {
@@ -74,7 +83,7 @@ module Maze
           uri = URI("#{uri}/#{path}")
         end
         request = Net::HTTP::Get.new(uri)
-        request.basic_auth(Maze.config.access_key, '')
+        request.basic_auth(@access_key, '')
         res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
           http.request(request)
         end


### PR DESCRIPTION
## Goal

Allows a list of all device groups available to the given BitBar access key to be output to the console.

## Tests

Running manually, sample outputs include:

- No access key specified:
```
bundle exec maze-runner --farm=bb --list-devices
...
Listing BitBar device groups available requires a valid access key
```

- Invalid access key (i.e. No device groups found):
```
bundle exec maze-runner --farm=bb --access-key=foobar --list-devices
...
There are no device groups available for the given user access key
```

- Valid access key:
```
bundle exec maze-runner --farm=bb --access-key=<REDACTED> --list-devices
...
BitBar device groups available:
------------------------------
Group name   : ANDROID_10
Group ID     : <ID>
OS           : ANDROID
Device count : 8
------------------------------
Group name   : ANDROID_12
Group ID     : <ID>
OS           : ANDROID
Device count : 16
------------------------------
Group name   : ANDROID_13
Group ID     : <ID>
OS           : ANDROID
Device count : 36
```
