### PR TITLE
Push to RubyGems.org on release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -348,3 +348,11 @@ steps:
             - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:${BUILDKITE_TAG}-cli-legacy
             - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli-legacy
             - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-cli-legacy
+
+  - label: 'Push to RubyGems.org'
+    if: build.tag =~ /^v[2-9]\.[0-9]+\.[0-9]+\$/
+    agents:
+      queue: macos-12-arm
+    commands:
+      - 'gem build bugsnag-maze-runner.gemspec'
+      - 'gem push bugsnag-maze-runner-*.gem'


### PR DESCRIPTION
v7 equivalent of #497 - a direct copy and paste of the Buildkite step.
