### PR TITLE
Improve JSON schema validation failure messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,13 @@
 ## Enhancements
 
 - Allow BitBar Selenium server URL to be configured [524](https://github.com/bugsnag/maze-runner/pull/524)
+- Improve JSON schema validation failure messages [516](https://github.com/bugsnag/maze-runner/pull/516)
 
 ## Removals
 
 - Remove absolute browser versions no longer supported by BitBar [523](https://github.com/bugsnag/maze-runner/pull/523)
   
 # 7.26.1 - 2023/04/20
-
-## Enhancements
-
-- Improve JSON schema validation failure messages [516](https://github.com/bugsnag/maze-runner/pull/516)
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # TBD
 
+## Enhancements
+
+- Improve JSON schema validation failure messages [516](https://github.com/bugsnag/maze-runner/pull/516)
+
 ## Fixes
 
 - Fix crash when trying to retry browser tests [515](https://github.com/bugsnag/maze-runner/pull/515)

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -44,9 +44,9 @@ def verify_schema_matches(list, list_name)
     if schema_errors.size > 0
       passed = false
       $stdout.puts "\n"
-      $stdout.puts "\e[31m--- #{list_name} #{index} failed validation with errors at the following locations:\e[0m"
+      $stdout.puts "\e[31m--- #{list_name} #{index} failed validation:\e[0m"
       schema_errors.each do |error|
-        $stdout.puts "\e[31m#{error["data_pointer"]} failed to match #{error["schema_pointer"]}\e[0m"
+        $stdout.puts "\e[31m#{JSONSchemer::Errors.pretty(error)}\e[0m"
       end
       $stdout.puts "\n"
     end


### PR DESCRIPTION
## Goal

Use `JSONSchemer::Errors.pretty` to output a nicer JSON schema validation failure message:

- https://www.rubydoc.info/gems/json_schemer/0.2.24/JSONSchemer/Errors
- https://github.com/davishmcclurg/json_schemer/blob/master/lib/json_schemer/errors.rb