### PR TITLE
Improve handling when failing to get BitBar credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Fix crash when trying to retry browser tests [515](https://github.com/bugsnag/maze-runner/pull/515)
+- Fix crash when BitBar credentials cannot be fetched [513](https://github.com/bugsnag/maze-runner/pull/513)
 
 # 7.26.0 - 2023/04/12
 

--- a/lib/maze/client/bb_client_utils.rb
+++ b/lib/maze/client/bb_client_utils.rb
@@ -70,7 +70,7 @@ module Maze
         def account_credentials(tms_uri)
           interval_seconds = 10
 
-          Maze::Wait.new(interval: interval_seconds, timeout: 1800).until do
+          credentials = Maze::Wait.new(interval: interval_seconds, timeout: 1800).until do
             output = request_account_index(tms_uri)
             case output.code
             when '200'
@@ -91,6 +91,10 @@ module Maze
               raise
             end
           end
+
+          return credentials if credentials
+
+          raise "Could not fetch BitBar credentials in time"
         end
 
         # Makes the HTTP call to acquire an account id

--- a/lib/maze/client/bb_client_utils.rb
+++ b/lib/maze/client/bb_client_utils.rb
@@ -68,7 +68,9 @@ module Maze
         #
         # @returns
         def account_credentials(tms_uri)
-          Maze::Wait.new(interval: 10, timeout: 1800).until do
+          interval_seconds = 10
+
+          Maze::Wait.new(interval: interval_seconds, timeout: 1800).until do
             output = request_account_index(tms_uri)
             case output.code
             when '200'
@@ -81,7 +83,7 @@ module Maze
               }
             when '409'
               # All accounts are in use, wait for one to become available
-              $logger.info 'All accounts are currently in use, retrying in 30s'
+              $logger.info("All accounts are currently in use, retrying in #{interval_seconds}s")
               false
             else
               # Something has gone wrong, throw an error


### PR DESCRIPTION
## Goal

Currently nothing checks if we successfully get BitBar credentials, so if the 30 minute timeout fails then we crash as `account_credentials` returns `false` and the code tries to use that as the credentials:

<img width="667" alt="image" src="https://user-images.githubusercontent.com/282732/231393438-3f73a6fe-58ad-406f-b2ff-ca041e822d85.png">

This PR changes this to raise an error explaining that fetching the credentials failed

I've also fixed the retry interval saying it's 30 seconds when it's actually 10 seconds