### PR TITLE
Allow JS to access the sampling header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix crash when trying to retry browser tests [515](https://github.com/bugsnag/maze-runner/pull/515)
 - Fix crash when BitBar credentials cannot be fetched [513](https://github.com/bugsnag/maze-runner/pull/513)
+- Allow JS to access the sampling header [517](https://github.com/bugsnag/maze-runner/pull/517)
 
 # 7.26.0 - 2023/04/12
 

--- a/lib/maze/servlets/trace_servlet.rb
+++ b/lib/maze/servlets/trace_servlet.rb
@@ -5,8 +5,11 @@ module Maze
     class TraceServlet < Servlet
       def set_response_header(header)
         super
+
         value = Maze::Server.sampling_probability
-        header['Bugsnag-Sampling-Probability'] =  value unless value == 'null'
+        header['Bugsnag-Sampling-Probability'] = value unless value == 'null'
+
+        header['Access-Control-Expose-Headers'] = 'Bugsnag-Sampling-Probability'
       end
     end
   end


### PR DESCRIPTION
## Goal

Cross-origin JavaScript requests are only allowed to read a set of "cors safe" headers by default. To allow scripts to read other headers, the server needs to set [`Access-Control-Expose-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) and explicitly list any additional allowed headers

This PR adds `Bugsnag-Sampling-Probability` as an allowed header in the trace servlet

See https://github.com/bugsnag/bugsnag-js-performance/pull/96