### PR TITLE
Fix crash in local selenium client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow JS to access the sampling header [517](https://github.com/bugsnag/maze-runner/pull/517)
 - Fail upload-app with non-zero exit code if access key not given [518](https://github.com/bugsnag/maze-runner/pull/518)
 - Ensure ids for apps uploaded to BitBar can be read from file [519](https://github.com/bugsnag/maze-runner/pull/519)
+- Fix crash in Selenium `LocalClient` caused by unimplemented method [521](https://github.com/bugsnag/maze-runner/pull/521)
 
 # 7.26.0 - 2023/04/12
 

--- a/lib/maze/client/selenium/local_client.rb
+++ b/lib/maze/client/selenium/local_client.rb
@@ -7,6 +7,10 @@ module Maze
           Maze.driver.start_driver
         end
 
+        def log_run_outro
+          # Nothing to do
+        end
+
         def stop_session
           # No need to quit the local driver
         end


### PR DESCRIPTION
## Goal

Fixes a recently introduced crash in local selenium client.

## Tests

This crash was readily reproducible by running `bundle exec maze-runner --farm=local --browser=firefox` in `test/fixtures/browser` - fixed after the change.