### PR TITLE
Provide access to document server via AWS public IP addresses

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -288,8 +288,8 @@ steps:
       artifacts#v1.9.0:
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
-        pull: browser-tests
-        run: browser-tests
+        pull: browser-tests-bitbar
+        run: browser-tests-bitbar
         service-ports: true
         use-aliases: true
         verbose: true
@@ -298,6 +298,7 @@ steps:
           - "--browser=firefox_latest"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--no-tunnel"
     env:
       RUBY_VERSION: "2.7"
     concurrency: 5

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -281,7 +281,7 @@ steps:
   # BitBar tests
   #
 
-  - label: 'BitBar web browser test - Firefox latest'
+  - label: 'BitBar web browser test - Safari 16'
     depends_on: "push-branch-cli"
     timeout_in_minutes: 10
     plugins:
@@ -295,7 +295,7 @@ steps:
         verbose: true
         command:
           - "--farm=bb"
-          - "--browser=firefox_latest"
+          - "--browser=safari_16"
           - "--aws-public-ip"
           - "--fail-fast"
           - "--no-tunnel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,7 @@ GEM
     yard (0.9.34)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -306,6 +306,28 @@ services:
     env_file:
       - ${DOCKER_ENV_FILE:-test/browser/features/fixtures/null_env}
 
+  browser-tests-bitbar:
+    build:
+      context: test/fixtures/browser
+      dockerfile: Dockerfile.w3c
+      args:
+        BRANCH_NAME:
+        RUBY_VERSION:
+    environment:
+      BITBAR_USERNAME:
+      BITBAR_ACCESS_KEY:
+      BUILDKITE:
+      BUILDKITE_BUILD_NUMBER:
+      BUILDKITE_LABEL:
+      BUILDKITE_PIPELINE_SLUG:
+      BUILDKITE_RETRY_COUNT:
+    env_file:
+      - ${DOCKER_ENV_FILE:-test/browser/features/fixtures/null_env}
+    ports:
+      - "9000-9499:9339"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
 networks:
   default:
     name: ${BUILDKITE_JOB_ID:-core-maze-runner}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -325,6 +325,7 @@ services:
       - ${DOCKER_ENV_FILE:-test/browser/features/fixtures/null_env}
     ports:
       - "9000-9499:9339"
+      - "9000-9499:9340"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -46,8 +46,14 @@ BeforeAll do
 
   # Determine public IP if enabled
   if Maze.config.aws_public_ip
-    Maze.public_address = Maze::AwsPublicIp.new.address
+    public_ip = Maze::AwsPublicIp.new
+    Maze.public_address = public_ip.address
     $logger.info "Public address: #{Maze.public_address}"
+
+    unless Maze.config.document_server_root.nil?
+      Maze.public_document_server_address = public_ip.document_server_address
+      $logger.info "Public document server address: #{Maze.public_document_server_address}"
+    end
   end
 
   # Start mock server

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -44,18 +44,6 @@ BeforeAll do
   Maze.run_uuid = SecureRandom.uuid
   $logger.info "UUID for this run: #{Maze.run_uuid}"
 
-  # Determine public IP if enabled
-  if Maze.config.aws_public_ip
-    public_ip = Maze::AwsPublicIp.new
-    Maze.public_address = public_ip.address
-    $logger.info "Public address: #{Maze.public_address}"
-
-    unless Maze.config.document_server_root.nil?
-      Maze.public_document_server_address = public_ip.document_server_address
-      $logger.info "Public document server address: #{Maze.public_document_server_address}"
-    end
-  end
-
   # Start mock server
   Maze::Server.start
   Maze::Server.set_response_delay_generator(Maze::Generator.new [Maze::Server::DEFAULT_RESPONSE_DELAY].cycle)
@@ -71,6 +59,18 @@ BeforeAll do
   # Start document server, if asked for
   # This must happen after any client hooks have run, so that they can set the server root
   Maze::DocumentServer.start unless Maze.config.document_server_root.nil?
+
+  # Determine public IP if enabled
+  if Maze.config.aws_public_ip
+    public_ip = Maze::AwsPublicIp.new
+    Maze.public_address = public_ip.address
+    $logger.info "Public address: #{Maze.public_address}"
+
+    unless Maze.config.document_server_root.nil?
+      Maze.public_document_server_address = public_ip.document_server_address
+      $logger.info "Public document server address: #{Maze.public_document_server_address}"
+    end
+  end
 
   # An initial setup for total success status
   $success = true

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -10,7 +10,8 @@ module Maze
   VERSION = '7.27.0'
 
   class << self
-    attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address, :run_uuid
+    attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,
+                  :public_document_server_address, :run_uuid
 
     def config
       @config ||= Maze::Configuration.new

--- a/lib/maze/aws_public_ip.rb
+++ b/lib/maze/aws_public_ip.rb
@@ -21,7 +21,6 @@ module Maze
 
       @ip = determine_public_ip
       @port = determine_public_port Maze.config.port
-      @address = "#{ip}:#{port}"
 
       unless Maze.config.document_server_root.nil?
         @document_server_port = determine_public_port Maze.config.document_server_port

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -4,7 +4,7 @@ module Maze
       class BitBarClient < BaseClient
         def start_session
           config = Maze.config
-          if ENV['BUILDKITE']
+          if ENV['BUILDKITE'] && !Maze.config.aws_public_ip
             credentials = Maze::Client::BitBarClientUtils.account_credentials config.tms_uri
             config.username = credentials[:username]
             config.access_key = credentials[:access_key]
@@ -36,8 +36,10 @@ module Maze
 
         def stop_session
           super
-          Maze::Client::BitBarClientUtils.stop_local_tunnel
-          Maze::Client::BitBarClientUtils.release_account(Maze.config.tms_uri) if ENV['BUILDKITE']
+          unless Maze.config.aws_public_ip
+            Maze::Client::BitBarClientUtils.stop_local_tunnel
+            Maze::Client::BitBarClientUtils.release_account(Maze.config.tms_uri) if ENV['BUILDKITE']
+          end
         end
       end
     end

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -16,9 +16,11 @@ module Maze
           capabilities.merge! JSON.parse(config.capabilities_option)
           config.capabilities = capabilities
 
-          Maze::Client::BitBarClientUtils.start_local_tunnel config.sb_local,
-                                                             config.username,
-                                                             config.access_key
+          unless Maze.config.aws_public_ip
+            Maze::Client::BitBarClientUtils.start_local_tunnel config.sb_local,
+                                                               config.username,
+                                                               config.access_key
+          end
 
           selenium_url = Maze.config.selenium_server_url
           Maze.driver = Maze::Driver::Browser.new :remote, selenium_url, config.capabilities

--- a/test/fixtures/browser/features/fixtures/test.html
+++ b/test/fixtures/browser/features/fixtures/test.html
@@ -2,12 +2,17 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <title>Test Fixture</title>
   </head>
   <body>
     <h1>Hello World</h1>
     <script type="text/javascript">
-      console.log("Hello");
-      fetch("http://bs-local.com:9339/notify", {
+      const parameters = new URLSearchParams(window.location.search)
+      const mazeAddress = parameters.get('maze_address')
+
+      console.log("Maze Runner address is " + mazeAddress);
+      url =
+      fetch(mazeAddress + "/notify", {
         method: 'POST', // *GET, POST, PUT, DELETE, etc.
         headers: {
           'Content-Type': 'application/json'

--- a/test/fixtures/browser/features/steps/browser_steps.rb
+++ b/test/fixtures/browser/features/steps/browser_steps.rb
@@ -1,6 +1,35 @@
+def get_document_server_url
+  if Maze.config.aws_public_ip
+    "http://#{Maze.public_document_server_address}"
+  else
+    "http://#{get_private_hostname}:#{Maze.config.document_server_port}"
+  end
+end
+
+def get_maze_runner_url
+  if Maze.config.aws_public_ip
+      "http://#{Maze.public_address}"
+  else
+    "http://#{get_private_hostname}:#{Maze.config.port}"
+  end
+end
+
+def get_private_hostname
+  case Maze.config.farm
+  when :local
+    'localhost'
+  when :bs
+    'bs-local.com'
+  else # :bb
+    'local'
+  end
+end
+
 When('I navigate to the test URL {string}') do |test_path|
-  path = get_test_url test_path
-  step("I navigate to the URL \"#{path}\"")
+  maze_address = get_maze_runner_url
+  doc_server = get_document_server_url
+  url = "#{doc_server}/#{test_path}?maze_address=#{CGI.escape(maze_address)}"
+  step("I navigate to the URL \"#{url}\"")
 end
 
 When('the exception matches the {string} values for the current browser') do |fixture|

--- a/test/fixtures/browser/features/support/env.rb
+++ b/test/fixtures/browser/features/support/env.rb
@@ -1,8 +1,12 @@
 require 'yaml'
 
-def get_test_url path
-  host = 'bs-local.com'
-  "http://#{host}:#{FIXTURES_SERVER_PORT}#{path}"
+def get_test_url(path)
+  if Maze.config.aws_public_ip
+    "http://#{Maze.public_address}#{path}"
+  else
+    "http://bs-local.com:#{FIXTURES_SERVER_PORT}#{path}"
+  end
+
 end
 
 BeforeAll do

--- a/test/fixtures/browser/features/support/env.rb
+++ b/test/fixtures/browser/features/support/env.rb
@@ -1,25 +1,9 @@
 require 'yaml'
 
-def get_test_url(path)
-  if Maze.config.aws_public_ip
-    "http://#{Maze.public_address}#{path}"
-  else
-    "http://bs-local.com:#{FIXTURES_SERVER_PORT}#{path}"
-  end
-
-end
-
-BeforeAll do
+Maze.hooks.before_all do
   Maze.config.receive_no_requests_wait = 15
   Maze.config.enforce_bugsnag_integrity = false
-
-  FIXTURES_SERVER_PORT = '9020'
-  DEV_NULL = Gem.win_platform? ? 'NUL' : '/dev/null'
-    pid = Process.spawn({"PORT"=>FIXTURES_SERVER_PORT},
-                        'ruby features/lib/server.rb',
-                        :out => DEV_NULL,
-                        :err => DEV_NULL)
-  Process.detach(pid)
+  Maze.config.document_server_root = 'features/fixtures'
 end
 
 at_exit do


### PR DESCRIPTION
## Goal

Allow (primarily browser-based) clients access to the document server through AWS EC2 public IP addresses.

## Design

Follows the same pattern used for access to the mock server through public IPs.  The document server just wasn't considered when it was introduced.

## Changeset

In addition to new plumbing, I've updated the CI step for browser tests to use the new functionality.  I've had to put it onto Safari as only those browsers are allowed by our firewall at present. 

## Tests

Covered by CI updaes.