### PR TITLE
Add 'latest' versions of Chrome, Firefox & Edge to BitBar browser list

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -277,7 +277,7 @@ steps:
   # BitBar tests
   #
 
-  - label: 'BitBar web browser test - Firefox v107'
+  - label: 'BitBar web browser test - Firefox latest'
     depends_on: "push-branch-cli"
     timeout_in_minutes: 10
     plugins:
@@ -291,7 +291,7 @@ steps:
         verbose: true
         command:
           - "--farm=bb"
-          - "--browser=firefox_107"
+          - "--browser=firefox_latest"
           - "--aws-public-ip"
           - "--fail-fast"
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # TBD
 
+## Enhancements
+
+- Add 'latest' versions of Chrome, Firefox & Edge to BitBar browser list [490](https://github.com/bugsnag/maze-runner/pull/490)
+
 ## Fixes
 
 - Fix integer attribute step looking at stringValue [487](https://github.com/bugsnag/maze-runner/pull/487)

--- a/lib/maze/client/selenium/bb_browsers.yml
+++ b/lib/maze/client/selenium/bb_browsers.yml
@@ -1,3 +1,10 @@
+chrome_latest:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'chrome'
+  version: 'latest'
+  resolution: '1920x1080'
+
 chrome_108:
   platform: 'Windows'
   osVersion: '11'
@@ -54,6 +61,13 @@ chrome_43:
   version: '43'
   resolution: '1920x1080'
 
+firefox_latest:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'firefox'
+  version: 'latest'
+  resolution: '1920x1080'
+
 firefox_107:
   platform: 'Windows'
   osVersion: '11'
@@ -108,6 +122,13 @@ ie_11:
   osVersion: '10'
   browserName: 'internet explorer'
   version: '11'
+  resolution: '1920x1080'
+
+edge_latest:
+  platform: 'Windows'
+  osVersion: '11'
+  browserName: 'MicrosoftEdge'
+  version: 'latest'
   resolution: '1920x1080'
 
 edge_106:


### PR DESCRIPTION
## Goal

BitBar now support using `latest` as a version to get the latest version of a given browser:

<img width="765" alt="image" src="https://user-images.githubusercontent.com/282732/223989196-f48520b0-cde5-43ff-a522-4b79f46d6bbc.png">

This PR adds the latest versions of Chrome, Firefox & Edge[^1] to `bb_browsers.yml` so we can use them in other repos

## Tests

Updated the Firefox version to `firefox_latest` in the pipeline

[^1]: I've not added Safari as (presumably) it'd also need the `osVersion` to be `latest` and I'm not sure if that's possible — there are basically no docs on this AFAICT. Safari only updates its major version once per year, so it's not as onerous to update manually compared to other browsers