### PR TITLE
Use URI.open directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Fixes
 
 - Improve logging when calculating BitBar dashboard project and test run [501](https://github.com/bugsnag/maze-runner/pull/502)
+- Use `URI.open` directly instead of `Kernel.open` [506](https://github.com/bugsnag/maze-runner/pull/506)
 
 # 7.23.0 - 2023/03/20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## Fixes
 
 - Improve logging when calculating BitBar dashboard project and test run [501](https://github.com/bugsnag/maze-runner/pull/502)
-- Use `URI.open` directly instead of `Kernel.open` [506](https://github.com/bugsnag/maze-runner/pull/506)
+- Use `URI.open` directly instead of `Kernel.open` [508](https://github.com/bugsnag/maze-runner/pull/508)
 
 # 7.23.0 - 2023/03/20
 

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -103,7 +103,7 @@ end
 # @step_input url [String] The URL to open.
 When('I open the URL {string}') do |url|
   begin
-    open(url, &:read)
+    URI.open(url, &:read)
   rescue OpenURI::HTTPError
     $logger.debug $!.inspect
   end


### PR DESCRIPTION
## Goal

Fix an error in the `I open the URL {string}` step when running with Ruby 3.  Corresponds to the following warning in Ruby 2:
```
warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```

## Tests

Reran the test in `bugsnag-java` that uncovered it.