### PR TITLE
Add a passthrough in trace validation for initial sampling payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Fixes
 
 - Fix wait for the SBSecureTunnel stopping [495](https://github.com/bugsnag/maze-runner/pull/495)
-- Add missing passthrough for the initial sampling value trace payload []()
+- Add missing passthrough for the initial sampling value trace payload [496](https://github.com/bugsnag/maze-runner/pull/496)
 
 # 7.22.0 - 2023/03/10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# TBD
+# 7.22.1 - 2023/03/13
 
 ## Fixes
 
 - Fix wait for the SBSecureTunnel stopping [495](https://github.com/bugsnag/maze-runner/pull/495)
+- Add missing passthrough for the initial sampling value trace payload []()
 
 # 7.22.0 - 2023/03/10
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.22.0)
+    bugsnag-maze-runner (7.22.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.22.0'
+  VERSION = '7.22.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address, :run_uuid

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -25,6 +25,9 @@ module Maze
       # Runs the validation against the trace given
       def validate
         @success = true
+        # Shortcut the validation if the body is empty for initial P gathering reasons
+        return if @body.keys.eql?(['resourceSpans']) && @body['resourceSpans'].empty?
+
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.spanId', '^[A-Fa-f0-9]{16}$')
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.traceId', '^[A-Fa-f0-9]{32}$')
         element_int_in_range('resourceSpans.0.scopeSpans.0.spans.0.kind', 0..5)

--- a/test/fixtures/payload-helpers/features/support/send_request.rb
+++ b/test/fixtures/payload-helpers/features/support/send_request.rb
@@ -10,7 +10,7 @@ def send_request(request_type, mock_api_port = 9339)
                '/sessions'
              elsif request_type == 'build'
                '/builds'
-             elsif request_type == 'trace' || request_type == 'browser-trace'
+             elsif request_type == 'trace' || request_type == 'browser-trace' || request_type == 'sampling-trace'
                '/traces'
              else
                '/notify'
@@ -59,6 +59,16 @@ def send_request(request_type, mock_api_port = 9339)
         },
         'app' => 'not null',
         'device' => 'not null'
+      }
+    },
+    'sampling-trace' => {
+      'headers' => {
+        'Bugsnag-Api-Key' => $api_key,
+        'Bugsnag-Payload-Version' => '1.0',
+        'Bugsnag-Sent-At' => Time.now().iso8601(3)
+      },
+      'body' => {
+        "resourceSpans": []
       }
     },
     'trace' => {

--- a/test/fixtures/payload-helpers/features/traces_support.feature
+++ b/test/fixtures/payload-helpers/features/traces_support.feature
@@ -1,9 +1,15 @@
 Feature: Testing support on traces endpoint
 
     Scenario: The traces endpoint can accept json payloads
-        # A mobile trace
-        When I send a "trace"-type request
+        # A sampling trace
+        When I send a "sampling-trace"-type request
         Then I wait to receive a trace
+        And The HTTP response header "Bugsnag-Sampling-Probability" equals "1"
+        And I discard the oldest trace
+
+        # A mobile trace
+        Then I send a "trace"-type request
+        And I wait to receive a trace
         And The HTTP response header "Bugsnag-Sampling-Probability" equals "1"
         And the trace payload field "resourceSpans.0.resource.attributes.0.key" equals "device.id"
         And the trace payload field "resourceSpans.0.resource.attributes.0.value.stringValue" equals "cd5c48566a5ba0b8597dca328c392e1a7f98ce86"


### PR DESCRIPTION
## Goal

Recently added trace payload validation breaks with full setups due to not allowing an exception through.
This PR adds that exception to the validation logic so a specific payload with an a single key of `resourceSpans` with no elements in the array will pass.

## Tests

Added proper E2E tests to cover the scenario.