### PR TITLE
Add Selenium session links after tests run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update upload-app script to allow BitBar uploads [504](https://github.com/bugsnag/maze-runner/pull/504)
 - Add Datadog StatsD metric reporting for BitBar devices [503](https://github.com/bugsnag/maze-runner/pull/503)
 - Add Datadog StatsD metric reporting appium test amounts [505](https://github.com/bugsnag/maze-runner/pull/505)
+- Add logged links for selenium test sessions []()
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Update upload-app script to allow BitBar uploads [504](https://github.com/bugsnag/maze-runner/pull/504)
 - Add Datadog StatsD metric reporting for BitBar devices [503](https://github.com/bugsnag/maze-runner/pull/503)
 - Add Datadog StatsD metric reporting appium test amounts [505](https://github.com/bugsnag/maze-runner/pull/505)
-- Add logged links for selenium test sessions []()
+- Add logged links for selenium test sessions [507](https://github.com/bugsnag/maze-runner/pull/507)
 
 ## Fixes
 

--- a/lib/maze/client/selenium/base_client.rb
+++ b/lib/maze/client/selenium/base_client.rb
@@ -6,6 +6,10 @@ module Maze
           raise 'Method not implemented by this class'
         end
 
+        def log_run_outro
+          raise 'Method not implemented by this class'
+        end
+
         def stop_session
           Maze.driver&.driver_quit
         end

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -33,8 +33,6 @@ module Maze
           $logger.info 'Appium session(s) created:'
           id = Maze.driver.session_id
           link = api_client.get_device_session_ui_link(id)
-          pp id
-          pp link
           $logger.info Maze::LogUtil.linkify(link, "BitBar session: #{id}") if link
         end
 

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -30,10 +30,10 @@ module Maze
         def log_run_outro
           api_client = BitBarApiClient.new(Maze.config.access_key)
 
-          $logger.info 'Appium session(s) created:'
+          $logger.info 'Selenium session created:'
           id = Maze.driver.session_id
           link = api_client.get_device_session_ui_link(id)
-          $logger.info Maze::LogUtil.linkify(link, "BitBar session: #{id}") if link
+          $logger.info Maze::LogUtil.linkify link, 'BitBar session(s)'
         end
 
         def stop_session

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -27,6 +27,18 @@ module Maze
           Maze.driver.start_driver
         end
 
+        def log_run_outro
+          api_client = BitBarApiClient.new(Maze.config.access_key)
+
+          $logger.info 'Appium session(s) created:'
+          @session_ids.each do |id|
+            link = api_client.get_device_session_ui_link(id)
+            pp id
+            pp link
+            $logger.info Maze::LogUtil.linkify(link, "BitBar session: #{id}") if link
+          end
+        end
+
         def stop_session
           super
           Maze::Client::BitBarClientUtils.stop_local_tunnel

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -33,7 +33,7 @@ module Maze
           $logger.info 'Selenium session created:'
           id = Maze.driver.session_id
           link = api_client.get_device_session_ui_link(id)
-          $logger.info Maze::LogUtil.linkify link, 'BitBar session(s)'
+          $logger.info Maze::LogUtil.linkify link, 'BitBar session(s)' if link
         end
 
         def stop_session

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -31,12 +31,11 @@ module Maze
           api_client = BitBarApiClient.new(Maze.config.access_key)
 
           $logger.info 'Appium session(s) created:'
-          @session_ids.each do |id|
-            link = api_client.get_device_session_ui_link(id)
-            pp id
-            pp link
-            $logger.info Maze::LogUtil.linkify(link, "BitBar session: #{id}") if link
-          end
+          id = Maze.driver.session_id
+          link = api_client.get_device_session_ui_link(id)
+          pp id
+          pp link
+          $logger.info Maze::LogUtil.linkify(link, "BitBar session: #{id}") if link
         end
 
         def stop_session

--- a/lib/maze/client/selenium/bs_client.rb
+++ b/lib/maze/client/selenium/bs_client.rb
@@ -83,6 +83,10 @@ module Maze
           url = "https://automate.browserstack.com/dashboard/v2/search?query=#{Maze.run_uuid}&type=builds"
           $logger.info Maze::LogUtil.linkify url, 'BrowserStack session(s)'
         end
+
+        def log_run_outro
+          log_session_info
+        end
       end
     end
   end

--- a/lib/maze/client/selenium/bs_client.rb
+++ b/lib/maze/client/selenium/bs_client.rb
@@ -59,6 +59,10 @@ module Maze
           Maze::Client::BrowserStackClientUtils.stop_local_tunnel
         end
 
+        def log_run_outro
+          log_session_info
+        end
+
         private
 
         # Determines and returns sensible project and build capabilities
@@ -82,10 +86,6 @@ module Maze
           # Log a link to the BrowserStack session search dashboard
           url = "https://automate.browserstack.com/dashboard/v2/search?query=#{Maze.run_uuid}&type=builds"
           $logger.info Maze::LogUtil.linkify url, 'BrowserStack session(s)'
-        end
-
-        def log_run_outro
-          log_session_info
         end
       end
     end

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -92,6 +92,13 @@ module Maze
         end
       end
 
+      # Returns the driver session ID
+      #
+      # @returns [String] The session ID of the selenium session
+      def session_id
+        @driver.session_id
+      end
+
       private
 
       # Creates and starts the selenium driver

--- a/lib/maze/hooks/browser_hooks.rb
+++ b/lib/maze/hooks/browser_hooks.rb
@@ -7,8 +7,12 @@ module Maze
         @client = Maze::Client::Selenium.start
       end
 
+      def after_all
+        @client&.log_run_outro
+      end
+
       def at_exit
-        @client.stop_session
+        @client&.stop_session
       end
     end
   end


### PR DESCRIPTION
## Goal

Adds links after BitBar and BrowserStack selenium test runs for easy access to the sessions.

Note - I realise this means on a successful BrowserStack run the links will appear close to one another, but on an unsuccessful run being able to access the session from both the top and bottom of the test run could prove useful.


## Tests

Verified the links are present and work manually.
