### PR TITLE
Add TRACE log level

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,9 +28,9 @@ steps:
       artifacts#v1.5.0:
         upload: "test/fixtures/android-appium-test/app/build/outputs/apk/release/app-release.apk"
 
-  - label: ':docker: Build CI image for Ruby 2.7'
+  - label: ':docker: Build CI image for Ruby 2'
     timeout_in_minutes: 30
-    key: "ci-image-ruby-2-7"
+    key: "ci-image-ruby-2"
     plugins:
       - docker-compose#v4.7.0:
           build:
@@ -42,7 +42,7 @@ steps:
           push:
             - ci-ruby-2:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2
     env:
-      RUBY_VERSION: "2.7"
+      RUBY_VERSION: "2"
 
   - label: ':docker: Build CI image for Ruby 3'
     timeout_in_minutes: 30
@@ -60,9 +60,9 @@ steps:
     env:
       RUBY_VERSION: "3"
 
-  - label: 'Unit tests with Ruby 2.7'
+  - label: 'Unit tests with Ruby 2'
     timeout_in_minutes: 30
-    depends_on: 'ci-image-ruby-2-7'
+    depends_on: 'ci-image-ruby-2'
     plugins:
       docker-compose#v4.7.0:
         run: unit-test-ruby-2
@@ -85,7 +85,7 @@ steps:
   - label: ':docker: Push W3C CLI image for branch'
     key: push-branch-cli
     timeout_in_minutes: 30
-    depends_on: "ci-image-ruby-2-7"
+    depends_on: "ci-image-ruby-2"
     plugins:
       - docker-compose#v4.7.0:
           build: cli
@@ -99,7 +99,7 @@ steps:
   - label: ':docker: Push Legacy CLI image for branch'
     key: push-branch-cli-legacy
     timeout_in_minutes: 30
-    depends_on: "ci-image-ruby-2-7"
+    depends_on: "ci-image-ruby-2"
     plugins:
       - docker-compose#v4.7.0:
           build: cli-legacy
@@ -110,9 +110,9 @@ steps:
           push:
             - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli-legacy
 
-  - label: 'No-device tests with Ruby 2.7 - batch 1'
+  - label: 'No-device tests with Ruby 2 - batch 1'
     timeout_in_minutes: 30
-    depends_on: "ci-image-ruby-2-7"
+    depends_on: "ci-image-ruby-2"
     plugins:
       - docker-compose#v4.7.0:
           run: framework-tests
@@ -125,13 +125,13 @@ steps:
       - docker-compose#v4.7.0:
           run: http-response-tests
     env:
-      RUBY_VERSION: "2.7"
+      RUBY_VERSION: "2"
       USE_LEGACY_DRIVER: "1"
     command: 'bundle exec maze-runner -e features/fixtures'
 
-  - label: 'No-device tests with Ruby 2.7 - batch 2'
+  - label: 'No-device tests with Ruby 2 - batch 2'
     timeout_in_minutes: 30
-    depends_on: "ci-image-ruby-2-7"
+    depends_on: "ci-image-ruby-2"
     plugins:
       - docker-compose#v4.7.0:
           run: payload-helper-tests
@@ -146,7 +146,7 @@ steps:
             - test/fixtures/payload-helpers/maze_output/**/*
             - test/fixtures/payload-helpers/maze_output/*
     env:
-      RUBY_VERSION: "2.7"
+      RUBY_VERSION: "2"
       USE_LEGACY_DRIVER: "1"
     command: 'bundle exec maze-runner -e features/fixtures'
 
@@ -210,7 +210,7 @@ steps:
       artifacts#v1.9.0:
         upload: test/fixtures/android-appium-test/maze_output/**/*
     env:
-      RUBY_VERSION: "2.7"
+      RUBY_VERSION: "2"
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -298,7 +298,7 @@ steps:
           - "--fail-fast"
           - "--no-tunnel"
     env:
-      RUBY_VERSION: "2.7"
+      RUBY_VERSION: "2"
     concurrency: 5
     concurrency_group: 'bitbar-web'
     concurrency_method: eager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Command line options reviewed for consistency [533](https://github.com/bugsnag/maze-runner/pull/533)
 - Upgrade Docker image to Ruby 3 [534](https://github.com/bugsnag/maze-runner/pull/534)
+- Update logger to provide a real TRACE level [535](https://github.com/bugsnag/maze-runner/pull/535)
 
 
 <!---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Command line options reviewed for consistency [533](https://github.com/bugsnag/maze-runner/pull/533)
 - Upgrade Docker image to Ruby 3 [534](https://github.com/bugsnag/maze-runner/pull/534)
-- Update logger to provide a real TRACE level [535](https://github.com/bugsnag/maze-runner/pull/535)
+- Update logger to provide a real TRACE level [536](https://github.com/bugsnag/maze-runner/pull/536)
 
 
 <!---

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,10 +2,16 @@
 
 ## v7 to v8
 
+### Command line options
+
 A couple of command line options have been renamed for consistency:
 
 `--enable-bugsnag` becomes `--bugsnag` (and `--no-bugsnag`)
 `--enable-retries` becomes `--retries` (and `--no-retries`)
+
+### Logging
+
+The `VERBOSE` environment variable no longer has any effect on the log level.  Use `TRACE` or `DEBUG` for the two log levels.
 
 ## v6 to v7
 

--- a/docs/Test_Outputs.md
+++ b/docs/Test_Outputs.md
@@ -15,7 +15,7 @@ Each scenario folder is organised into a `passed` or `failed` folder immediately
 
 ## Logging
 
-Maze Runner contains a Ruby logger connected to `STDOUT` that will attempt to log several events that occur during the testing life-cycle.  By default, the logger is set to report `INFO` level events or higher, but will log `DEBUG` level events if the `VERBOSE` or `DEBUG` flags are set.  If the `QUIET` flag is set it will instead log at the `ERROR` level and above.
+Maze Runner contains a Ruby logger connected to `STDOUT` that will attempt to log events occurring during the testing life-cycle.  By default, the logger is set to report `INFO` level events or higher, but will log `DEBUG` AND `TRACE` level events if the corresponding environment variables are set.  If the `QUIET` flag is set it will log only at the `ERROR` level and above.
 
 ### Customising the logger
 

--- a/lib/maze/api/appium/file_manager.rb
+++ b/lib/maze/api/appium/file_manager.rb
@@ -20,7 +20,7 @@ module Maze
                    "/sdcard/Android/data/#{@driver.app_id}/files/#{filename}"
                  end
 
-          $logger.debug "Pushing file to '#{path}' with contents: #{contents}"
+          $logger.trace "Pushing file to '#{path}' with contents: #{contents}"
           @driver.push_file(path, contents)
         end
       end

--- a/lib/maze/appium_server.rb
+++ b/lib/maze/appium_server.rb
@@ -44,7 +44,7 @@ module Maze
         @appium_thread = Thread.new do
           PTY.spawn(command) do |stdout, _stdin, pid|
             @pid = pid
-            $logger.debug("Appium:#{@pid}") { 'Appium server started' }
+            $logger.trace("Appium:#{@pid}") { 'Appium server started' }
             stdout.each do |line|
               log_line(line)
             end
@@ -66,7 +66,7 @@ module Maze
       def stop
         return unless running
 
-        $logger.debug("Appium:#{@pid}") { 'Stopping appium server' }
+        $logger.trace("Appium:#{@pid}") { 'Stopping appium server' }
         Process.kill('INT', @pid)
         @pid = nil
         @appium_thread.join

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -17,7 +17,7 @@ module Maze
             device_group_ids = api_client.get_device_group_ids(device_or_group_names)
             if device_group_ids
               # Device group found - find a free device in it
-              $logger.debug "Got group ids #{device_group_ids} for #{device_or_group_names}"
+              $logger.trace "Got group ids #{device_group_ids} for #{device_or_group_names}"
               group_count, device = api_client.find_device_in_groups(device_group_ids)
               if device.nil?
                 # TODO: Retry rather than fail, see PLAT-7377

--- a/lib/maze/client/bb_api_client.rb
+++ b/lib/maze/client/bb_api_client.rb
@@ -44,7 +44,7 @@ module Maze
           all_devices += query_api(path, query)['data']
         end
 
-        $logger.debug "All available devices in group(s) #{device_group_ids}: #{JSON.pretty_generate(all_devices)}"
+        $logger.trace "All available devices in group(s) #{device_group_ids}: #{JSON.pretty_generate(all_devices)}"
         filtered_devices = all_devices.reject { |device| device['locked'] }
 
         # Only send gauges to DataDog for single device groups
@@ -64,7 +64,7 @@ module Maze
         if all_devices.size == 0
           Maze::Helper.error_exit "No devices found with name '#{device_name}'"
         else
-          $logger.debug "All available devices with name #{device_name}: #{JSON.pretty_generate(all_devices)}"
+          $logger.trace "All available devices with name #{device_name}: #{JSON.pretty_generate(all_devices)}"
           filtered_devices = all_devices.reject { |device| device['locked'] }
           if filtered_devices.size == 0
             Maze::Helper.error_exit "None of the #{all_devices.size} devices with name '#{device_name}' are currently available"

--- a/lib/maze/client/bb_client_utils.rb
+++ b/lib/maze/client/bb_client_utils.rb
@@ -182,7 +182,7 @@ module Maze
               end
 
               exit_status = wait_thr.value.to_i
-              $logger.debug "Exit status: #{exit_status}"
+              $logger.trace "Exit status: #{exit_status}"
 
               output.each { |line| $logger.warn('SBSecureTunnel') {line.chomp} } unless exit_status == 0
 

--- a/lib/maze/logger.rb
+++ b/lib/maze/logger.rb
@@ -5,6 +5,7 @@ require 'singleton'
 
 # Monkey patch a 'trace' log level into the standard Logger
 class Logger
+  remove_const(:SEV_LABEL)
   SEV_LABEL = {
     -1 => 'TRACE',
     0 => 'DEBUG',

--- a/lib/maze/logger.rb
+++ b/lib/maze/logger.rb
@@ -3,6 +3,31 @@
 require 'logger'
 require 'singleton'
 
+# Monkey patch a 'trace' log level into the standard Logger
+class Logger
+  SEV_LABEL = {
+    -1 => 'TRACE',
+    0 => 'DEBUG',
+    1 => 'INFO',
+    2 => 'WARN',
+    3 => 'ERROR',
+    4 => 'FATAL',
+    5 => 'ANY'
+  }
+
+  module Severity
+    TRACE=-1
+  end
+
+  def trace(name = nil, &block)
+    add(TRACE, nil, name, &block)
+  end
+
+  def trace?
+    @level <= TRACE
+  end
+end
+
 # Logger classes
 module Maze
   # A logger, with level configured according to the environment
@@ -12,7 +37,9 @@ module Maze
     attr_accessor :datetime_format
 
     def initialize
-      if ENV['VERBOSE'] || ENV['DEBUG']
+      if ENV['TRACE']
+        super(STDOUT, level: Logger::TRACE)
+      elsif ENV['DEBUG']
         super(STDOUT, level: Logger::DEBUG)
       elsif ENV['QUIET']
         super(STDOUT, level: Logger::ERROR)

--- a/lib/maze/repeaters/request_repeater.rb
+++ b/lib/maze/repeaters/request_repeater.rb
@@ -80,7 +80,7 @@ module Maze
       end
       
       def log(message = '')
-        $logger.debug message
+        $logger.trace message
       end
     end
   end

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -195,7 +195,7 @@ module Maze
 
             # Mount a block to respond to all requests with status:200
             server.mount_proc '/' do |_request, response|
-              $logger.debug 'Received request on server root, responding with 200'
+              $logger.trace 'Received request on server root, responding with 200'
               response.header['Access-Control-Allow-Origin'] = '*'
               response.body = 'Maze runner received request'
               response.status = 200

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -145,9 +145,9 @@ module Maze
       private
 
       def log_request(request)
-        $logger.debug "#{request.request_method} request received"
-        $logger.debug "URI: #{request.unparsed_uri}"
-        $logger.debug "HEADERS: #{request.raw_header}"
+        $logger.trace "#{request.request_method} request received"
+        $logger.trace "URI: #{request.unparsed_uri}"
+        $logger.trace "HEADERS: #{request.raw_header}"
         return if request.body.nil?
 
         case request['Content-Type']
@@ -156,12 +156,12 @@ module Maze
         when %r{^multipart/form-data; boundary=([^;]+)}
           boundary = WEBrick::HTTPUtils.dequote(Regexp.last_match(1))
           body = WEBrick::HTTPUtils.parse_form_data(request.body, boundary)
-          $logger.debug 'BODY:'
-          LogUtil.log_hash(Logger::Severity::DEBUG, body)
+          $logger.trace 'BODY:'
+          LogUtil.log_hash(Logger::Severity::TRACE, body)
         when %r{^application/json$}
-          $logger.debug "BODY: #{JSON.pretty_generate(JSON.parse(request.body))}"
+          $logger.trace "BODY: #{JSON.pretty_generate(JSON.parse(request.body))}"
         else
-          $logger.debug "BODY: #{request.body}"
+          $logger.trace "BODY: #{request.body}"
         end
       end
 
@@ -182,7 +182,7 @@ module Maze
         # Both digest types are stored whatever
         sha1 = Digest::SHA1.hexdigest(request.body)
         simple = request.body.bytesize
-        $logger.debug "DIGESTS computed: sha1=#{sha1} simple=#{simple}"
+        $logger.trace "DIGESTS computed: sha1=#{sha1} simple=#{simple}"
 
         # Check digests match
         case parts[0]

--- a/lib/maze/terminating_server.rb
+++ b/lib/maze/terminating_server.rb
@@ -107,7 +107,7 @@ module Maze
         while (request = socket.gets) && (request.chomp.length > 0)
           key, val = request.chomp.split(': ')
           headers[key] = val
-          $logger.debug "Received #{headers.size} headers"
+          $logger.trace "Received #{headers.size} headers"
         end
         headers
       end

--- a/test/appium_server_test.rb
+++ b/test/appium_server_test.rb
@@ -2,6 +2,7 @@
 
 require 'test_helper'
 require 'pty'
+require 'set'
 require_relative '../lib/maze/appium_server.rb'
 
 class AppiumServerTest < Test::Unit::TestCase
@@ -86,7 +87,7 @@ class AppiumServerTest < Test::Unit::TestCase
     pid = 12345
 
     # Corresponds to the debug call
-    $logger.expects(:debug).with("Appium:#{pid}").once
+    $logger.expects(:trace).with("Appium:#{pid}").once
 
     # Expect Thread.new to be called, and allow block to process expect the mock alive? to be called
     Thread.expects(:new).returns(thread_mock).yields
@@ -190,7 +191,7 @@ class AppiumServerTest < Test::Unit::TestCase
     Maze::AppiumServer.instance_variable_set(:@appium_thread, thread_mock)
 
     thread_mock.expects(:join)
-    $logger.expects(:debug).with("Appium:#{pid}")
+    $logger.expects(:trace).with("Appium:#{pid}")
     Process.expects(:kill).with('INT', pid)
 
     Maze::AppiumServer.stop


### PR DESCRIPTION
## Goal

Add a `TRACE` log level.

## Design

The rule of thumb is that `DEBUG` level logs should be of use to people running Maze Runner tests.  `TRACE` level logs are of interest to people developing Maze Runner itself.

## Documentation

Markdown docs updated.

## Changeset

Built in logger monkey patches to add a TRACE level.  Existing DEBUG level logs reviewed throughout.

There was also a subtle build problem introduced by #534 - the tag for the Ruby 2 image that would pushed did not precisely match the tag being requested in another.  The build for that PR only passed because the tag previously existing in the development of the branch and so just happened to exist.  The problem only became evident due to the new branch name and "clean start".

## Tests

Covered by CI and I also ran a quick test locally that the `DEBUG` and `TRACE` environment variables affect the logging as expected.
