### PR TITLE
Update published Docker image to Ruby 3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,68 +28,35 @@ steps:
       artifacts#v1.5.0:
         upload: "test/fixtures/android-appium-test/app/build/outputs/apk/release/app-release.apk"
 
-  - label: ':docker: Build CI image for Ruby 2.7'
+  - label: ':docker: Build CI image'
     timeout_in_minutes: 30
-    key: "ci-image-ruby-2-7"
+    key: "ci-image"
     plugins:
       - docker-compose#v4.7.0:
           build:
-            - ci-ruby-2.7
+            - ci
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
           cache-from:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
       - docker-compose#v4.7.0:
           push:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
-    env:
-      RUBY_VERSION: "2.7"
+            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
-  - label: ':docker: Build CI image for Ruby 3'
+  - label: 'Unit tests'
     timeout_in_minutes: 30
-    key: "ci-image-ruby-3"
-    plugins:
-      - docker-compose#v4.7.0:
-          build:
-            - ci-ruby-3
-          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
-          cache-from:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
-      - docker-compose#v4.7.0:
-          push:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
-    env:
-      RUBY_VERSION: "3"
-
-  - label: 'Unit tests with Ruby 2.7'
-    timeout_in_minutes: 30
-    depends_on: 'ci-image-ruby-2-7'
+    depends_on: 'ci-image'
     plugins:
       docker-compose#v4.7.0:
         run: unit-test
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:
-          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
-    env:
-      RUBY_VERSION: "2.7"
-    command: 'bundle exec rake'
-
-  - label: 'Unit tests with Ruby 3'
-    timeout_in_minutes: 30
-    depends_on: 'ci-image-ruby-3'
-    plugins:
-      docker-compose#v4.7.0:
-        run: unit-test
-        image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
-        cache-from:
-          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
-    env:
-      RUBY_VERSION: "3"
+          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
     command: 'bundle exec rake'
 
   - label: ':docker: Push W3C Docker image for branch'
     key: push-branch-cli
     timeout_in_minutes: 30
-    depends_on: "ci-image-ruby-2-7"
+    depends_on: "ci-image"
     plugins:
       - docker-compose#v4.7.0:
           build: cli
@@ -103,7 +70,7 @@ steps:
   - label: ':docker: Push Legacy Docker image for branch'
     key: push-branch-cli-legacy
     timeout_in_minutes: 30
-    depends_on: "ci-image-ruby-2-7"
+    depends_on: "ci-image"
     plugins:
       - docker-compose#v4.7.0:
           build: cli-legacy
@@ -114,9 +81,9 @@ steps:
           push:
             - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli-legacy
 
-  - label: 'No-device tests with Ruby 2.7 - batch 1'
+  - label: 'No-device tests - batch 1'
     timeout_in_minutes: 30
-    depends_on: "ci-image-ruby-2-7"
+    depends_on: "ci-image"
     plugins:
       - docker-compose#v4.7.0:
           run: framework-tests
@@ -128,13 +95,11 @@ steps:
           run: cli-tests
       - docker-compose#v4.7.0:
           run: http-response-tests
-    env:
-      RUBY_VERSION: "2.7"
     command: 'bundle exec maze-runner -e features/fixtures'
 
-  - label: 'No-device tests with Ruby 2.7 - batch 2'
+  - label: 'No-device tests - batch 2'
     timeout_in_minutes: 30
-    depends_on: "ci-image-ruby-2-7"
+    depends_on: "ci-image"
     plugins:
       - docker-compose#v4.7.0:
           run: payload-helper-tests
@@ -144,46 +109,6 @@ steps:
           run: doc-server-tests
       - docker-compose#v4.7.0:
           run: exit-codes-tests
-      - artifacts#v1.9.0:
-          upload:
-            - test/fixtures/payload-helpers/maze_output/**/*
-            - test/fixtures/payload-helpers/maze_output/*
-    env:
-      RUBY_VERSION: "2.7"
-    command: 'bundle exec maze-runner -e features/fixtures'
-
-  - label: 'No-device tests with Ruby 3 - batch 1'
-    timeout_in_minutes: 30
-    depends_on: "ci-image-ruby-3"
-    plugins:
-      - docker-compose#v4.7.0:
-          run: framework-tests
-      - docker-compose#v4.7.0:
-          run: comparison-tests
-      - docker-compose#v4.7.0:
-          run: proxy-tests
-      - docker-compose#v4.7.0:
-          run: cli-tests
-      - docker-compose#v4.7.0:
-          run: http-response-tests
-    env:
-      RUBY_VERSION: "3"
-    command: 'bundle exec maze-runner -e features/fixtures'
-
-  - label: 'No-device tests with Ruby 3 - batch 2'
-    timeout_in_minutes: 30
-    depends_on: "ci-image-ruby-3"
-    plugins:
-      - docker-compose#v4.7.0:
-          run: payload-helper-tests
-      - docker-compose#v4.7.0:
-          run: docker-tests
-      - docker-compose#v4.7.0:
-          run: doc-server-tests
-      - docker-compose#v4.7.0:
-          run: exit-codes-tests
-    env:
-      RUBY_VERSION: "3"
     command: 'bundle exec maze-runner -e features/fixtures'
 
   #
@@ -211,8 +136,7 @@ steps:
           - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli-legacy
       artifacts#v1.9.0:
         upload: test/fixtures/android-appium-test/maze_output/**/*
-    env:
-      RUBY_VERSION: "2.7"
+    concurrency: 5
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -238,8 +162,6 @@ steps:
           - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
       artifacts#v1.9.0:
         upload: test/fixtures/android-appium-test/maze_output/**/*
-    env:
-      RUBY_VERSION: "3"
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -299,8 +221,6 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "--no-tunnel"
-    env:
-      RUBY_VERSION: "2.7"
     concurrency: 5
     concurrency_group: 'bitbar-web'
     concurrency_method: eager
@@ -326,8 +246,6 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
-    env:
-      RUBY_VERSION: "3"
     concurrency: 25
     concurrency_group: 'bitbar-app'
     concurrency_method: eager
@@ -348,10 +266,10 @@ steps:
       - docker-compose#v4.7.0:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:${BUILDKITE_TAG}-cli
-            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli
+            - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-cli
             - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:${BUILDKITE_TAG}-cli-legacy
-            - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli-legacy
+            - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli-legacy
             - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-cli-legacy
 
   - label: 'Push to RubyGems.org'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 8.0.0 - TBD
+
+## Enhancements
+
+- Upgrade Docker image to Ruby 3 [534](https://github.com/bugsnag/maze-runner/pull/534)
+
+
+<!---
+
+END OF v8 INTEGRATION
+
+--->
+
 # 7.30.1 - 2023/05/13
 
 ## Fixes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,24 +13,18 @@ services:
       dockerfile: dockerfiles/Dockerfile.ci
       context: .
       target: ci
-      args:
-        - RUBY_VERSION
 
   cli:
     build:
       dockerfile: dockerfiles/Dockerfile.ci
       context: .
       target: cli
-      args:
-        - RUBY_VERSION=2.7
 
   cli-legacy:
     build:
       dockerfile: dockerfiles/Dockerfile.ci
       context: .
       target: cli-legacy
-      args:
-        - RUBY_VERSION=2.7
 
   docs:
     build:
@@ -45,7 +39,6 @@ services:
       dockerfile: Dockerfile.w3c
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     extra_hosts:
       - "maze-local:127.0.0.1"
     environment:
@@ -79,7 +72,6 @@ services:
       dockerfile: Dockerfile.w3c
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     extra_hosts:
       - "maze-local:127.0.0.1"
     environment:
@@ -115,7 +107,6 @@ services:
       dockerfile: Dockerfile.legacy
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     extra_hosts:
       - "maze-local:127.0.0.1"
     environment:
@@ -149,7 +140,6 @@ services:
       context: test/fixtures/ios-app
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     extra_hosts:
       - "maze-local:127.0.0.1"
     environment:
@@ -176,7 +166,6 @@ services:
       context: test/fixtures/cli
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
 
@@ -185,7 +174,6 @@ services:
       context: test/fixtures/comparison
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
 
@@ -194,7 +182,6 @@ services:
       context: test/fixtures/doc-server
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
 
@@ -203,7 +190,6 @@ services:
       context: test/fixtures/exit-codes
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
 
@@ -212,7 +198,6 @@ services:
       context: test/fixtures/framework
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
 
@@ -221,7 +206,6 @@ services:
       context: test/fixtures/docker-app
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
       NETWORK_NAME: "${BUILDKITE_JOB_ID:-core-maze-runner}"
@@ -233,7 +217,6 @@ services:
       context: test/fixtures/proxy
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
 
@@ -242,7 +225,6 @@ services:
       context: test/fixtures/payload-helpers
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
     volumes:
@@ -253,7 +235,6 @@ services:
       context: test/fixtures/http-response
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
 
@@ -262,8 +243,6 @@ services:
       dockerfile: dockerfiles/Dockerfile.ci
       context: .
       target: unit-test
-      args:
-        RUBY_VERSION:
 
   browser-tests:
     build:
@@ -271,7 +250,6 @@ services:
       dockerfile: Dockerfile.w3c
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       BUILDKITE:
       BROWSER_STACK_USERNAME:
@@ -293,7 +271,6 @@ services:
       dockerfile: Dockerfile.legacy
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       BUILDKITE:
       BROWSER_STACK_USERNAME:
@@ -312,7 +289,6 @@ services:
       dockerfile: Dockerfile.w3c
       args:
         BRANCH_NAME:
-        RUBY_VERSION:
     environment:
       BITBAR_USERNAME:
       BITBAR_ACCESS_KEY:

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,6 +1,5 @@
-# Ruby image are based on Debian
-ARG RUBY_VERSION
-FROM ruby:${RUBY_VERSION}-bullseye as ci-base
+# Ruby images are based on Debian
+FROM ruby:3-bullseye as ci-base
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     apt-get install -y apt-utils wget unzip bash bundler \

--- a/test/fixtures/cli/Dockerfile
+++ b/test/fixtures/cli/Dockerfile
@@ -1,6 +1,5 @@
 ARG BRANCH_NAME
-ARG RUBY_VERSION
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 RUN sudo apt-get install -y nodejs

--- a/test/fixtures/comparison/Dockerfile
+++ b/test/fixtures/comparison/Dockerfile
@@ -1,6 +1,5 @@
 ARG BRANCH_NAME
-ARG RUBY_VERSION
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/doc-server/Dockerfile
+++ b/test/fixtures/doc-server/Dockerfile
@@ -1,6 +1,5 @@
 ARG BRANCH_NAME
-ARG RUBY_VERSION
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/docker-app/Dockerfile
+++ b/test/fixtures/docker-app/Dockerfile
@@ -1,6 +1,5 @@
 ARG BRANCH_NAME
-ARG RUBY_VERSION
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/exit-codes/Dockerfile
+++ b/test/fixtures/exit-codes/Dockerfile
@@ -1,6 +1,5 @@
 ARG BRANCH_NAME
-ARG RUBY_VERSION
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/framework/Dockerfile
+++ b/test/fixtures/framework/Dockerfile
@@ -1,5 +1,5 @@
 ARG BRANCH_NAME
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/framework/Dockerfile
+++ b/test/fixtures/framework/Dockerfile
@@ -1,6 +1,5 @@
 ARG BRANCH_NAME
-ARG RUBY_VERSION
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/http-response/Dockerfile
+++ b/test/fixtures/http-response/Dockerfile
@@ -1,6 +1,5 @@
 ARG BRANCH_NAME
-ARG RUBY_VERSION
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/ios-app/dockerfile
+++ b/test/fixtures/ios-app/dockerfile
@@ -1,6 +1,5 @@
 ARG BRANCH_NAME
-ARG RUBY_VERSION
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
 WORKDIR /app
 COPY features features

--- a/test/fixtures/payload-helpers/Dockerfile
+++ b/test/fixtures/payload-helpers/Dockerfile
@@ -1,6 +1,5 @@
 ARG BRANCH_NAME
-ARG RUBY_VERSION
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
 COPY . /app
 WORKDIR /app

--- a/test/fixtures/proxy/Dockerfile
+++ b/test/fixtures/proxy/Dockerfile
@@ -1,6 +1,5 @@
 ARG BRANCH_NAME
-ARG RUBY_VERSION
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
## Goal

Update the shipped Docker image to be based on Ruby 3, rather than 2.

## Design

The minimum Ruby version for development remains unchanged at 2, but shipping with 3 will allow clients to use the new language features in their test code.

We occasionally find ourselves wanting to run with Ruby 2, in environments where there is not a convenient Ruby 3 package available - but these instances are becoming less common by the day.  It doesn't warrant the extra complexity in the build pipeline and build time, so running with Ruby 2 will now be "best endeavours" support.

## Tests

Covered by CI.