### PR TITLE
Allow --list-devices option for BitBar to list devices belong to a device group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Enhancements
 
-- Add --list-devices option for BitBar device groups [480](https://github.com/bugsnag/maze-runner/pull/480)
+- Add --list-devices option for BitBar devices and device groups
+  - [480](https://github.com/bugsnag/maze-runner/pull/480)
+  - [481](https://github.com/bugsnag/maze-runner/pull/481)
 
 # 7.19.0 - 2023/02/22
 

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -134,10 +134,17 @@ class MazeRunnerEntry
         Maze::Client::Appium::BrowserStackDevices.list_devices('android')
       when :bb
         unless options[Maze::Option::ACCESS_KEY]
-          puts 'Listing BitBar device groups available requires a valid access key'
+          puts 'Listing BitBar devices or device groups available requires a valid access key'
           exit 1
         end
-        Maze::Client::Appium::BitBarDevices.list_device_groups(options[Maze::Option::ACCESS_KEY])
+        access_key = options[Maze::Option::ACCESS_KEY]
+        if options[Maze::Option::DEVICE] && !options[Maze::Option::DEVICE].empty?
+          options[Maze::Option::DEVICE].each do |device_group|
+            Maze::Client::Appium::BitBarDevices.list_devices_for_group(device_group, access_key)
+          end
+        else
+          Maze::Client::Appium::BitBarDevices.list_device_groups(access_key)
+        end
       else
         Maze::Client::Appium::BrowserStackDevices.list_devices('ios')
         Maze::Client::Appium::BrowserStackDevices.list_devices('android')

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -83,7 +83,7 @@ module Maze
               puts "There are no devices available for the #{device_group} device group"
               return
             end
-
+            puts "BitBar devices available for device group #{device_group}:"
             devices['data'].each do |device|
               puts '------------------------------'
               puts "Device name : #{device['displayName']}"

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -60,7 +60,7 @@ module Maze
             device_groups = api_client.get_device_group_list
             unless device_groups['data'] && !device_groups['data'].empty?
               puts 'There are no device groups available for the given user access key'
-              exit 0
+              exit 1
             end
             puts "BitBar device groups available:"
             device_groups['data'].sort_by{|g| g['displayName']}.each do |group|
@@ -68,6 +68,31 @@ module Maze
               puts "Group name   : #{group['displayName']}"
               puts "OS           : #{group['osType']}"
               puts "Device count : #{group['deviceCount']}"
+            end
+          end
+
+          def list_devices_for_group(device_group, access_key)
+            api_client = BitBarApiClient.new(access_key)
+            group_id = api_client.get_device_group_id(device_group)
+            unless group_id
+              puts "No device groups were found with the given name #{device_group}"
+              return
+            end
+            devices = api_client.get_device_list_for_group(group_id)
+            if devices['data'].empty?
+              puts "There are no devices available for the #{device_group} device group"
+              return
+            end
+
+            devices['data'].each do |device|
+              puts '------------------------------'
+              puts "Device name : #{device['displayName']}"
+              puts "OS type     : #{device['platform']}"
+              puts "OS version  : #{device['softwareVersion']['releaseVersion']}"
+
+              if device['platform'].eql? 'ANDROID'
+                puts "API level   : #{device['softwareVersion']['apiLevel']}"
+              end
             end
           end
 

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -84,11 +84,10 @@ module Maze
               return
             end
             puts "BitBar devices available for device group #{device_group}:"
-            devices['data'].each do |device|
+            devices['data'].sort_by{|d| d['displayName']}.each do |device|
               puts '------------------------------'
               puts "Device name : #{device['displayName']}"
-              puts "OS type     : #{device['platform']}"
-              puts "OS version  : #{device['softwareVersion']['releaseVersion']}"
+              puts "OS          : #{device['platform']} #{device['softwareVersion']['releaseVersion']}"
 
               if device['platform'].eql? 'ANDROID'
                 puts "API level   : #{device['softwareVersion']['apiLevel']}"

--- a/lib/maze/client/bb_api_client.rb
+++ b/lib/maze/client/bb_api_client.rb
@@ -9,9 +9,15 @@ module Maze
         @access_key = access_key
       end
 
-      # Get a formatted list of all available device groups
+      # Get a list of all available device groups
       def get_device_group_list
         query_api('device-groups')
+      end
+
+      # Get a list of all available devices in a device group
+      def get_device_list_for_group(device_group_id)
+        path = "device-groups/#{device_group_id}/devices"
+        query_api(path)
       end
 
       # Get the id of a device group given its name


### PR DESCRIPTION
## Goal

Allows a list of all devices belonging to a given BitBar access key and device group to be output to the console.

## Tests

Running manually, sample outputs include:

- No access key specified:
```
bundle exec maze-runner --farm=bb --device=ANDROID_10 --list-devices
...
Listing BitBar devices or device groups available requires a valid access key
```

- Invalid access key (i.e. No device groups found):
```
bundle exec maze-runner --farm=bb --access-key=foobar --device=ANDROID_10 --list-devices
...
No device groups were found with the given name ANDROID_10
```

- Valid access key, invalid device group name:
```
bundle exec maze-runner --farm=bb --access-key=<REDACTED> --device=ANDROID_ --list-devices
...
No device groups were found with the given name ANDROID_
```

- Valid access key:
```
bundle exec maze-runner --farm=bb --access-key=<REDACTED> --device=ANDROID_10 --list-devices
...
BitBar devices available for device group ANDROID_10:
------------------------------
Device name : Google Pixel 3a -US
OS type     : ANDROID
OS version  : 10
API level   : 29
------------------------------
Device name : Google Pixel 4 -US
OS type     : ANDROID
OS version  : 10
API level   : 29
------------------------------
Device name : Google Pixel 3a XL Android 10 -US
OS type     : ANDROID
OS version  : 10
API level   : 29
```

