### PR TITLE
Add new step and associated method to search for table-defined spans

### DIFF
--- a/test/fixtures/payload-helpers/features/support/send_request.rb
+++ b/test/fixtures/payload-helpers/features/support/send_request.rb
@@ -138,6 +138,46 @@ def send_request(request_type, mock_api_port = 9339)
                       }
                     ],
                     "name":"ManualSpanScenario"
+                  },
+                  {
+                    "spanId":"96775346bf426548",
+                    "startTimeUnixNano":"1677082367269565184",
+                    "traceId":"4dea8da13b30db98f1c56bee0fdc734c",
+                    "endTimeUnixNano":"1677082367269576192",
+                    "kind":"SPAN_KIND_INTERNAL",
+                    "attributes":[
+                      {
+                        "key":"test.bool_value",
+                        "value":{
+                          "boolValue":true
+                        }
+                      },
+                      {
+                        "key":"test.string_value",
+                        "value":{
+                          "stringValue":"frayed_knot"
+                        }
+                      },
+                      {
+                        "key":"test.int_value",
+                        "value":{
+                          "intValue":50
+                        }
+                      },
+                      {
+                        "key":"test.double_value",
+                        "value":{
+                          "doubleValue":6.4
+                        }
+                      },
+                      {
+                        "key":"test.bytes_value",
+                        "value":{
+                          "bytesValue":"deadbeef"
+                        }
+                      }
+                    ],
+                    "name":"TestSpan"
                   }
                 ]
               }
@@ -295,6 +335,22 @@ def send_request(request_type, mock_api_port = 9339)
                         }
                       }
                     ]
+                  },
+                  {
+                    "spanId":"96775346bf426548",
+                    "startTimeUnixNano":"1677082367269565184",
+                    "traceId":"4dea8da13b30db98f1c56bee0fdc734c",
+                    "endTimeUnixNano":"1677082367269576192",
+                    "kind":"SPAN_KIND_INTERNAL",
+                    "attributes":[
+                      {
+                        "key":"test.next_payload_value",
+                        "value":{
+                          "stringValue":"another!"
+                        }
+                      }
+                    ],
+                    "name":"TestSpan"
                   }
                 ]
               }

--- a/test/fixtures/payload-helpers/features/traces_support.feature
+++ b/test/fixtures/payload-helpers/features/traces_support.feature
@@ -83,3 +83,17 @@ Feature: Testing support on traces endpoint
        Given I set up the maze-harness console
        And I input "bundle exec maze-runner --port=9349 features/failing_schema.feature" interactively
        Then the last interactive command exit code is 1
+
+    Scenario: Spans can be validated across requests
+        When I send a "trace"-type request
+        And I send a "browser-trace"-type request
+        Then a span named "TestSpan" contains the attributes:
+            | attribute               | type        | value       |
+            | test.bool_value         | boolValue   | true        |
+            | test.string_value       | stringValue | frayed_knot |
+            | test.int_value          | intValue    | 50          |
+            | test.double_value       | doubleValue | 6.4         |
+            | test.bytes_value        | bytesValue  | deadbeef    |
+        And a span named "TestSpan" contains the attributes:
+            | attribute               | type        | value       |
+            | test.next_payload_value | stringValue | another!    |


### PR DESCRIPTION
## Goal

When testing traces we need to locate spans with a particular name, and verify they contain certain attributes.  This allows that test to be set up via a gherkin table in the style of:

```
        Then a span named "TestSpan" contains the attributes:
            | attribute               | type        | value       |
            | test.bool_value         | boolValue   | true        |
            | test.string_value       | stringValue | frayed_knot |
            | test.int_value          | intValue    | 50          |
            | test.double_value       | doubleValue | 6.4         |
            | test.bytes_value        | bytesValue  | deadbeef    |
```

## Tests

End to end tests have been updated to verify the tests work correctly.  Practical testing has been carried out by @yousif-bugsnag 
