### PR TITLE
Do not use Android 7 in test pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -186,7 +186,7 @@ steps:
   # BrowserStack tests
   #
 
-  - label: 'BrowserStack app-automate - Android 7 - JWP'
+  - label: 'BrowserStack app-automate - JWP protocol'
     timeout_in_minutes: 20
     depends_on:
       - "appium-test-fixture"
@@ -200,7 +200,7 @@ steps:
         command:
           - "--app=build/outputs/apk/release/app-release.apk"
           - "--farm=bs"
-          - "--device=ANDROID_7_1"
+          - "--device=ANDROID_13_0"
           - "--fail-fast"
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:
@@ -213,7 +213,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: 'BrowserStack app-automate - Android 13 - W3C'
+  - label: 'BrowserStack app-automate - W3C protocol'
     timeout_in_minutes: 20
     depends_on:
       - "appium-test-fixture"


### PR DESCRIPTION
## Goal

Bump the JWP protocol step to use Android 13 rather than 7.

## Design

The Android 7 device is becoming increasingly unavailable on BrowserStack, causing failures in the pipeline and blocking PRs.  The thing we really want to test is support for the JWP protocol on BrowserStack in general, as opposed to a specific Android version.  Therefore bumping it to a version that has a lot more device availability.

## Tests

Covered by CI.