### PR TITLE
Start the document server after client hooks run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Fixes
+
+- Start the document server after client hooks run so the document root can be set with other Maze Runner configuration [484](https://github.com/bugsnag/maze-runner/pull/484)
+
 # 7.20.0 - 2023/02/28
 
 ## Enhancements

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -44,9 +44,6 @@ BeforeAll do
   Maze.run_uuid = SecureRandom.uuid
   $logger.info "UUID for this run: #{Maze.run_uuid}"
 
-  # Start document server, if asked for
-  Maze::DocumentServer.start unless Maze.config.document_server_root.nil?
-
   # Determine public IP if enabled
   if Maze.config.aws_public_ip
     Maze.public_address = Maze::AwsPublicIp.new.address
@@ -64,6 +61,10 @@ BeforeAll do
 
   # Call any blocks registered by the client
   Maze.hooks.call_before_all
+
+  # Start document server, if asked for
+  # This must happen after any client hooks have run, so that they can set the server root
+  Maze::DocumentServer.start unless Maze.config.document_server_root.nil?
 end
 
 # @param config The Cucumber config


### PR DESCRIPTION
## Goal

Currently the document server is started in Maze Runner's `BeforeAll` block. This runs before any Maze Runner hooks are run, which is usually where Maze Runner configuration would be applied

For example, this doesn't currently work but will after this PR:

```rb
Maze.hooks.before_all do
  Maze.config.document_server_root = 'some/path'
end
```