### PR TITLE
Add trace step to confirm parent-child span relationships

### DIFF
--- a/lib/features/steps/trace_steps.rb
+++ b/lib/features/steps/trace_steps.rb
@@ -186,6 +186,22 @@ Then('a span named {string} contains the attributes:') do |span_name, table|
   end
 end
 
+Then('a span named {string} has a parent named {string}') do |child_name, parent_name|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  child_spans = spans.find_all { |span| span['name'].eql?(child_name) }
+  raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{child_name}" if child_spans.empty?
+  parent_spans = spans.find_all { |span| span['name'].eql?(parent_name) }
+  raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{parent_name}" if parent_spans.empty?
+
+  expectedParentIds = child_spans.map { |span| span['parentSpanId'] }
+  parentIds = parent_spans.map { |span| span['spanId'] }
+  match = expectedParentIds.any? { |expected_id| parentIds.include?(expected_id) }
+
+  unless match
+    raise Test::Unit::AssertionFailedError.new "No child span named #{child_name} was found with a parent named #{parent_name}"
+  end
+end
+
 def spans_from_request_list list
   return list.remaining
              .flat_map { |req| req[:body]['resourceSpans'] }

--- a/test/fixtures/payload-helpers/features/support/send_request.rb
+++ b/test/fixtures/payload-helpers/features/support/send_request.rb
@@ -156,7 +156,8 @@ def send_request(request_type, mock_api_port = 9339)
                     "name":"ManualSpanScenario"
                   },
                   {
-                    "spanId":"96775346bf426548",
+                    "spanId":"96775346a21aa300",
+                    "parentSpanId":"96775346bf426548",
                     "startTimeUnixNano":"1677082367269565184",
                     "traceId":"4dea8da13b30db98f1c56bee0fdc734c",
                     "endTimeUnixNano":"1677082367269576192",

--- a/test/fixtures/payload-helpers/features/traces_support.feature
+++ b/test/fixtures/payload-helpers/features/traces_support.feature
@@ -87,6 +87,7 @@ Feature: Testing support on traces endpoint
     Scenario: Spans can be validated across requests
         When I send a "trace"-type request
         And I send a "browser-trace"-type request
+        And I wait to receive 2 traces
         Then a span named "TestSpan" contains the attributes:
             | attribute               | type        | value       |
             | test.bool_value         | boolValue   | true        |
@@ -98,3 +99,8 @@ Feature: Testing support on traces endpoint
             | attribute               | type        | value       |
             | test.next_payload_value | stringValue | another!    |
         And a span field "kind" equals 1
+
+    Scenario: Parent-child spans can be matched together
+        When I send a "trace"-type request
+        And I wait to receive a trace
+        Then a span named "TestSpan" has a parent named "ManualSpanScenario"


### PR DESCRIPTION
## Goal

Adds a step to assert a parent-child relationship between a pair of named spans.

## Tests

Negative testing was performed manually, and positive tests were added to the e2e tests
