### PR TITLE
Read app option from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix crash when BitBar credentials cannot be fetched [513](https://github.com/bugsnag/maze-runner/pull/513)
 - Allow JS to access the sampling header [517](https://github.com/bugsnag/maze-runner/pull/517)
 - Fail upload-app with non-zero exit code if access key not given [518](https://github.com/bugsnag/maze-runner/pull/518)
+- Ensure ids for apps uploaded to BitBar can be read from file [519](https://github.com/bugsnag/maze-runner/pull/519)
 
 # 7.26.0 - 2023/04/12
 

--- a/lib/maze/helper.rb
+++ b/lib/maze/helper.rb
@@ -83,7 +83,7 @@ module Maze
         return argument unless argument.start_with? '@'
 
         file = argument[1..argument.size]
-        File.read file
+        (File.read file).strip
       end
 
       # Returns the current platform all lower-case.

--- a/lib/maze/option/validator.rb
+++ b/lib/maze/option/validator.rb
@@ -108,7 +108,7 @@ module Maze
             errors << "Browser type '#{browser}' unknown on BitBar.  Must be one of: #{browser_list}."
           end
         elsif device
-          app = options[Option::APP]
+          app = Maze::Helper.read_at_arg_file options[Option::APP]
           if app.nil?
             errors << "--#{Option::APP} must be provided when running on a device"
           else


### PR DESCRIPTION
## Goal

Allow the id for an app previously uploaded to BitBar to be read from a file.

## Design

This mechanism has been in place for BrowserStack for some time.  If the `--app` options starts with an `@` then Maze Runner will read the contents of the file.  The change had just not been applied on the BitBar side.

## Tests

Tested locally.