### PR TITLE
Fix wait for the SBSecureTunnel stopping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Fixes
+
+- Fix wait for the SBSecureTunnel stopping [495](https://github.com/bugsnag/maze-runner/pull/495)
+
 # 7.22.0 - 2023/03/10
 
 ## Enhancements


### PR DESCRIPTION
## Goal

Currently Maze Runner waits for the BitBar "ready file" to be deleted as a sign of the SBSecureTunnel being stopped. However, it doesn't look like this file is actually deleting and MR doesn't check if the wait succeeds — this means we wait for a full 30 seconds for every test run that uses BitBar

We can instead wait for the thread that's running the secure tunnel binary to stop

I've also added a log for the success & fail cases, so we know the status of the tunnel thread when exiting