### PR TITLE
Improve calculation of BitBar dashboard properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-# TBD
+# 7.24.0 - TBD
 
 ## Enhancements
 
 - Add logic for step `a span field {string} equals {int}` [501](https://github.com/bugsnag/maze-runner/pull/501)
+
+## Fixes
+
+- Improve logging when calculating BitBar dashboard project and test run [501](https://github.com/bugsnag/maze-runner/pull/502)
 
 # 7.23.0 - 2023/03/20
 

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -77,7 +77,7 @@ module Maze
           else
             $logger.warn "Cannot determine BitBar project name using git.  Does the Docker container need a volume mapping for .git?"
             if ENV['BUILDKITE']
-              $logger.info 'Using '
+              $logger.info 'Using BUILDKITE_PIPELINE_SLUG for BitBar project'
               project = ENV['BUILDKITE_PIPELINE_SLUG']
             else
               $logger.warn 'Unable to determine project name, consider running Maze Runner from within a Git repository'
@@ -86,7 +86,13 @@ module Maze
           end
           #  BUILDKITE_RETRY_COUNT
           if ENV['BUILDKITE']
-            test_run = "#{ENV['BUILDKITE_BUILD_NUMBER']} - #{ENV['BUILDKITE_LABEL']}"
+            bk_retry = ENV['BUILDKITE_RETRY_COUNT']
+            retry_string = if !bk_retry.nil? && bk_retry.to_i > 1
+                             " (#{bk_retry})"
+                           else
+                             ''
+                           end
+            test_run = "#{ENV['BUILDKITE_BUILD_NUMBER']} - #{ENV['BUILDKITE_LABEL']}#{retry_string}"
           else
             test_run = Maze.run_uuid
           end

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -75,24 +75,28 @@ module Maze
           if status == 0
             project = File.basename(output[0].strip)
           else
+            $logger.warn "Cannot determine BitBar project name using git.  Does the Docker container need a volume mapping for .git?"
             if ENV['BUILDKITE']
+              $logger.info 'Using '
               project = ENV['BUILDKITE_PIPELINE_SLUG']
             else
               $logger.warn 'Unable to determine project name, consider running Maze Runner from within a Git repository'
               project = 'Unknown'
             end
           end
-
+          #  BUILDKITE_RETRY_COUNT
           if ENV['BUILDKITE']
             test_run = "#{ENV['BUILDKITE_BUILD_NUMBER']} - #{ENV['BUILDKITE_LABEL']}"
           else
             test_run = Maze.run_uuid
           end
 
+          $logger.info "BitBar dashboard project: #{project}"
+          $logger.info "BitBar dashboard test run: #{test_run}"
           {
             'bitbar:options' => {
-              bitbar_project: project,
-              bitbar_testrun: test_run
+              bitbarProject: project,
+              bitbarTestrun: test_run
             }
           }
         end

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -70,21 +70,23 @@ module Maze
         #
         # @return [Hash] A hash containing the capabilities.
         def dashboard_capabilities
-          # Attempt to use the current git repo as the project name
-          output, status = Maze::Runner.run_command('git rev-parse --show-toplevel')
-          if status == 0
-            project = File.basename(output[0].strip)
+
+          # Determine project name
+          if ENV['BUILDKITE']
+            $logger.info 'Using BUILDKITE_PIPELINE_SLUG for BitBar project'
+            project = ENV['BUILDKITE_PIPELINE_SLUG']
           else
-            $logger.warn "Cannot determine BitBar project name using git.  Does the Docker container need a volume mapping for .git?"
-            if ENV['BUILDKITE']
-              $logger.info 'Using BUILDKITE_PIPELINE_SLUG for BitBar project'
-              project = ENV['BUILDKITE_PIPELINE_SLUG']
+            # Attempt to use the current git repo
+            output, status = Maze::Runner.run_command('git rev-parse --show-toplevel')
+            if status == 0
+              project = File.basename(output[0].strip)
             else
               $logger.warn 'Unable to determine project name, consider running Maze Runner from within a Git repository'
               project = 'Unknown'
             end
           end
-          #  BUILDKITE_RETRY_COUNT
+
+          # Test run
           if ENV['BUILDKITE']
             bk_retry = ENV['BUILDKITE_RETRY_COUNT']
             retry_string = if !bk_retry.nil? && bk_retry.to_i > 1

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -73,7 +73,7 @@ module Maze
 
           # Determine project name
           if ENV['BUILDKITE']
-            $logger.info 'Using BUILDKITE_PIPELINE_SLUG for BitBar project'
+            $logger.info 'Using BUILDKITE_PIPELINE_SLUG for BitBar project name'
             project = ENV['BUILDKITE_PIPELINE_SLUG']
           else
             # Attempt to use the current git repo
@@ -99,12 +99,12 @@ module Maze
             test_run = Maze.run_uuid
           end
 
-          $logger.info "BitBar dashboard project: #{project}"
-          $logger.info "BitBar dashboard test run: #{test_run}"
+          $logger.info "BitBar project name: #{project}"
+          $logger.info "BitBar test run: #{test_run}"
           {
             'bitbar:options' => {
-              bitbarProject: project,
-              bitbarTestrun: test_run
+              bitbar_project: project,
+              bitbar_testrun: test_run
             }
           }
         end


### PR DESCRIPTION
## Goal

Simplify how the BitBar project name and test run values are calculated, whilst also improving logging so that repos can more easily set themselves up with the right environment variables.

## Design

I've simplified the logic on Buildkite to avoid using Git - it's just an unnecessary complexity.  The Buildkite slug is adequate and invariably exactly the same.  I've also improved the logging to make it easier to see how values are generated and set up docker-compose services for CI accordingly.

## Tests

Unit tests updated and given a trial run using bugsnag-android.