### PR TITLE
Remove `SBSecureTunnel` output in debug mode

### DIFF
--- a/lib/maze/client/bb_client_utils.rb
+++ b/lib/maze/client/bb_client_utils.rb
@@ -153,7 +153,6 @@ module Maze
               output = []
               stdout_and_stderr.each do |line|
                 output << line
-                $logger.debug('SBSecureTunnel') {line.chomp}
               end
 
               exit_status = wait_thr.value.to_i


### PR DESCRIPTION
## Goal

The `SBSecureTunnel` binary expects to be run interactively in the foreground and so logs some pretty graphs showing the incoming/outgoing requests per second

This doesn't work nicely when it's run in the background by Maze Runner because updating the graphs causes the entire output to run again

Other than just spamming Maze Runner's output, this also appears to break Buildkite's log parsing:

![image](https://user-images.githubusercontent.com/282732/223994341-0adb87e7-4b06-43b7-b11e-0f2c80b43fc1.png)

Maze Runner will still collect the output to be logged at warning level if the process crashes, so this change _shouldn't_ hide legitimate problems