### PR TITLE
Allow multiple device groups to be listed

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -305,7 +305,7 @@ steps:
     concurrency_group: 'bitbar-web'
     concurrency_method: eager
 
-  - label: 'BitBar app-automate - Android 10'
+  - label: 'BitBar app-automate - Android'
     timeout_in_minutes: 20
     depends_on:
       - "appium-test-fixture"
@@ -321,7 +321,7 @@ steps:
         command:
           - "--app=build/outputs/apk/release/app-release.apk"
           - "--farm=bb"
-          - "--device=ANDROID_10"
+          - "--device=ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
           - "--fail-fast"
           - "--no-tunnel"
           - "--aws-public-ip"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 7.29.0 - 2023/05/09
+# 7.30.0 - TBD
 
 ## Enhancements
 
-- Allow a list of BitBar device groups to be selected from [529](https://github.com/bugsnag/maze-runner/pull/529)
+- Allow a list of BitBar device groups to be selected from [530](https://github.com/bugsnag/maze-runner/pull/530)
 
 # 7.29.0 - 2023/05/09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Enhancements
 
+- Allow a list of BitBar device groups to be selected from [529](https://github.com/bugsnag/maze-runner/pull/529)
+
+# 7.29.0 - 2023/05/09
+
+## Enhancements
+
 - Update appium capabilities for appium 2.0 compatibility [512](https://github.com/bugsnag/maze-runner/pull/512)
 - Add support for Edge latest on BrowserStack [528](https://github.com/bugsnag/maze-runner/pull/528)
 

--- a/docs/Device_Mode.md
+++ b/docs/Device_Mode.md
@@ -41,7 +41,7 @@ bundle exec maze-runner features/smoke_tests    \
                         --fail-fast
 ```
 
-In the case of BitBar, the `--device` option maps directly to the name of either a device, or a device group configured in the BitBar dashboard.
+For BitBar, the `--device` option maps directly to the name of either a device, or a device group configured in the BitBar dashboard.  Multiple device groups can also be listed, separated by a pipe.  Maze Runner will select an available device from them at random.  E.g. `--device=ANDROID_10|ANDROID_11`.
 
 ## Appium client modes
 

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -9,24 +9,25 @@ module Maze
       class BitBarDevices
         class << self
           # Uses the BitBar API to find an available device from the group name given, or a device of that name
-          # @param device_or_group_name [String] Name of the device, or device group for which to find an available device
+          # @param device_or_group_names [String] Name of the device, or device group(s) for which to find an available
+          # device.  Multiple device group names can be separated by a pipe.
           # @return Capabilities hash for the available device
-          def get_available_device(device_or_group_name)
+          def get_available_device(device_or_group_names)
             api_client = BitBarApiClient.new(Maze.config.access_key)
-            device_group_id = api_client.get_device_group_id(device_or_group_name)
-            if device_group_id
+            device_group_ids = api_client.get_device_group_ids(device_or_group_names)
+            if device_group_ids
               # Device group found - find a free device in it
-              $logger.debug "Got group id #{device_group_id} for #{device_or_group_name}"
-              group_count, device = api_client.find_device_in_group(device_group_id)
+              $logger.debug "Got group ids #{device_group_ids} for #{device_or_group_names}"
+              group_count, device = api_client.find_device_in_groups(device_group_ids)
               if device.nil?
                 # TODO: Retry rather than fail, see PLAT-7377
                 Maze::Helper.error_exit 'There are no devices available'
               else
-                $logger.info "#{group_count} device(s) currently available in group '#{device_or_group_name}'"
+                $logger.info "#{group_count} device(s) currently available in group(s) '#{device_or_group_names}'"
               end
             else
               # See if there is a device with the given name
-              device = api_client.find_device device_or_group_name
+              device = api_client.find_device device_or_group_names
             end
 
             device_name = device['displayName']


### PR DESCRIPTION
## Goal

Allow multiple device group name for BitBar, from which an available device will be selected at random.

E.g. `--device=ANDROID_11|ANDROID_12`.

## Design

This change was slightly more complicated than I anticipated, as I needed to refactor some methods a little to handle multiple API calls.

## Documentation

Docs updated.

## Tests

Covered by CI and I'm also performed some testing locally with both single and multiple device group names.