### PR TITLE
Update published Docker image to Ruby 3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,13 +34,13 @@ steps:
     plugins:
       - docker-compose#v4.7.0:
           build:
-            - ci-ruby-2.7
+            - ci-ruby-2
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
           cache-from:
-            - ci-ruby-2.7:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
+            - ci-ruby-2:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2
       - docker-compose#v4.7.0:
           push:
-            - ci-ruby-2.7:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
+            - ci-ruby-2:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2
     env:
       RUBY_VERSION: "2.7"
 
@@ -65,12 +65,10 @@ steps:
     depends_on: 'ci-image-ruby-2-7'
     plugins:
       docker-compose#v4.7.0:
-        run: unit-test
+        run: unit-test-ruby-2
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:
-          - ci-ruby-2.7:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
-    env:
-      RUBY_VERSION: "2.7"
+          - ci-ruby-2:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2
     command: 'bundle exec rake'
 
   - label: 'Unit tests with Ruby 3'
@@ -78,12 +76,10 @@ steps:
     depends_on: 'ci-image-ruby-3'
     plugins:
       docker-compose#v4.7.0:
-        run: unit-test
+        run: unit-test-ruby-3
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:
           - ci-ruby-3:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
-    env:
-      RUBY_VERSION: "3"
     command: 'bundle exec rake'
 
   - label: ':docker: Push W3C CLI image for branch'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -126,6 +126,7 @@ steps:
           run: http-response-tests
     env:
       RUBY_VERSION: "2.7"
+      USE_LEGACY_DRIVER: "1"
     command: 'bundle exec maze-runner -e features/fixtures'
 
   - label: 'No-device tests with Ruby 2.7 - batch 2'
@@ -146,6 +147,7 @@ steps:
             - test/fixtures/payload-helpers/maze_output/*
     env:
       RUBY_VERSION: "2.7"
+      USE_LEGACY_DRIVER: "1"
     command: 'bundle exec maze-runner -e features/fixtures'
 
   - label: 'No-device tests with Ruby 3 - batch 1'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,10 +37,10 @@ steps:
             - ci-ruby-2.7
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
           cache-from:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
+            - ci-ruby-2.7:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
       - docker-compose#v4.7.0:
           push:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
+            - ci-ruby-2.7:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
     env:
       RUBY_VERSION: "2.7"
 
@@ -53,10 +53,10 @@ steps:
             - ci-ruby-3
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
           cache-from:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
+            - ci-ruby-3:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
       - docker-compose#v4.7.0:
           push:
-            - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
+            - ci-ruby-3:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
     env:
       RUBY_VERSION: "3"
 
@@ -68,7 +68,7 @@ steps:
         run: unit-test
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:
-          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
+          - ci-ruby-2.7:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2.7
     env:
       RUBY_VERSION: "2.7"
     command: 'bundle exec rake'
@@ -81,12 +81,12 @@ steps:
         run: unit-test
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:
-          - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
+          - ci-ruby-3:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-3
     env:
       RUBY_VERSION: "3"
     command: 'bundle exec rake'
 
-  - label: ':docker: Push W3C Docker image for branch'
+  - label: ':docker: Push W3C CLI image for branch'
     key: push-branch-cli
     timeout_in_minutes: 30
     depends_on: "ci-image-ruby-2-7"
@@ -100,7 +100,7 @@ steps:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
 
-  - label: ':docker: Push Legacy Docker image for branch'
+  - label: ':docker: Push Legacy CLI image for branch'
     key: push-branch-cli-legacy
     timeout_in_minutes: 30
     depends_on: "ci-image-ruby-2-7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Command line options reviewed for consistency [533](https://github.com/bugsnag/maze-runner/pull/533)
+- Upgrade Docker image to Ruby 3 [534](https://github.com/bugsnag/maze-runner/pull/534)
 
 
 <!---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,7 @@ services:
         RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
+      USE_LEGACY_DRIVER:
 
   comparison-tests:
     build:
@@ -190,6 +191,7 @@ services:
         RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
+      USE_LEGACY_DRIVER:
 
   doc-server-tests:
     build:
@@ -199,6 +201,7 @@ services:
         RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
+      USE_LEGACY_DRIVER:
 
   exit-codes-tests:
     build:
@@ -208,6 +211,7 @@ services:
         RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
+      USE_LEGACY_DRIVER:
 
   framework-tests:
     build:
@@ -217,6 +221,7 @@ services:
         RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
+      USE_LEGACY_DRIVER:
 
   docker-tests:
     build:
@@ -226,6 +231,7 @@ services:
         RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
+      USE_LEGACY_DRIVER:
       NETWORK_NAME: "${BUILDKITE_JOB_ID:-core-maze-runner}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -238,6 +244,7 @@ services:
         RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
+      USE_LEGACY_DRIVER:
 
   payload-helper-tests:
     build:
@@ -247,6 +254,7 @@ services:
         RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
+      USE_LEGACY_DRIVER:
     volumes:
       - ./test/fixtures/payload-helpers/maze_output:/app/maze_output
 
@@ -258,6 +266,7 @@ services:
         RUBY_VERSION:
     environment:
       MAZE_BUGSNAG_API_KEY:
+      USE_LEGACY_DRIVER:
 
   unit-test-ruby-2:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -261,13 +261,13 @@ services:
     build:
       dockerfile: dockerfiles/Dockerfile.ci-ruby-2
       context: .
-      target: unit-test
+      target: unit-test-ruby-2
 
   unit-test-ruby-3:
     build:
       dockerfile: dockerfiles/Dockerfile.ci-ruby-3
       context: .
-      target: unit-test
+      target: unit-test-ruby-3
 
   browser-tests:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       context: .
       target: ci-ruby-3
 
-  ci-ruby-2.7:
+  ci-ruby-2:
     build:
       dockerfile: dockerfiles/Dockerfile.ci-ruby-2
       context: .
@@ -257,13 +257,17 @@ services:
     environment:
       MAZE_BUGSNAG_API_KEY:
 
-  unit-test:
+  unit-test-ruby-2:
     build:
-      dockerfile: dockerfiles/Dockerfile.ci
+      dockerfile: dockerfiles/Dockerfile.ci-ruby-2
       context: .
       target: unit-test
-      args:
-        RUBY_VERSION:
+
+  unit-test-ruby-3:
+    build:
+      dockerfile: dockerfiles/Dockerfile.ci-ruby-3
+      context: .
+      target: unit-test
 
   browser-tests:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       dockerfile: dockerfiles/Dockerfile.ci-ruby-2
       context: .
       target: ci-ruby-2
+    environment:
+      USE_LEGACY_DRIVER: 1
 
   cli:
     build:
@@ -262,6 +264,8 @@ services:
       dockerfile: dockerfiles/Dockerfile.ci-ruby-2
       context: .
       target: unit-test-ruby-2
+    environment:
+      USE_LEGACY_DRIVER: 1
 
   unit-test-ruby-3:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,29 +8,29 @@ services:
     volumes:
       - ./:/scan
 
-  ci:
+  ci-ruby-3:
     build:
-      dockerfile: dockerfiles/Dockerfile.ci
+      dockerfile: dockerfiles/Dockerfile.ci-ruby-3
       context: .
-      target: ci
-      args:
-        - RUBY_VERSION
+      target: ci-ruby-3
+
+  ci-ruby-2.7:
+    build:
+      dockerfile: dockerfiles/Dockerfile.ci-ruby-2
+      context: .
+      target: ci-ruby-2
 
   cli:
     build:
-      dockerfile: dockerfiles/Dockerfile.ci
+      dockerfile: dockerfiles/Dockerfile.ci-ruby-3
       context: .
       target: cli
-      args:
-        - RUBY_VERSION=2.7
 
   cli-legacy:
     build:
-      dockerfile: dockerfiles/Dockerfile.ci
+      dockerfile: dockerfiles/Dockerfile.ci-ruby-2
       context: .
       target: cli-legacy
-      args:
-        - RUBY_VERSION=2.7
 
   docs:
     build:

--- a/dockerfiles/Dockerfile.ci-ruby-2
+++ b/dockerfiles/Dockerfile.ci-ruby-2
@@ -38,9 +38,9 @@ COPY Gemfile* bugsnag-maze-runner.gemspec ./
 
 RUN rm Gemfile.lock && USE_LEGACY_DRIVER=1 bundle install
 
-FROM ci-legacy as cli-legacy
+FROM ci-ruby-2 as cli-legacy
 ENTRYPOINT ["bundle", "exec", "maze-runner"]
 
-FROM ci-legacy as unit-test-ruby-2
+FROM ci-ruby-2 as unit-test-ruby-2
 COPY test/ test/
 COPY Rakefile .

--- a/dockerfiles/Dockerfile.ci-ruby-2
+++ b/dockerfiles/Dockerfile.ci-ruby-2
@@ -1,0 +1,46 @@
+# Ruby image are based on Debian
+FROM ruby:2-bullseye as ci-ruby-2
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y apt-utils wget unzip bash bundler \
+                       # Needed for symbolication
+                       llvm-11 \
+                       # Needed to install docker compose
+                       ca-certificates \
+                       curl \
+                       gnupg \
+                       lsb-release
+
+# https://docs.docker.com/engine/install/ubuntu/#set-up-the-repository
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# install docker & docker compose
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+RUN ruby -v
+
+RUN wget -q https://storage.googleapis.com/bugsnag-public-test-dependencies/BrowserStackLocal-linux-x64-v8_4.zip \
+  && unzip BrowserStackLocal-linux-x64-v8_4.zip \
+  && rm BrowserStackLocal-linux-x64-v8_4.zip
+
+RUN wget -q https://sbsecuretunnel.s3.amazonaws.com/cli/linux/SBSecureTunnel \
+  && chmod +x SBSecureTunnel
+
+WORKDIR /app/
+
+COPY bin/ bin/
+COPY lib/ lib/
+COPY Gemfile* bugsnag-maze-runner.gemspec ./
+
+RUN rm Gemfile.lock && USE_LEGACY_DRIVER=1 bundle install
+
+FROM ci-legacy as cli-legacy
+ENTRYPOINT ["bundle", "exec", "maze-runner"]
+
+FROM ci-legacy as unit-test-ruby-2
+COPY test/ test/
+COPY Rakefile .

--- a/dockerfiles/Dockerfile.ci-ruby-3
+++ b/dockerfiles/Dockerfile.ci-ruby-3
@@ -38,9 +38,9 @@ COPY Gemfile* bugsnag-maze-runner.gemspec ./
 
 RUN bundle install
 
-FROM ci as cli
+FROM ci-ruby-3 as cli
 ENTRYPOINT ["bundle", "exec", "maze-runner"]
 
-FROM ci as unit-test-ruby-3
+FROM ci-ruby-3 as unit-test-ruby-3
 COPY test/ test/
 COPY Rakefile .

--- a/dockerfiles/Dockerfile.ci-ruby-3
+++ b/dockerfiles/Dockerfile.ci-ruby-3
@@ -1,6 +1,5 @@
 # Ruby image are based on Debian
-ARG RUBY_VERSION
-FROM ruby:${RUBY_VERSION}-bullseye as ci-base
+FROM ruby:3-bullseye as ci-ruby-3
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     apt-get install -y apt-utils wget unzip bash bundler \
@@ -37,18 +36,11 @@ COPY bin/ bin/
 COPY lib/ lib/
 COPY Gemfile* bugsnag-maze-runner.gemspec ./
 
-FROM ci-base as ci
 RUN bundle install
-
-FROM ci-base as ci-legacy
-RUN rm Gemfile.lock && USE_LEGACY_DRIVER=1 bundle install
 
 FROM ci as cli
 ENTRYPOINT ["bundle", "exec", "maze-runner"]
 
-FROM ci-legacy as cli-legacy
-ENTRYPOINT ["bundle", "exec", "maze-runner"]
-
-FROM ci as unit-test
+FROM ci as unit-test-ruby-3
 COPY test/ test/
 COPY Rakefile .


### PR DESCRIPTION
## Goal

Update the shipped Docker image to be based on Ruby 3, rather than 2.  This applies to the image that uses the W3C protocol for Appium and Selenium.  The legacy (JSON-WP) image remains as Ruby 2, as Selenium 3 is not compatible with
Ruby 3.

## Design

The minimum Ruby version for development remains unchanged at 2, but shipping with 3 will allow clients to use the new language features in their test code.  

There's also sill the option of using the "legacy" image (which uses the JSON-WP protocol with Appium and Selenium.  The legacy image cannot be updated to Ruby 3, as the Selenium 3 client will not run with it.

## Changeset

I've refactored the Docker files/compose services a little - opting for a little duplication in exchange for (hopefully) greater clarity on what the pipeline is running.  Previously I found it difficult to see what was running and whether the Docker caching was working correctly.  I hope the end result is a little clearly by being more explicit about the Ruby version in use.

## Tests

Covered by CI.  I've also inspected the output from each build step in the pipeline, to ensure that the version of Ruby is as expected (Mae Runner outputs it when it starts).