### PR TITLE
Review command line options for consistency

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -348,10 +348,10 @@ steps:
       - docker-compose#v4.7.0:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:${BUILDKITE_TAG}-cli
-            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli
+            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-cli
             - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:${BUILDKITE_TAG}-cli-legacy
-            - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli-legacy
+            - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli-legacy
             - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-cli-legacy
 
   - label: 'Push to RubyGems.org'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Command line options reviewed for consistency [xyz](https://github.com/bugsnag/maze-runner/pull/xyz)
+- Command line options reviewed for consistency [533](https://github.com/bugsnag/maze-runner/pull/533)
 
 
 <!---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 8.0.0 - TBD
+
+## Enhancements
+
+- Command line options reviewed for consistency [xyz](https://github.com/bugsnag/maze-runner/pull/xyz)
+
+
+<!---
+
+END OF v8 INTEGRATION
+
+--->
+
 # 7.30.1 - 2023/05/13
 
 ## Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Ensure that:
 If the release will create a new major version, also ensure that:
 1. The `Push Docker image for tag` step in `.buildkite/pipeline.yml`
    1. Will recognise the new tag in the `if` condition.
-   1. Pushes the built release image with the correct tag for the major release stream (e.g. `latest-v7-cli`)
+   1. Pushes the built release image with the correct tag for the major release stream (e.g. `latest-v8-cli`)
 
 #### Performing the release
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.30.1)
+    bugsnag-maze-runner (8.0.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,12 @@
 # Upgrading Guide
 
+## v7 to v8
+
+A couple of command line options have been renamed for consistency:
+
+`--enable-bugsnag` becomes `--bugsnag` (and `--no-bugsnag`)
+`--enable-retries` becomes `--retries` (and `--no-retries`)
+
 ## v6 to v7
 
 Support for Sauce Labs has been removed as we are no longer able to test it.

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.30.1'
+  VERSION = '8.0.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -58,7 +58,7 @@ module Maze
     AWS_PUBLIC_IP = 'aws-public-ip'
     ASPECTO_REPEATER_API_KEY = 'aspecto-repeater-api-key'
     BUGSNAG_REPEATER_API_KEY = 'repeater-api-key'
-    ENABLE_BUGSNAG = 'enable-bugsnag'
-    ENABLE_RETRIES = 'enable-retries'
+    ENABLE_BUGSNAG = 'bugsnag'
+    ENABLE_RETRIES = 'retries'
   end
 end

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -58,7 +58,7 @@ module Maze
     AWS_PUBLIC_IP = 'aws-public-ip'
     ASPECTO_REPEATER_API_KEY = 'aspecto-repeater-api-key'
     BUGSNAG_REPEATER_API_KEY = 'repeater-api-key'
-    ENABLE_BUGSNAG = 'bugsnag'
-    ENABLE_RETRIES = 'retries'
+    BUGSNAG = 'bugsnag'
+    RETRIES = 'retries'
   end
 end

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -31,12 +31,12 @@ module Maze
                 type: :boolean,
                 default: false
 
-            opt Option::ENABLE_RETRIES,
+            opt Option::RETRIES,
                 'Enables retrying failed scenarios when tagged',
                 type: :boolean,
                 default: true
 
-            opt Option::ENABLE_BUGSNAG,
+            opt Option::BUGSNAG,
                 'Enables reporting to Bugsnag on scenario failure (requires MAZE_BUGSNAG_API_KEY)',
                 type: :boolean,
                 default: true

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -29,24 +29,29 @@ module Maze
             opt Option::AWS_PUBLIC_IP,
                 'Intended for use on Buildkite with the Elastic CI Stack for CI.  Enables awareness of being run with a public IP address.',
                 type: :boolean,
+                short: :none,
                 default: false
 
             opt Option::RETRIES,
                 'Enables retrying failed scenarios when tagged',
                 type: :boolean,
+                short: :none,
                 default: true
 
             opt Option::BUGSNAG,
                 'Enables reporting to Bugsnag on scenario failure (requires MAZE_BUGSNAG_API_KEY)',
                 type: :boolean,
+                short: :none,
                 default: true
 
             opt Option::ASPECTO_REPEATER_API_KEY,
                 'Enables forwarding of all received POST requests to Aspecto, using the API key provided.  MAZE_ASPECTO_REPEATER_API_KEY may also be set.',
+                short: :none,
                 type: :string
 
             opt Option::BUGSNAG_REPEATER_API_KEY,
                 'Enables forwarding of all received POST requests to Bugsnag, using the API key provided.  MAZE_REPEATER_API_KEY may also be set.',
+                short: :none,
                 type: :string
 
             text ''
@@ -54,12 +59,15 @@ module Maze
 
             opt Option::BIND_ADDRESS,
                 'Mock server bind address',
+                short: :none,
                 type: :string
             opt Option::PORT,
                 'Mock server port',
+                short: :none,
                 default: 9339
             opt Option::NULL_PORT,
                 'Terminating connection port',
+                short: :none,
                 default: 9341
 
             text ''
@@ -67,12 +75,15 @@ module Maze
 
             opt Option::DS_ROOT,
                 'Document server root',
+                short: :none,
                 type: :string
             opt Option::DS_BIND_ADDRESS,
                 'Document server bind address',
+                short: :none,
                 type: :string
             opt Option::DS_PORT,
                 'Document server port',
+                short: :none,
                 default: 9340
 
             text ''
@@ -80,16 +91,20 @@ module Maze
 
             opt Option::FARM,
                 'Device farm to use: "bs" (BrowserStack) or "local"',
+                short: :none,
                 type: :string
             opt Option::APP,
                 'The app to be installed and run against.  Assumed to be contained in a file if prefixed with @.',
+                short: :none,
                 type: :string
             opt Option::A11Y_LOCATOR,
                 'Locate elements by accessibility id rather than id',
+                short: :none,
                 type: :boolean,
                 default: false
             opt Option::CAPABILITIES,
                 'Additional desired Appium capabilities as a JSON string',
+                short: :none,
                 default: '{}'
 
             text ''
@@ -106,49 +121,61 @@ module Maze
                 type: :string
             opt Option::USERNAME,
                 'Device farm username. Consumes env var from environment based on farm set',
+                short: :none,
                 type: :string
             opt Option::ACCESS_KEY,
                 'Device farm access key. Consumes env var from environment based on farm set',
+                short: :none,
                 type: :string
             opt Option::APPIUM_VERSION,
                 'The Appium version to use',
+                short: :none,
                 type: :string
             opt Option::LIST_DEVICES,
                 'Lists the devices available for the configured device farm, or all devices if none are specified',
+                short: :none,
                 default: false
             opt Option::APP_BUNDLE_ID,
                 'The bundle identifier of the test application',
+                short: :none,
                 type: :string
             opt Option::TUNNEL,
                 'Start the device farm secure tunnel',
+                short: :none,
                 default: true
             opt Option::APPIUM_SERVER,
                 "Appium server URL.  Defaults are: \n" +
                 "  --farm=local - MAZE_APPIUM_SERVER or http://localhost:4723/wd/hub\n" +
                 "  --farm=bb - MAZE_APPIUM_SERVER or https://us-west-mobile-hub.bitbar.com/wd/hub\n" +
                 'Not used for --farm=bs',
+                short: :none,
                 type: :string
             opt Option::SELENIUM_SERVER,
                 "Selenium server URL. Only used for --farm=bb, defaulting to MAZE_SELENIUM_SERVER or https://us-west-desktop-hub.bitbar.com/wd/hub",
+                short: :none,
                 type: :string
 
             # SmartBear-only options
             opt Option::SB_LOCAL,
                 '(SB only) Path to the SBSecureTunnel binary. MAZE_SB_LOCAL env var or "/SBSecureTunnel" by default',
+                short: :none,
                 type: :string
 
             # BrowserStack-only options
             opt Option::BS_LOCAL,
                 '(BS only) Path to the BrowserStackLocal binary. MAZE_BS_LOCAL env var or "/BrowserStackLocal" by default',
+                short: :none,
                 type: :string
 
             # TMS options
             opt Option::TMS_URI,
                 'URI of the test management server root.  MAZE_TMS_URI env var',
+                short: :none,
                 type: :string
 
             opt Option::TMS_TOKEN,
                 'Token used to access the test management server.  MAZE_TMS_TOKEN env var',
+                short: :none,
                 type: :string
 
             text ''
@@ -156,21 +183,27 @@ module Maze
 
             opt Option::OS,
                 'OS type to use ("ios", "android")',
+                short: :none,
                 type: :string
             opt Option::OS_VERSION,
                 'The intended OS version when running on a local device',
+                short: :none,
                 type: :string
             opt Option::START_APPIUM,
                 'Whether a local Appium server should be start.  Only used for --farm=local.',
+                short: :none,
                 default: true
             opt Option::APPIUM_LOGFILE,
                 'The file local appium server output is logged to, defaulting to "appium_server.log"',
+                short: :none,
                 default: 'appium_server.log'
             opt Option::APPLE_TEAM_ID,
                 'Apple Team Id, required for local iOS testing. MAZE_APPLE_TEAM_ID env var by default',
+                short: :none,
                 type: :string
             opt Option::UDID,
                 'Apple UDID, required for local iOS testing. MAZE_UDID env var by default',
+                short: :none,
                 type: :string
 
             text ''
@@ -178,16 +211,19 @@ module Maze
 
             opt Option::FILE_LOG,
                 "Writes lists of received requests to the maze_output folder for all scenarios",
+                short: :none,
                 type: :boolean,
                 default: true
 
             opt Option::LOG_REQUESTS,
                 "Log lists of received requests to the console in the event of scenario failure.  Defaults to true if the BUILDKITE environment variable is set",
+                short: :none,
                 type: :boolean,
                 default: false
 
             opt Option::ALWAYS_LOG,
                 "Always log all received requests at the end of a scenario, whether is passes or fails",
+                short: :none,
                 type: :boolean,
                 default: false
 

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -19,8 +19,8 @@ module Maze
 
           # General options
           config.aws_public_ip = options[Maze::Option::AWS_PUBLIC_IP]
-          config.enable_retries = options[Maze::Option::ENABLE_RETRIES]
-          config.enable_bugsnag = options[Maze::Option::ENABLE_BUGSNAG]
+          config.enable_retries = options[Maze::Option::RETRIES]
+          config.enable_bugsnag = options[Maze::Option::BUGSNAG]
           config.tms_uri = options[Maze::Option::TMS_URI]
           config.tms_token = options[Maze::Option::TMS_TOKEN]
           config.aspecto_repeater_api_key = options[Maze::Option::ASPECTO_REPEATER_API_KEY]

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -92,9 +92,37 @@ class ProcessorTest < Test::Unit::TestCase
 
     assert_true config.file_log
     assert_true config.start_tunnel
+    assert_true config.enable_bugsnag
+    assert_true config.enable_retries
     assert_false config.log_requests
     assert_false config.always_log
     assert_nil config.bugsnag_repeater_api_key
+  end
+
+  def test_overriden_defaults
+    args = %w[--no-bugsnag --no-retries --no-file-log --no-tunnel --log-requests --always-log --bind-address=1.2.3.4 \
+              --port=1234]
+    options = Maze::Option::Parser.parse args
+    config = Maze::Configuration.new
+    Maze::Option::Processor.populate config, options
+
+    assert_equal '1.2.3.4', config.bind_address
+    assert_equal 1234, config.port
+
+    assert_equal nil, config.document_server_root
+    assert_equal nil, config.document_server_bind_address
+    assert_equal 9340, config.document_server_port
+
+    assert_equal :id, config.locator
+    assert_nil config.capabilities
+
+    assert_false config.file_log
+    assert_false config.start_tunnel
+    assert_false config.enable_bugsnag
+    assert_false config.enable_retries
+
+    assert_true config.log_requests
+    assert_true config.always_log
   end
 
   def test_filename_options


### PR DESCRIPTION
## Goal

Name boolean CLI options consistently.

## Design

This is a breaking change (whilst we are already moving into v8).

I've just removed the `enable-` on a couple of command line options to be consistent with out Boolean options.  Although this might seem less clear when looking at options in isolation, I think it hangs together when considered the output from `--help` and also means less verbose use of the tool.

## Documentation

CLI help and upgrading guide updated.

## Changeset

Command line options and their symbolic names updated.

I've also set the `short:` options for all CLI options to `:none`, meaning that an abbreviated form of the CLI option will not be generated.  These can conflict with the underlying options for Cucumber in surprising ways (e.g. the `-e` Cucumber option suddenly meaning something completely different).

## Tests

New unit test added.