### PR TITLE
Update upload-app script for use with BitBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Add logic for step `a span field {string} equals {int}` [501](https://github.com/bugsnag/maze-runner/pull/501)
+- Update upload-app script to allow BitBar uploads []()
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Enhancements
 
 - Add logic for step `a span field {string} equals {int}` [501](https://github.com/bugsnag/maze-runner/pull/501)
-- Update upload-app script to allow BitBar uploads []()
+- Update upload-app script to allow BitBar uploads [504](https://github.com/bugsnag/maze-runner/pull/504)
 
 ## Fixes
 

--- a/bin/upload-app
+++ b/bin/upload-app
@@ -3,6 +3,7 @@
 
 require_relative '../lib/maze'
 require_relative '../lib/maze/client/bs_client_utils'
+require_relative '../lib/maze/client/bb_client_utils'
 require_relative '../lib/maze/logger'
 require_relative '../lib/maze/helper'
 require 'optimist'
@@ -11,45 +12,70 @@ require 'net/http'
 
 class UploadAppEntry
   def start(args)
-    p = Optimist::Parser.new do
-      text 'Upload app files to BrowserStack'
-      text ''
-      text 'Requires BROWSER_STACK_USERNAME and BROWSER_STACK_ACCESS_KEY'
+    parser = Optimist::Parser.new do
+      text 'Upload app files to a device farm'
       text ''
       text 'Usage [OPTIONS]'
       text ''
       opt :help,
-          'Print this help.'
+        'Print this help.'
       opt :app,
-          'The app to upload.',
-          :type => :string
+        'The app to upload.',
+        type: :string,
+        required: true
       opt :app_id_file,
-          'The file to write the uploaded app ID back to',
-          :type => :string
+        'The file to write the uploaded app ID back to',
+        type: :string
+      opt :farm,
+        'The device farm to upload the app to, one of bb (BitBar) or bs (BrowserStack) (required)',
+        type: :string,
+        required: true
+      opt :username,
+        'Device farm username. Defaults to BROWSER_STACK_DEVICES_USERNAME variable (required for BrowserStack)',
+        type: :string
+      opt :access_key,
+        'Device farm access key. Defaults to BROWSER_STACK_DEVICES_ACCESS_KEY or BITBAR_ACCESS_KEY environment variables (required)',
+        type: :string
     end
 
-    opts = Optimist::with_standard_exception_handling p do
+    options = Optimist::with_standard_exception_handling parser do
       raise Optimist::HelpNeeded if ARGV.empty? # show help screen
-      p.parse ARGV
+      parser.parse ARGV
     end
 
-    # Get browserstack username and access key from the environment
-    username = ENV['BROWSER_STACK_USERNAME']
-    access_key = ENV['BROWSER_STACK_ACCESS_KEY']
+    # Get username and access key from the environment
+    case options[:farm]
+    when 'bs'
+      options[:username] ||= ENV['BROWSER_STACK_DEVICES_USERNAME'] || ENV['BROWSER_STACK_USERNAME']
+      options[:access_key] ||= ENV['BROWSER_STACK_DEVICES_ACCESS_KEY'] ||ENV['BROWSER_STACK_ACCESS_KEY']
+      if options[:username].nil?
+        $logger.warn 'Browserstack requires username option to be set'
+        Optimist::with_standard_exception_handling parser do
+          raise Optimist::HelpNeeded
+        end
+      end
+    when 'bb'
+      options[:access_key] ||= ENV['BITBAR_ACCESS_KEY']
+    end
 
-    # Check if BROWSER_STACK_USERNAME or BROWSER_STACK_ACCESS_KEY has been set
-    if username.nil? || access_key.nil?
-      $logger.warn "BROWSER_STACK_USERNAME or BROWSER_STACK_ACCESS_KEY has not been set"
-      Optimist::with_standard_exception_handling p do
+    if options[:access_key].nil?
+      $logger.warn 'An access_key is required to upload the app'
+      Optimist::with_standard_exception_handling parser do
         raise Optimist::HelpNeeded
       end
     end
 
-    Maze::Client::BrowserStackClientUtils.upload_app username,
-                                                     access_key,
-                                                     opts[:app],
-                                                     opts[:app_id_file]
-
+    case options[:farm]
+    when 'bs'
+      Maze::Client::BrowserStackClientUtils.upload_app options[:username],
+                                                       options[:access_key],
+                                                       options[:app],
+                                                       options[:app_id_file]
+    when 'bb'
+      Maze::Client::BitBarClientUtils.upload_app options[:access_key],
+                                                 options[:app],
+                                                 options[:app_id_file]
+    end
   end
 end
 

--- a/bin/upload-app
+++ b/bin/upload-app
@@ -27,9 +27,9 @@ class UploadAppEntry
         'The file to write the uploaded app ID back to',
         type: :string
       opt :farm,
-        'The device farm to upload the app to, one of bb (BitBar) or bs (BrowserStack) (required)',
+        'The device farm to upload the app to, one of bb (BitBar) or bs (BrowserStack) (default)',
         type: :string,
-        required: true
+        default: 'bs'
       opt :username,
         'Device farm username. Defaults to BROWSER_STACK_DEVICES_USERNAME variable (required for BrowserStack)',
         type: :string

--- a/lib/maze/client/bb_client_utils.rb
+++ b/lib/maze/client/bb_client_utils.rb
@@ -17,7 +17,8 @@ module Maze
         # Uploads an app to BitBar for later consumption
         # @param api_key [String] The BitBar API key
         # @param app [String] A path to the application file
-        def upload_app(api_key, app)
+        # @param app_id_file [String] the file to write the uploaded app url to BrowserStack
+        def upload_app(api_key, app, app_id_file=nil)
           uuid_regex = /\A[0-9]+\z/
 
           if uuid_regex.match? app
@@ -53,6 +54,12 @@ module Maze
               raise
             end
           end
+
+          unless app_id_file.nil?
+            $logger.info "Writing uploaded app id to #{app_id_file}"
+            File.write(Maze::Helper.expand_path(app_id_file), app_uuid)
+          end
+
           app_uuid
         end
 

--- a/lib/maze/client/bb_client_utils.rb
+++ b/lib/maze/client/bb_client_utils.rb
@@ -17,7 +17,7 @@ module Maze
         # Uploads an app to BitBar for later consumption
         # @param api_key [String] The BitBar API key
         # @param app [String] A path to the application file
-        # @param app_id_file [String] the file to write the uploaded app url to BrowserStack
+        # @param app_id_file [String] the file to write the uploaded app url to BitBar
         def upload_app(api_key, app, app_id_file=nil)
           uuid_regex = /\A[0-9]+\z/
 


### PR DESCRIPTION
## Goal

This allows us to upload an app to BitBar early during a build process then use that application ID later in the build to avoid uploading build artefacts more than once.

While the `farm` argument will allow us to switch to BitBar, the default will remain as BrowserStack to maintain continuity with our current pipelines.

## Tests

Tested multiple times to ensure the uploads function as expected with varying amounts of arguments present.
