### PR TITLE
Fix crash when trying to retry browser tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Fixes
+
+- Fix crash when trying to retry browser tests [515](https://github.com/bugsnag/maze-runner/pull/515)
+
 # 7.26.0 - 2023/04/12
 
 ## Enhancements

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -27,7 +27,7 @@ module Maze
 
       # Refreshes the page
       def refresh
-        @driver.refresh
+        @driver.navigate.refresh
       end
 
       # Quits the driver


### PR DESCRIPTION
## Goal

Fixes a crash when trying to retry browser tests:
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/282732/232450207-17a9a150-fae7-4cbe-861c-2473ba765c2f.png">

`refresh` doesn't exist on the Selenium WebDriver, it's on the `navigate` object: https://www.selenium.dev/documentation/webdriver/interactions/navigation/#refresh