### PR TITLE
Add chrome 43 & 72 and firefox 78 to available BitBar browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-# TBD
+# 7.20.0 - 2023/02/28
 
 ## Enhancements
 
 - Add --list-devices option for BitBar devices and device groups
   - [480](https://github.com/bugsnag/maze-runner/pull/480)
   - [481](https://github.com/bugsnag/maze-runner/pull/481)
+- Add BitBar browsers to those currently available [483](https://github.com/bugsnag/maze-runner/pull/483)
+  - Firefox 78
+  - Chrome 43 and 72
 
 ## Removals
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.19.0)
+    bugsnag-maze-runner (7.20.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -161,6 +161,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
   x86_64-darwin-20
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,6 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  ruby
   x86_64-darwin-19
   x86_64-darwin-20
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.19.0'
+  VERSION = '7.20.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address, :run_uuid

--- a/lib/maze/client/selenium/bb_browsers.yml
+++ b/lib/maze/client/selenium/bb_browsers.yml
@@ -40,6 +40,20 @@ chrome_103:
   version: '103'
   resolution: '1920x1080'
 
+chrome_72:
+	platform: 'Windows'
+	osVersion: '10'
+	browserName: 'chrome'
+	version: '72'
+	resolution: '1920x1080'
+
+chrome_43:
+	platform': 'Windows'
+	osVersion: '10'
+	browserName: 'chrome'
+	version: '43'
+	resolution: '1920x1080'
+
 firefox_107:
   platform: 'Windows'
   osVersion: '11'
@@ -81,6 +95,13 @@ firefox_102:
   browserName: 'firefox'
   version: '102'
   resolution: '1920x1080'
+
+firefox_78:
+	platform: 'Windows'
+	osVersion: '10'
+	browserName: 'firefox'
+	version: '78'
+	resolution: '1920x1080'
 
 ie_11:
   platform: 'Windows'

--- a/lib/maze/client/selenium/bb_browsers.yml
+++ b/lib/maze/client/selenium/bb_browsers.yml
@@ -41,18 +41,18 @@ chrome_103:
   resolution: '1920x1080'
 
 chrome_72:
-	platform: 'Windows'
-	osVersion: '10'
-	browserName: 'chrome'
-	version: '72'
-	resolution: '1920x1080'
+  platform: 'Windows'
+  osVersion: '10'
+  browserName: 'chrome'
+  version: '72'
+  resolution: '1920x1080'
 
 chrome_43:
-	platform': 'Windows'
-	osVersion: '10'
-	browserName: 'chrome'
-	version: '43'
-	resolution: '1920x1080'
+  platform': 'Windows'
+  osVersion: '10'
+  browserName: 'chrome'
+  version: '43'
+  resolution: '1920x1080'
 
 firefox_107:
   platform: 'Windows'
@@ -97,11 +97,11 @@ firefox_102:
   resolution: '1920x1080'
 
 firefox_78:
-	platform: 'Windows'
-	osVersion: '10'
-	browserName: 'firefox'
-	version: '78'
-	resolution: '1920x1080'
+  platform: 'Windows'
+  osVersion: '10'
+  browserName: 'firefox'
+  version: '78'
+  resolution: '1920x1080'
 
 ie_11:
   platform: 'Windows'


### PR DESCRIPTION
For usage in Bugsnag JS browser test pipeline