### PR TITLE
Only use separate BitBar accounts on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -190,7 +190,7 @@ steps:
   # BrowserStack tests
   #
 
-  - label: 'BrowserStack app-automate - Android 7 - JWP'
+  - label: 'BrowserStack app-automate - Android 8.1 - JWP'
     timeout_in_minutes: 20
     depends_on:
       - "appium-test-fixture"
@@ -204,7 +204,7 @@ steps:
         command:
           - "--app=build/outputs/apk/release/app-release.apk"
           - "--farm=bs"
-          - "--device=ANDROID_7_1"
+          - "--device=ANDROID_8_1"
           - "--fail-fast"
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Enhancements
 
-- Update appium capabilities for appium 2.0 compatibility [526](https://github.com/bugsnag/maze-runner/pull/526)
+- Update appium capabilities for appium 2.0 compatibility [512](https://github.com/bugsnag/maze-runner/pull/512)
 
 ## Fix
 
-- Only use separate BitBar accounts on CI [512](https://github.com/bugsnag/maze-runner/pull/512)
+- Only use separate BitBar accounts on CI [526](https://github.com/bugsnag/maze-runner/pull/526)
 
 # 7.28.0 - 2023/05/02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Enhancements
 
-- Update appium capabilities for appium 2.0 compatibility [512](https://github.com/bugsnag/maze-runner/pull/512)
+- Update appium capabilities for appium 2.0 compatibility [526](https://github.com/bugsnag/maze-runner/pull/526)
+
+## Fix
+
+- Only use separate BitBar accounts on CI [512](https://github.com/bugsnag/maze-runner/pull/512)
 
 # 7.28.0 - 2023/05/02
 

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -12,9 +12,11 @@ module Maze
           config.capabilities = capabilities
 
           if Maze::Client::BitBarClientUtils.use_local_tunnel?
-            credentials = Maze::Client::BitBarClientUtils.account_credentials config.tms_uri
-            config.username = credentials[:username]
-            config.access_key = credentials[:access_key]
+            if ENV['BUILDKITE']
+              credentials = Maze::Client::BitBarClientUtils.account_credentials config.tms_uri
+              config.username = credentials[:username]
+              config.access_key = credentials[:access_key]
+            end
 
             Maze::Client::BitBarClientUtils.start_local_tunnel config.sb_local,
                                                                config.username,

--- a/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -17,7 +17,7 @@ import kotlin.concurrent.thread
 import org.json.JSONObject
 import org.json.JSONTokener
 
-const val CONFIG_FILE_TIMEOUT = 30000
+const val CONFIG_FILE_TIMEOUT = 10000
 
 class MainActivity : AppCompatActivity() {
 

--- a/test/fixtures/browser/features/steps/browser_steps.rb
+++ b/test/fixtures/browser/features/steps/browser_steps.rb
@@ -24,7 +24,7 @@ def get_private_hostname
     'bs-local.com'
   else # :bb
     # Get the IP address of the local machine - this is the only way I could
-    # find to make it with with Firefox, Chrome and Safari over the tunnel.
+    # find to make it work with Firefox, Chrome and Safari over the tunnel.
     addr_infos = Socket.ip_address_list.reject( &:ipv6? )
                                        .reject( &:ipv4_loopback? )
     address = addr_infos[0].ip_address

--- a/test/fixtures/browser/features/steps/browser_steps.rb
+++ b/test/fixtures/browser/features/steps/browser_steps.rb
@@ -1,3 +1,5 @@
+require 'socket'
+
 def get_document_server_url
   if Maze.config.aws_public_ip
     "http://#{Maze.public_document_server_address}"
@@ -21,14 +23,20 @@ def get_private_hostname
   when :bs
     'bs-local.com'
   else # :bb
-    'local'
+    # Get the IP address of the local machine - this is the only way I could
+    # find to make it with with Firefox, Chrome and Safari over the tunnel.
+    addr_infos = Socket.ip_address_list.reject( &:ipv6? )
+                                       .reject( &:ipv4_loopback? )
+    address = addr_infos[0].ip_address
+    $logger.info "Using IP address #{address} to reach Maze Runner"
+    address
   end
 end
 
 When('I navigate to the test URL {string}') do |test_path|
   maze_address = get_maze_runner_url
   doc_server = get_document_server_url
-  url = "#{doc_server}/#{test_path}?maze_address=#{CGI.escape(maze_address)}"
+  url = "#{doc_server}#{test_path}?maze_address=#{CGI.escape(maze_address)}"
   step("I navigate to the URL \"#{url}\"")
 end
 


### PR DESCRIPTION
## Goal

Fix an issue running browser tests on BitBar on local machines.

## Design

On CI, if the secure tunnel is used, we use multiple BitBar users as each user can only start a single secure tunnel.  Locally, there is no need to have separate users - local user accounts are sufficient.

This change was introduced in a recent PR, during a time that the secure tunnel was broken and so we couldn't test it locally.

## Changeset

I've made some changes to the browser test fixture so that the tests can be run on Chrome, Firefox or Safari on a local machine.

I've also bumped the version of Android in use for the legacy protocol (JsonWP) tests, as BrowserStack are increasingly short of Android 7 devices, causing unnecessary test failures.  We don't need to test on an old device to test the legacy protocol.

## Tests

Tested locally and CI covers that usage.