### PR TITLE
Set the default HTTP verb for status setting to 'POST' request only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Enhancements
+
+- Set default verb for HTTP status code steps to "POST" [506](https://github.com/bugsnag/maze-runner/pull/506)
+
 # 7.24.0 - 2023/03/30
 
 ## Enhancements

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -15,20 +15,6 @@ When('I set the HTTP status code to {int}') do |status_code|
   Maze::Server.set_status_code_generator(Maze::Generator.new [status_code].cycle)
 end
 
-# Sets the HTTP status code to be used for the next POST request
-#
-# @step_input status_code [Integer] The status code to return
-When('I set the HTTP status code for the next request to {int}') do |status_code|
-  step %{Then I set the HTTP status code for the next "POST" request to #{status_code}}
-end
-
-# Sets the HTTP status code to be used for the next set of POST requests
-#
-# @step_input status_codes [String] A comma separated list of status codes to return
-When('I set the HTTP status code for the next requests to {string}') do |status_codes|
-  step %{Then I set the HTTP status code for the next "POST" requests to "status_codes"}
-end
-
 # Sets the HTTP status code to be used for the next set of requests for a given connection type
 #
 # @step_input http_verb [String] The type of request this code will be used for
@@ -55,6 +41,20 @@ end
 When('I set the HTTP status code for the next {string} request to {int}') do |http_verb, status_code|
   raise("Invalid HTTP verb: #{http_verb}") unless Maze::Server::ALLOWED_HTTP_VERBS.include?(http_verb)
   Maze::Server.set_status_code_generator(create_defaulting_generator([status_code], Maze::Server::DEFAULT_STATUS_CODE), http_verb)
+end
+
+# Sets the HTTP status code to be used for the next POST request
+#
+# @step_input status_code [Integer] The status code to return
+When('I set the HTTP status code for the next request to {int}') do |status_code|
+  step %{I set the HTTP status code for the next "POST" request to #{status_code}}
+end
+
+# Sets the HTTP status code to be used for the next set of POST requests
+#
+# @step_input status_codes [String] A comma separated list of status codes to return
+When('I set the HTTP status code for the next requests to {string}') do |status_codes|
+  step %{I set the HTTP status code for the next "POST" requests to "#{status_codes}"}
 end
 
 # Sets the sampling probability to be used for all subsequent trace responses

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -15,22 +15,31 @@ When('I set the HTTP status code to {int}') do |status_code|
   Maze::Server.set_status_code_generator(Maze::Generator.new [status_code].cycle)
 end
 
-# Sets the HTTP status code to be used for the next request
+# Sets the HTTP status code to be used for the next POST request
 #
 # @step_input status_code [Integer] The status code to return
 When('I set the HTTP status code for the next request to {int}') do |status_code|
-  Maze::Server.set_status_code_generator(create_defaulting_generator([status_code], Maze::Server::DEFAULT_STATUS_CODE))
+  step %{Then I set the HTTP status code for the next "POST" request to #{status_code}}
 end
 
-# Sets the HTTP status code to be used for the next set of requests
+# Sets the HTTP status code to be used for the next set of POST requests
 #
 # @step_input status_codes [String] A comma separated list of status codes to return
 When('I set the HTTP status code for the next requests to {string}') do |status_codes|
-  codes = status_codes.split(',').map(&:strip)
-  Maze::Server.set_status_code_generator(create_defaulting_generator(codes, Maze::Server::DEFAULT_STATUS_CODE))
+  step %{Then I set the HTTP status code for the next "POST" requests to "status_codes"}
 end
 
-# Steps the HTTP status code to be used for all subsequent requests for a given connection type
+# Sets the HTTP status code to be used for the next set of requests for a given connection type
+#
+# @step_input http_verb [String] The type of request this code will be used for
+# @step_input status_codes [String] A comma separated list of status codes to return
+When('I set the HTTP status code for the next {string} requests to {string}') do |http_verb, status_codes|
+  raise("Invalid HTTP verb: #{http_verb}") unless Maze::Server::ALLOWED_HTTP_VERBS.include?(http_verb)
+  codes = status_codes.split(',').map(&:strip)
+  Maze::Server.set_status_code_generator(create_defaulting_generator(codes, Maze::Server::DEFAULT_STATUS_CODE), http_verb)
+end
+
+# Sets the HTTP status code to be used for all subsequent requests for a given connection type
 #
 # @step_input http_verb [String] The type of request this code will be used for
 # @step_input status_code [Integer] The status code to return
@@ -39,7 +48,7 @@ When('I set the HTTP status code for {string} requests to {int}') do |http_verb,
   Maze::Server.set_status_code_generator(Maze::Generator.new([status_code].cycle), http_verb)
 end
 
-# Steps the HTTP status code to be used for the next request for a given connection type
+# Sets the HTTP status code to be used for the next request for a given connection type
 #
 # @step_input http_verb [String] The type of request this code will be used for
 # @step_input status_code [Integer] The status code to return

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -8,13 +8,6 @@ When('I wait for the host {string} to open port {string}') do |host, port|
   Maze::Network.wait_for_port(host, port)
 end
 
-# Sets the HTTP status code to be used for all subsequent requests
-#
-# @step_input status_code [Integer] The status code to return
-When('I set the HTTP status code to {int}') do |status_code|
-  Maze::Server.set_status_code_generator(Maze::Generator.new [status_code].cycle)
-end
-
 # Sets the HTTP status code to be used for the next set of requests for a given connection type
 #
 # @step_input http_verb [String] The type of request this code will be used for
@@ -41,6 +34,13 @@ end
 When('I set the HTTP status code for the next {string} request to {int}') do |http_verb, status_code|
   raise("Invalid HTTP verb: #{http_verb}") unless Maze::Server::ALLOWED_HTTP_VERBS.include?(http_verb)
   Maze::Server.set_status_code_generator(create_defaulting_generator([status_code], Maze::Server::DEFAULT_STATUS_CODE), http_verb)
+end
+
+# Sets the HTTP status code to be used for all subsequent POST requests
+#
+# @step_input status_code [Integer] The status code to return
+When('I set the HTTP status code to {int}') do |status_code|
+  step %{I set the HTTP status code for "POST" requests to #{status_code}}
 end
 
 # Sets the HTTP status code to be used for the next POST request

--- a/test/fixtures/http-response/features/scripts/send_verbed_requests.rb
+++ b/test/fixtures/http-response/features/scripts/send_verbed_requests.rb
@@ -29,4 +29,16 @@ second_post_request.body = %({
   "second_options_code": "#{second_options_response.code}"
 })
 
-http.request(second_post_request)
+second_post_response = http.request(second_post_request)
+
+third_post_request = Net::HTTP::Post.new('/notify')
+third_post_request['Content-Type'] = 'application/json'
+
+third_post_request.body = %({
+  "first_options_code": "#{first_options_response.code}",
+  "first_post_code": "#{first_post_response.code}",
+  "second_options_code": "#{second_options_response.code}",
+  "second_post_code": "#{second_post_response.code}"
+})
+
+http.request(third_post_request)

--- a/test/fixtures/http-response/features/set_different_responses.feature
+++ b/test/fixtures/http-response/features/set_different_responses.feature
@@ -50,39 +50,59 @@ Feature: Setting different response codes
     Scenario: Server response code can be set for a specific connection type (504)
         Given I set the HTTP status code for the next "OPTIONS" request to 504
         When I run the script "features/scripts/send_verbed_requests.rb" using ruby synchronously
-        And I wait to receive 2 errors
+        And I wait to receive 3 errors
         Then the error payload field "first_options_code" equals "504"
         And I discard the oldest error
         And the error payload field "first_options_code" equals "504"
         And the error payload field "first_post_code" equals "200"
         And the error payload field "second_options_code" equals "200"
+        And I discard the oldest error
+        And the error payload field "second_post_code" equals "200"
 
     Scenario: Server response code can be set for all subsequent instances of a  specific connection type (505)
         Given I set the HTTP status code for "OPTIONS" requests to 505
         When I run the script "features/scripts/send_verbed_requests.rb" using ruby synchronously
-        And I wait to receive 2 errors
+        And I wait to receive 3 errors
         Then the error payload field "first_options_code" equals "505"
         And I discard the oldest error
         And the error payload field "first_options_code" equals "505"
         And the error payload field "first_post_code" equals "200"
         And the error payload field "second_options_code" equals "505"
+        And I discard the oldest error
+        And the error payload field "second_post_code" equals "200"
 
     Scenario: Codes without a verb defaults to POST requests
         Given I set the HTTP status code for the next request to 503
         And I run the script "features/scripts/send_verbed_requests.rb" using ruby synchronously
-        And I wait to receive 2 errors
+        And I wait to receive 3 errors
         Then the error payload field "first_options_code" equals "200"
         And I discard the oldest error
         And the error payload field "first_options_code" equals "200"
         And the error payload field "first_post_code" equals "503"
         And the error payload field "second_options_code" equals "200"
+        And I discard the oldest error
+        And the error payload field "second_post_code" equals "200"
 
     Scenario: A list of codes without a verb defaults to POST requests
         Given I set the HTTP status code for the next requests to "501,502"
         And I run the script "features/scripts/send_verbed_requests.rb" using ruby synchronously
-        And I wait to receive 2 errors
+        And I wait to receive 3 errors
         Then the error payload field "first_options_code" equals "200"
         And I discard the oldest error
         And the error payload field "first_options_code" equals "200"
         And the error payload field "first_post_code" equals "501"
         And the error payload field "second_options_code" equals "200"
+        And I discard the oldest error
+        And the error payload field "second_post_code" equals "502"
+
+    Scenario: Setting blanket codes without a verb defaults to POST requests
+        Given I set the HTTP status code to 408
+        And I run the script "features/scripts/send_verbed_requests.rb" using ruby synchronously
+        And I wait to receive 3 errors
+        Then the error payload field "first_options_code" equals "200"
+        And I discard the oldest error
+        And the error payload field "first_options_code" equals "200"
+        And the error payload field "first_post_code" equals "408"
+        And the error payload field "second_options_code" equals "200"
+        And I discard the oldest error
+        And the error payload field "second_post_code" equals "408"

--- a/test/fixtures/http-response/features/set_different_responses.feature
+++ b/test/fixtures/http-response/features/set_different_responses.feature
@@ -76,3 +76,13 @@ Feature: Setting different response codes
         And the error payload field "first_options_code" equals "200"
         And the error payload field "first_post_code" equals "503"
         And the error payload field "second_options_code" equals "200"
+
+    Scenario: A list of codes without a verb defaults to POST requests
+        Given I set the HTTP status code for the next requests to "501,502"
+        And I run the script "features/scripts/send_verbed_requests.rb" using ruby synchronously
+        And I wait to receive 2 errors
+        Then the error payload field "first_options_code" equals "200"
+        And I discard the oldest error
+        And the error payload field "first_options_code" equals "200"
+        And the error payload field "first_post_code" equals "501"
+        And the error payload field "second_options_code" equals "200"

--- a/test/fixtures/http-response/features/set_different_responses.feature
+++ b/test/fixtures/http-response/features/set_different_responses.feature
@@ -66,3 +66,13 @@ Feature: Setting different response codes
         And the error payload field "first_options_code" equals "505"
         And the error payload field "first_post_code" equals "200"
         And the error payload field "second_options_code" equals "505"
+
+    Scenario: Codes without a verb defaults to POST requests
+        Given I set the HTTP status code for the next request to 503
+        And I run the script "features/scripts/send_verbed_requests.rb" using ruby synchronously
+        And I wait to receive 2 errors
+        Then the error payload field "first_options_code" equals "200"
+        And I discard the oldest error
+        And the error payload field "first_options_code" equals "200"
+        And the error payload field "first_post_code" equals "503"
+        And the error payload field "second_options_code" equals "200"


### PR DESCRIPTION
## Goal

We've found that when setting status responses for incoming requests, OPTIONS requests can cause inconsistent behaviour between tests, and currently have to be specially accounted for.  Following discussion we believe that desiring a set response to effect the OPTIONS request is generally rare or undesirable behaviour.

This change introduces a default verb of POST for any step that sets a specific number of responses (next/list) if a verb isn't already specified.  This should have minimal impact across the vast majority of tests, but will put the status code steps more in line with their expected purpose.

## Tests

Existing HTTP status tests have been updated to cover the new defaulting behaviour where it isn't covered already.
