### PR TITLE
Fail upload-app with non-zero exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix crash when trying to retry browser tests [515](https://github.com/bugsnag/maze-runner/pull/515)
 - Fix crash when BitBar credentials cannot be fetched [513](https://github.com/bugsnag/maze-runner/pull/513)
 - Allow JS to access the sampling header [517](https://github.com/bugsnag/maze-runner/pull/517)
+- Fail upload-app with non-zero exit code if access key not given [518](https://github.com/bugsnag/maze-runner/pull/518)
 
 # 7.26.0 - 2023/04/12
 

--- a/bin/upload-app
+++ b/bin/upload-app
@@ -59,9 +59,8 @@ class UploadAppEntry
     end
 
     if options[:access_key].nil?
-      $logger.warn 'An access_key is required to upload the app'
       Optimist::with_standard_exception_handling parser do
-        raise Optimist::HelpNeeded
+        raise Optimist::CommandlineError.new('An access_key is required to upload the app', 1)
       end
     end
 

--- a/bin/upload-app
+++ b/bin/upload-app
@@ -60,7 +60,7 @@ class UploadAppEntry
 
     if options[:access_key].nil?
       Optimist::with_standard_exception_handling parser do
-        raise Optimist::CommandlineError.new('An access_key is required to upload the app', 1)
+        parser.die('An access_key is required to upload the app', 1)
       end
     end
 


### PR DESCRIPTION
## Goal

Fail upload-app with non-zero exit code if the BitBar access key is not provided.

## Design

When first using this in a pipeline it took me a while to realise that the previous Buildkite step had errored, but passed in Buildkite due to the exit code of 0.

## Tests

Tested locally.