### PR TITLE
Store sampling requests in their own list 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Command line options reviewed for consistency [533](https://github.com/bugsnag/maze-runner/pull/533)
 - Upgrade Docker image to Ruby 3 [534](https://github.com/bugsnag/maze-runner/pull/534)
 - Update logger to provide a real TRACE level [536](https://github.com/bugsnag/maze-runner/pull/536)
-- Fiter p-value trace requests into their own `RequestList` [537](https://github.com/bugsnag/maze-runner/pull/537)
+- Fiter sampling requests into their own `RequestList` [537](https://github.com/bugsnag/maze-runner/pull/537)
 
 
 <!---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Command line options reviewed for consistency [533](https://github.com/bugsnag/maze-runner/pull/533)
 - Upgrade Docker image to Ruby 3 [534](https://github.com/bugsnag/maze-runner/pull/534)
 - Update logger to provide a real TRACE level [536](https://github.com/bugsnag/maze-runner/pull/536)
-- Fiter sampling requests into their own `RequestList` [537](https://github.com/bugsnag/maze-runner/pull/537)
+- Filter sampling requests into their own `RequestList` [537](https://github.com/bugsnag/maze-runner/pull/537)
 
 
 <!---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Command line options reviewed for consistency [533](https://github.com/bugsnag/maze-runner/pull/533)
 - Upgrade Docker image to Ruby 3 [534](https://github.com/bugsnag/maze-runner/pull/534)
 - Update logger to provide a real TRACE level [536](https://github.com/bugsnag/maze-runner/pull/536)
+- Fiter p-value trace requests into their own `RequestList` [537](https://github.com/bugsnag/maze-runner/pull/537)
 
 
 <!---

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,12 +11,9 @@ A couple of command line options have been renamed for consistency:
 
 ### Request lists
 
-Both the p-value and regular trace requests continue to be received by the `/traces` endpoint, but the p-value requests are now stored in their own `RequestList`.  
+Both the sampling and regular trace requests continue to be received by the `/traces` endpoint, but the sampling requests are now stored in their own `RequestList`.  This list can be accessed in the same way as `sessions`, `errors`, etc by using `sampling request(s)` as the step argument.
 
-The following Cucumber steps change as a result:
-- `I receive and discard the initial p-value request` renamed to `I receive and discard the initial p_value`
-- `I wait to receive {int} {word}` no accepts a `p_value` as the `word` parameter.
-- Similarly for `I discard the oldest {word}`.
+With this change, the step `I receive and discard the initial p-value request` is no longer needed and has been removed.
 
 ### Logging
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,6 +9,15 @@ A couple of command line options have been renamed for consistency:
 `--enable-bugsnag` becomes `--bugsnag` (and `--no-bugsnag`)
 `--enable-retries` becomes `--retries` (and `--no-retries`)
 
+### Request lists
+
+Both the p-value and regular trace requests continue to be received by the `/traces` endpoint, but the p-value requests are now stored in their own `RequestList`.  
+
+The following Cucumber steps change as a result:
+- `I receive and discard the initial p-value request` renamed to `I receive and discard the initial p_value`
+- `I wait to receive {int} {word}` no accepts a `p_value` as the `word` parameter.
+- Similarly for `I discard the oldest {word}`.
+
 ### Logging
 
 The `VERBOSE` environment variable no longer has any effect on the log level.  Use `TRACE` or `DEBUG` for the two log levels.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,8 @@ A couple of command line options have been renamed for consistency:
 `--enable-bugsnag` becomes `--bugsnag` (and `--no-bugsnag`)
 `--enable-retries` becomes `--retries` (and `--no-retries`)
 
+### Request lists
+
 ## v6 to v7
 
 Support for Sauce Labs has been removed as we are no longer able to test it.

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -73,7 +73,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then('the {word} payload field {string} equals the platform-dependent string:') do |request_type, field_path, platform_values|
+Then('the {request_type} payload field {string} equals the platform-dependent string:') do |request_type, field_path, platform_values|
   test_string_platform_values(request_type, field_path, platform_values)
 end
 
@@ -100,7 +100,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then('the {word} payload field {string} equals the platform-dependent numeric:') do |request_type, field_path, platform_values|
+Then('the {request_type} payload field {string} equals the platform-dependent numeric:') do |request_type, field_path, platform_values|
   test_numeric_platform_values(request_type, field_path, platform_values)
 end
 
@@ -127,7 +127,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The field to test
 # @step_input platform_values [DataTable] A table of acceptable values for each platform
-Then('the {word} payload field {string} equals the platform-dependent boolean:') do |request_type, field_path, platform_values|
+Then('the {request_type} payload field {string} equals the platform-dependent boolean:') do |request_type, field_path, platform_values|
   test_boolean_platform_values(request_type, field_path, platform_values)
 end
 

--- a/lib/features/steps/header_steps.rb
+++ b/lib/features/steps/header_steps.rb
@@ -27,7 +27,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
 # @step_input header_value [String] The string it should match
-Then('the {request_type} (sampling request) {string} header equals {string}') do |request_type, header_name, header_value|
+Then('the {request_type} {string} header equals {string}') do |request_type, header_name, header_value|
   Maze.check.not_nil(Maze::Server.list_for(request_type).current[:request][header_name],
                      "The #{request_type} '#{header_name}' header wasn't present in the request")
   Maze.check.equal(header_value, Maze::Server.list_for(request_type).current[:request][header_name])

--- a/lib/features/steps/header_steps.rb
+++ b/lib/features/steps/header_steps.rb
@@ -6,7 +6,7 @@
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
-Then('the {word} {string} header is not null') do |request_type, header_name|
+Then('the {request_type} {string} header is not null') do |request_type, header_name|
   Maze.check.not_nil(Maze::Server.list_for(request_type).current[:request][header_name],
                      "The #{request_type} '#{header_name}' header should not be null")
 end
@@ -15,7 +15,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
-Then('the {word} {string} header is null') do |request_type, header_name|
+Then('the {request_type} {string} header is null') do |request_type, header_name|
   request = Maze::Server.list_for(request_type).current[:request]
 
   Maze.check.nil(request[header_name],
@@ -27,7 +27,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
 # @step_input header_value [String] The string it should match
-Then('the {word} {string} header equals {string}') do |request_type, header_name, header_value|
+Then('the {request_type} (sampling request) {string} header equals {string}') do |request_type, header_name, header_value|
   Maze.check.not_nil(Maze::Server.list_for(request_type).current[:request][header_name],
                      "The #{request_type} '#{header_name}' header wasn't present in the request")
   Maze.check.equal(header_value, Maze::Server.list_for(request_type).current[:request][header_name])
@@ -38,7 +38,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
 # @step_input regex_string [String] The regex to match with
-Then('the {word} {string} header matches the regex {string}') do |request_type, header_name, regex_string|
+Then('the {request_type} {string} header matches the regex {string}') do |request_type, header_name, regex_string|
   regex = Regexp.new(regex_string)
   value = Maze::Server.list_for(request_type).current[:request][header_name]
   Maze.check.match(regex, value)
@@ -49,7 +49,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
 # @step_input header_values [DataTable] A parsed data table
-Then('the {word} {string} header equals one of:') do |request_type, header_name, header_values|
+Then('the {request_type} {string} header equals one of:') do |request_type, header_name, header_values|
   Maze.check.include(header_values.raw.flatten, Maze::Server.list_for(request_type).current[:request][header_name])
 end
 
@@ -57,7 +57,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
-Then('the {word} {string} header is a timestamp') do |request_type, header_name|
+Then('the {request_type} {string} header is a timestamp') do |request_type, header_name|
   header = Maze::Server.list_for(request_type).current[:request][header_name]
   Maze.check.match(TIMESTAMP_REGEX, header)
 end
@@ -65,7 +65,7 @@ end
 # Checks that the Bugsnag-Integrity header is a SHA1 or simple digest
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
-When('the {word} Bugsnag-Integrity header is valid') do |request_type|
+When('the {request_type} Bugsnag-Integrity header is valid') do |request_type|
   Maze.check.true(Maze::Helper.valid_bugsnag_integrity_header(Maze::Server.list_for(request_type).current),
                   'Invalid Bugsnag-Integrity header detected')
 end

--- a/lib/features/steps/multipart_request_steps.rb
+++ b/lib/features/steps/multipart_request_steps.rb
@@ -22,7 +22,7 @@ end
 # Verifies that any type of request contains multipart form-data
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
-Then('the {word} request is valid multipart form-data') do |request_type|
+Then('the {request_type} request is valid multipart form-data') do |request_type|
   list = Maze::Server.list_for request_type
   valid_multipart_form_data?(list.current)
 end
@@ -30,7 +30,7 @@ end
 # Verifies all requests of a given type contain multipart form-data
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
-Then('all {word} requests are valid multipart form-data') do |request_type|
+Then('all {request_type} requests are valid multipart form-data') do |request_type|
   list = Maze::Server.list_for request_type
   list.all.all? { |request| valid_multipart_form_data?(request) }
 end
@@ -39,7 +39,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input part_count [Integer] The number of expected fields
-Then('the {word} multipart request has {int} fields') do |request_type, part_count|
+Then('the {request_type} multipart request has {int} fields') do |request_type, part_count|
   list = Maze::Server.list_for request_type
   parts = list.current[:body]
   Maze.check.equal(part_count, parts.size)
@@ -48,7 +48,7 @@ end
 # Tests a given type of multipart request has at least one field.
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
-Then('the {word} multipart request has a non-empty body') do |request_type|
+Then('the {request_type} multipart request has a non-empty body') do |request_type|
   list = Maze::Server.list_for request_type
   parts = list.current[:body]
   Maze.check.true(parts.size.positive?, "Multipart request payload contained #{parts.size} fields")
@@ -73,7 +73,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
-Then('the {word} multipart body does not match the JSON file in {string}') do |request_type, json_path|
+Then('the {request_type} multipart body does not match the JSON file in {string}') do |request_type, json_path|
   Maze.check.true(File.exist?(json_path), "'#{json_path}' does not exist")
   payload_list = Maze::Server.list_for request_type
   raw_payload_value = payload_list.current[:body]
@@ -88,7 +88,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
-Then('the {word} multipart body matches the JSON file in {string}') do |request_type, json_path|
+Then('the {request_type} multipart body matches the JSON file in {string}') do |request_type, json_path|
   Maze.check.true(File.exist?(json_path), "'#{json_path}' does not exist")
   payload_list = Maze::Server.list_for request_type
   raw_payload_value = payload_list.current[:body]
@@ -104,7 +104,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
 # @step_input json_path [String] Path to a JSON file relative to maze-runner root
-Then('the {word} multipart field {string} matches the JSON file in {string}') do |request_type, field_path, json_path|
+Then('the {request_type} multipart field {string} matches the JSON file in {string}') do |request_type, field_path, json_path|
   Maze.check.true(File.exist?(json_path), "'#{json_path}' does not exist")
   payload_list = Maze::Server.list_for request_type
   payload_value = JSON.parse(payload_list.current[:body][field_path].to_s)
@@ -117,7 +117,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input part_key [String] The key to the multipart element
-Then('the field {string} for multipart {word} is not null') do |part_key, request_type|
+Then('the field {string} for multipart {request_type} is not null') do |part_key, request_type|
   parts = Maze::Server.list_for(request_type).current[:body]
   Maze.check.not_nil(parts[part_key], "The field '#{part_key}' should not be null")
 end
@@ -126,7 +126,7 @@ end
 #
 # @step_input part_key [String] The key to the multipart element
 # @step_input request_type [String] The type of request (error, session, build, etc)
-Then('the field {string} for multipart {word} is null') do |part_key, request_type|
+Then('the field {string} for multipart {request_type} is null') do |part_key, request_type|
   parts = Maze::Server.list_for(request_type).current[:body]
   Maze.check.nil(parts[part_key], "The field '#{part_key}' should be null")
 end
@@ -136,7 +136,7 @@ end
 # @step_input part_key [String] The key to the multipart element
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input expected_value [String] The string to match against
-Then('the field {string} for multipart {word} equals {string}') do |part_key, request_type, expected_value|
+Then('the field {string} for multipart {request_type} equals {string}') do |part_key, request_type, expected_value|
   parts = Maze::Server.list_for(request_type).current[:body]
   Maze.check.equal(parts[part_key], expected_value)
 end

--- a/lib/features/steps/payload_steps.rb
+++ b/lib/features/steps/payload_steps.rb
@@ -6,7 +6,7 @@
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input fixture_path [String] Path to a JSON fixture
-Then('the {word} payload body does not match the JSON fixture in {string}') do |request_type, fixture_path|
+Then('the {request_type} payload body does not match the JSON fixture in {string}') do |request_type, fixture_path|
   payload_value = Maze::Server.list_for(request_type).current[:body]
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
@@ -17,7 +17,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input fixture_path [String] Path to a JSON fixture
-Then('the {word} payload body matches the JSON fixture in {string}') do |request_type, fixture_path|
+Then('the {request_type} payload body matches the JSON fixture in {string}') do |request_type, fixture_path|
   payload_value = Maze::Server.list_for(request_type).current[:body]
   expected_value = JSON.parse(open(fixture_path, &:read))
   result = Maze::Compare.value(expected_value, payload_value)
@@ -30,7 +30,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
 # @step_input fixture_path [String] Path to a JSON fixture
-Then('the {word} payload field {string} matches the JSON fixture in {string}') \
+Then('the {request_type}(|a b) payload field {string} matches the JSON fixture in {string}') \
 do |request_type, field_path, fixture_path|
   list = Maze::Server.list_for(request_type)
   payload_value = Maze::Helper.read_key_path(list.current[:body], field_path)
@@ -44,7 +44,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
-Then('the {word} payload field {string} is true') do |request_type, field_path|
+Then('the {request_type} payload field {string} is true') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
   Maze.check.true(Maze::Helper.read_key_path(list.current[:body], field_path))
 end
@@ -53,7 +53,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
-Then('the {word} payload field {string} is false') do |request_type, field_path|
+Then('the {request_type} payload field {string} is false') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
   Maze.check.false(Maze::Helper.read_key_path(list.current[:body], field_path))
 end
@@ -62,7 +62,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
-Then('the {word} payload field {string} is null') do |request_type, field_path|
+Then('the {request_type} payload field {string} is null') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
   Maze.check.nil(Maze::Helper.read_key_path(list.current[:body], field_path))
 end
@@ -71,7 +71,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
-Then('the {word} payload field {string} is not null') do |request_type, field_path|
+Then('the {request_type} payload field {string} is not null') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
   Maze.check.not_nil(Maze::Helper.read_key_path(list.current[:body], field_path))
 end
@@ -81,7 +81,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
 # @step_input int_value [Integer] The value to test against
-Then('the {word} payload field {string} equals {int}') do |request_type, field_path, int_value|
+Then('the {request_type} payload field {string} equals {int}') do |request_type, field_path, int_value|
   Maze.check.equal(int_value,
                    Maze::Helper.read_key_path(Maze::Server.list_for(request_type).current[:body], field_path))
 end
@@ -91,7 +91,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] Path to the tested element
 # @step_input float_value [Float] The value to test against
-Then('the {word} payload field {string} equals {float}') do |request_type, field_path, float_value|
+Then('the {request_type} payload field {string} equals {float}') do |request_type, field_path, float_value|
   Maze.check.equal(float_value,
                    Maze::Helper.read_key_path(Maze::Server.list_for(request_type).current[:body], field_path))
 end
@@ -102,7 +102,7 @@ end
 # @step_input field_path [String] Path to the tested element
 # @step_input float_value [Float] The value to test against
 # @step_input places [Int] The number of decimal places to round the actual value to first
-Then('the {word} payload field {string} equals {float} to {int} decimal place(s)') do |request_type, field_path, float_value, places|
+Then('the {request_type} payload field {string} equals {float} to {int} decimal place(s)') do |request_type, field_path, float_value, places|
   body = Maze::Server.list_for(request_type).current[:body]
   rounded_value = Maze::Helper.read_key_path(body, field_path).round places
   Maze.check.equal(float_value,
@@ -114,7 +114,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input env_var [String] The environment variable to test against
-Then('the {word} payload field {string} equals the environment variable {string}') \
+Then('the {request_type} payload field {string} equals the environment variable {string}') \
 do |request_type, field_path, env_var|
   environment_value = ENV[env_var]
   Maze.check.false(environment_value.nil?, "The environment variable #{env_var} must not be nil")
@@ -129,7 +129,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input int_value [Integer] The value to compare against
-Then('the {word} payload field {string} is greater than {int}') do |request_type, field_path, int_value|
+Then('the {request_type} payload field {string} is greater than {int}') do |request_type, field_path, int_value|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
   Maze.check.kind_of Integer, value
@@ -141,7 +141,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input int_value [Integer] The value to compare against
-Then('the {word} payload field {string} is less than {int}') do |request_type, field_path, int_value|
+Then('the {request_type} payload field {string} is less than {int}') do |request_type, field_path, int_value|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
   Maze.check.kind_of Integer, value
@@ -154,7 +154,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
-Then('the {word} payload field {string} equals {string}') do |request_type, field_path, string_value|
+Then('the {request_type} payload field {string} equals {string}') do |request_type, field_path, string_value|
   list = Maze::Server.list_for(request_type)
   Maze.check.equal(string_value, Maze::Helper.read_key_path(list.current[:body], field_path))
 end
@@ -164,7 +164,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
-Then('the {word} payload field {string} starts with {string}') do |request_type, field_path, string_value|
+Then('the {request_type} payload field {string} starts with {string}') do |request_type, field_path, string_value|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
   Maze.check.kind_of String, value
@@ -179,7 +179,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The payload element to test
 # @step_input string_value [String] The string to test against
-Then('the {word} payload field {string} ends with {string}') do |request_type, field_path, string_value|
+Then('the {request_type} payload field {string} ends with {string}') do |request_type, field_path, string_value|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field_path)
   Maze.check.kind_of String, value
@@ -194,7 +194,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload element to test
 # @step_input count [Integer] The value expected
-Then('the {word} payload field {string} is an array with {int} elements') do |request_type, field, count|
+Then('the {request_type} payload field {string} is an array with {int} elements') do |request_type, field, count|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field)
   Maze.check.kind_of Array, value
@@ -205,7 +205,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload element to test
-Then('the {word} payload field {string} is a non-empty array') do |request_type, field|
+Then('the {request_type} payload field {string} is a non-empty array') do |request_type, field|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field)
   Maze.check.kind_of Array, value
@@ -217,7 +217,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload element to test
 # @step_input regex [String] The regex to test against
-Then('the {word} payload field {string} matches the regex {string}') do |request_type, field, regex_string|
+Then('the {request_type} payload field {string} matches the regex {string}') do |request_type, field, regex_string|
   regex = Regexp.new(regex_string)
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field)
@@ -228,7 +228,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload element to test
-Then('the {word} payload field {string} is a parsable timestamp in seconds') do |request_type, field|
+Then('the {request_type} payload field {string} is a parsable timestamp in seconds') do |request_type, field|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], field)
   begin
@@ -245,7 +245,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input key_path [String] The path to the tested array
 # @step_input element_key_path [String] The key for the expected element inside the array
-Then('each element in {word} payload field {string} has {string}') do |request_type, key_path, element_key_path|
+Then('each element in {request_type} payload field {string} has {string}') do |request_type, key_path, element_key_path|
   list = Maze::Server.list_for(request_type)
   value = Maze::Helper.read_key_path(list.current[:body], key_path)
   Maze.check.kind_of Array, value

--- a/lib/features/steps/query_parameter_steps.rb
+++ b/lib/features/steps/query_parameter_steps.rb
@@ -7,7 +7,7 @@
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input parameter_name [String] The parameter to test
 # @step_input parameter_value [String] The expected value
-Then('the {word} {string} query parameter equals {string}') do |request_type, parameter_name, parameter_value|
+Then('the {request_type} {string} query parameter equals {string}') do |request_type, parameter_name, parameter_value|
   Maze.check.equal(parameter_value,
                    Maze::Helper.parse_querystring(Maze::Server.list_for(request_type).current)[parameter_name][0])
 end
@@ -16,7 +16,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input parameter_name [String] The parameter to test
-Then('the {word} {string} query parameter is not null') do |request_type, parameter_name|
+Then('the {request_type} {string} query parameter is not null') do |request_type, parameter_name|
   Maze.check.not_nil(Maze::Helper.parse_querystring(Maze::Server.list_for(request_type).current)[parameter_name][0],
                      "The '#{parameter_name}' query parameter should not be null")
 end
@@ -25,7 +25,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input parameter_name [String] The parameter to test
-Then('the {word} {string} query parameter is a timestamp') do |request_type, parameter_name|
+Then('the {request_type} {string} query parameter is a timestamp') do |request_type, parameter_name|
   param = Maze::Helper.parse_querystring(Maze::Server.list_for(request_type).current)[parameter_name][0]
   Maze.check.match(TIMESTAMP_REGEX, param)
 end

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -56,6 +56,18 @@ Then('I wait to receive {int} {word}') do |request_count, request_type|
   list.sort_by_sent_at! request_count
 end
 
+# Continually checks to see if the required amount of requests have been received,
+# timing out according to @see Maze.config.receive_requests_wait.
+# If all expected requests are received and have the Bugsnag-Sent-At header, they
+# will be sorted by the header.
+#
+# @step_input request_count [Integer] The amount of requests expected
+Then('I wait to receive {int} sampling request(s)') do |request_count|
+  list = Maze::Server.p_values
+  assert_received_requests request_count, list, 'sampling requests'
+  list.sort_by_sent_at! request_count
+end
+
 # Continually checks to see if at least the number requests given has been received,
 # timing out according to @see Maze.config.receive_requests_wait.
 #
@@ -110,6 +122,14 @@ Then('I discard the oldest {word}') do |request_type|
   raise "No #{request_type} to discard" if Maze::Server.list_for(request_type).current.nil?
 
   Maze::Server.list_for(request_type).next
+end
+
+# Moves to the next sampling request
+#
+Then('I discard the oldest sampling request') do |request_type|
+  raise "No sampling requests to discard" if Maze::Server.p_values.current.nil?
+
+  Maze::Server.p_values.next
 end
 
 Then('the received errors match:') do |table|

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -34,12 +34,12 @@ def assert_received_requests(request_count, list, list_name, precise = true)
 end
 
 #
-# Error request assertions
+# Request assertions
 #
 # Shortcut to waiting to receive a single request of the given type
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
-Then('I wait to receive a(n) {word}') do |request_type|
+Then('I wait to receive a(n) {request_type}') do |request_type|
   step "I wait to receive 1 #{request_type}"
 end
 
@@ -50,21 +50,9 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input request_count [Integer] The amount of requests expected
-Then('I wait to receive {int} {word}') do |request_count, request_type|
+Then('I wait to receive {int} {request_type}') do |request_count, request_type|
   list = Maze::Server.list_for(request_type)
   assert_received_requests request_count, list, request_type
-  list.sort_by_sent_at! request_count
-end
-
-# Continually checks to see if the required amount of requests have been received,
-# timing out according to @see Maze.config.receive_requests_wait.
-# If all expected requests are received and have the Bugsnag-Sent-At header, they
-# will be sorted by the header.
-#
-# @step_input request_count [Integer] The amount of requests expected
-Then('I wait to receive {int} sampling request(s)') do |request_count|
-  list = Maze::Server.p_values
-  assert_received_requests request_count, list, 'sampling requests'
   list.sort_by_sent_at! request_count
 end
 
@@ -75,7 +63,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input request_count [Integer] The amount of requests expected
-Then('I wait to receive at least {int} {word}') do |request_count, request_type|
+Then('I wait to receive at least {int} {request_type}') do |request_count, request_type|
   list = Maze::Server.list_for(request_type)
   assert_received_requests request_count, list, request_type, false
 end
@@ -84,7 +72,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field_path [String] The field to sort by
-Then('I sort the {word} by the payload field {string}') do |request_type, field_path|
+Then('I sort the {request_type} by the payload field {string}') do |request_type, field_path|
   list = Maze::Server.list_for(request_type)
   list.sort_by! field_path
 end
@@ -94,7 +82,7 @@ end
 #
 # @step_input min_received [Integer] The minimum amount of requests required to pass
 # @step_input request_type [String] The type of request (error, session, build, etc)
-Then('I have received at least {int} {word}') do |min_received, request_type|
+Then('I have received at least {int} {request_type}') do |min_received, request_type|
   list = Maze::Server.list_for(request_type)
   Maze.check.operator(list.size_remaining, :>=, min_received, "Actually received #{list.size_remaining} #{request_type} requests")
 end
@@ -103,7 +91,7 @@ end
 #
 # @step_input request_type [String] The type of request ('error', 'session', build, etc), or 'requests' to assert on all
 #   request types.
-Then('I should receive no {word}') do |request_type|
+Then('I should receive no {request_type}') do |request_type|
   sleep Maze.config.receive_no_requests_wait
   if request_type == 'requests'
     # Assert that the test Server hasn't received any requests at all.
@@ -118,18 +106,10 @@ end
 # Moves to the next request
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
-Then('I discard the oldest {word}') do |request_type|
+Then('I discard the oldest {request_type}') do |request_type|
   raise "No #{request_type} to discard" if Maze::Server.list_for(request_type).current.nil?
 
   Maze::Server.list_for(request_type).next
-end
-
-# Moves to the next sampling request
-#
-Then('I discard the oldest sampling request') do |request_type|
-  raise "No sampling requests to discard" if Maze::Server.p_values.current.nil?
-
-  Maze::Server.p_values.next
 end
 
 Then('the received errors match:') do |table|

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -15,7 +15,7 @@ end
 #
 # @step_input endpoint [String] The endpoint to set
 # @step_input name [String] The environment variable
-When('I store the {word} endpoint in the environment variable {string}') do |endpoint, name|
+When('I store the {request_type} endpoint in the environment variable {string}') do |endpoint, name|
   steps %(
     When I set environment variable "#{name}" to "http://maze-runner:#{Maze.config.port}/#{endpoint}"
   )
@@ -41,7 +41,7 @@ end
 #
 # @step_input script_path [String] Path to the script to be run
 # @step_input command [String] The command to run the script with, e.g. 'ruby'
-When('I run the script {string} using {word} synchronously') do |script_path, command|
+When('I run the script {string} using {request_type} synchronously') do |script_path, command|
   Maze::Runner.run_script(script_path, blocking: true, command: command)
 end
 

--- a/lib/features/steps/runner_steps.rb
+++ b/lib/features/steps/runner_steps.rb
@@ -15,7 +15,7 @@ end
 #
 # @step_input endpoint [String] The endpoint to set
 # @step_input name [String] The environment variable
-When('I store the {request_type} endpoint in the environment variable {string}') do |endpoint, name|
+When('I store the {word} endpoint in the environment variable {string}') do |endpoint, name|
   steps %(
     When I set environment variable "#{name}" to "http://maze-runner:#{Maze.config.port}/#{endpoint}"
   )
@@ -41,7 +41,7 @@ end
 #
 # @step_input script_path [String] Path to the script to be run
 # @step_input command [String] The command to run the script with, e.g. 'ruby'
-When('I run the script {string} using {request_type} synchronously') do |script_path, command|
+When('I run the script {string} using {word} synchronously') do |script_path, command|
   Maze::Runner.run_script(script_path, blocking: true, command: command)
 end
 

--- a/lib/features/steps/trace_steps.rb
+++ b/lib/features/steps/trace_steps.rb
@@ -80,7 +80,7 @@ Then('the trace payload field {string} boolean attribute {string} is false') do 
 end
 
 # @!group Span steps
-Then('a span {request_type} equals {string}') do |attribute, expected|
+Then('a span {word} equals {string}') do |attribute, expected|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   selected_attributes = spans.map { |span| span[attribute] }
   Maze.check.includes selected_attributes, expected

--- a/lib/features/steps/trace_steps.rb
+++ b/lib/features/steps/trace_steps.rb
@@ -7,11 +7,11 @@ When('I wait for {int} span(s)') do |span_count|
   assert_received_spans span_count, Maze::Server.list_for('traces')
 end
 
-When('I receive and discard the initial p-value request') do
+When('I receive and discard the initial p_value') do
   steps %Q{
-    And I wait to receive at least 1 trace
-    And the trace payload field "resourceSpans" is an array with 0 elements
-    And I discard the oldest trace
+    And I wait to receive at least 1 p_value
+    And the p_value payload field "resourceSpans" is an array with 0 elements
+    And I discard the oldest p_value
   }
 end
 

--- a/lib/features/steps/trace_steps.rb
+++ b/lib/features/steps/trace_steps.rb
@@ -7,14 +7,6 @@ When('I wait for {int} span(s)') do |span_count|
   assert_received_spans span_count, Maze::Server.list_for('traces')
 end
 
-When('I receive and discard the initial p_value') do
-  steps %Q{
-    And I wait to receive at least 1 p_value
-    And the p_value payload field "resourceSpans" is an array with 0 elements
-    And I discard the oldest p_value
-  }
-end
-
 Then('I should have received no spans') do
   sleep Maze.config.receive_no_requests_wait
   Maze.check.equal spans_from_request_list(Maze::Server.list_for('traces')).size, 0
@@ -88,7 +80,7 @@ Then('the trace payload field {string} boolean attribute {string} is false') do 
 end
 
 # @!group Span steps
-Then('a span {word} equals {string}') do |attribute, expected|
+Then('a span {request_type} equals {string}') do |attribute, expected|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   selected_attributes = spans.map { |span| span[attribute] }
   Maze.check.includes selected_attributes, expected

--- a/lib/features/steps/value_steps.rb
+++ b/lib/features/steps/value_steps.rb
@@ -7,7 +7,7 @@ require 'date'
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to store
 # @step_input key [String] The key to store the value against
-Then('the {word} payload field {string} is stored as the value {string}') do |request_type, field, key|
+Then('the {request_type} payload field {string} is stored as the value {string}') do |request_type, field, key|
   list = Maze::Server.list_for request_type
   value = Maze::Helper.read_key_path(list.current[:body], field)
   Maze::Store.values[key] = value.dup
@@ -18,7 +18,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
-Then('the {word} payload field {string} equals the stored value {string}') do |request_type, field, key|
+Then('the {request_type} payload field {string} equals the stored value {string}') do |request_type, field, key|
   list = Maze::Server.list_for request_type
   payload_value = Maze::Helper.read_key_path(list.current[:body], field)
   stored_value = Maze::Store.values[key]
@@ -31,7 +31,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
-Then('the {word} payload field {string} does not equal the stored value {string}') do |request_type, field, key|
+Then('the {request_type} payload field {string} does not equal the stored value {string}') do |request_type, field, key|
   list = Maze::Server.list_for request_type
   payload_value = Maze::Helper.read_key_path(list.current[:body], field)
   stored_value = Maze::Store.values[key]
@@ -44,7 +44,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
-Then('the {word} payload field {string} equals the stored value {string} ignoring case') do |request_type, field, key|
+Then('the {request_type} payload field {string} equals the stored value {string} ignoring case') do |request_type, field, key|
   list = Maze::Server.list_for request_type
   payload_value = Maze::Helper.read_key_path(list.current[:body], field)
   stored_value = Maze::Store.values[key]
@@ -59,7 +59,7 @@ end
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
 # @step_input key [String] The key indicating a previously stored value
-Then('the {word} payload field {string} does not equal the stored value {string} ignoring case') do |request_type, field, key|
+Then('the {request_type} payload field {string} does not equal the stored value {string} ignoring case') do |request_type, field, key|
   list = Maze::Server.list_for request_type
   payload_value = Maze::Helper.read_key_path(list.current[:body], field)
   stored_value = Maze::Store.values[key]
@@ -73,7 +73,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
-Then('the {word} payload field {string} is a number') do |request_type, field|
+Then('the {request_type} payload field {string} is a number') do |request_type, field|
   list = Maze::Server.list_for request_type
   value = Maze::Helper.read_key_path(list.current[:body], field)
   Maze.check.kind_of Numeric, value
@@ -83,7 +83,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
-Then('the {word} payload field {string} is an integer') do |request_type, field|
+Then('the {request_type} payload field {string} is an integer') do |request_type, field|
   list = Maze::Server.list_for request_type
   value = Maze::Helper.read_key_path(list.current[:body], field)
   Maze.check.kind_of Integer, value
@@ -93,7 +93,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
-Then('the {word} payload field {string} is a date') do |request_type, field|
+Then('the {request_type} payload field {string} is a date') do |request_type, field|
   list = Maze::Server.list_for request_type
   value = Maze::Helper.read_key_path(list.current[:body], field)
   date = begin
@@ -108,7 +108,7 @@ end
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input field [String] The payload field to test
-Then('the {word} payload field {string} is a UUID') do |request_type, field|
+Then('the {request_type} payload field {string} is a UUID') do |request_type, field|
   list = Maze::Server.list_for request_type
   value = Maze::Helper.read_key_path(list.current[:body], field)
   Maze.check.not_nil(value, "Expected UUID, got nil for #{field}")

--- a/lib/features/support/cucumber_types.rb
+++ b/lib/features/support/cucumber_types.rb
@@ -1,0 +1,6 @@
+ParameterType(
+  name:        'request_type',
+  regexp:      /error(s)|session(s)|build(s)|log(s)|metric(s)|sampling request(s)|trace(s)|upload(s)|sourcemap(s)|invalid request(s)/,
+  type:        String,
+  transformer: ->(s) { s }
+)

--- a/lib/features/support/cucumber_types.rb
+++ b/lib/features/support/cucumber_types.rb
@@ -1,6 +1,6 @@
 ParameterType(
   name:        'request_type',
-  regexp:      /error(s)|session(s)|build(s)|log(s)|metric(s)|sampling request(s)|trace(s)|upload(s)|sourcemap(s)|invalid request(s)/,
+  regexp:      /errors?|sessions?|builds?|logs?|metrics?|sampling requests?|traces?|uploads?|sourcemaps?|invalid requests?/,
   type:        String,
   transformer: ->(s) { s }
 )

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -25,8 +25,6 @@ module Maze
       # Runs the validation against the trace given
       def validate
         @success = true
-        # Shortcut the validation if the body is empty for initial P gathering reasons
-        return if @body.keys.eql?(['resourceSpans']) && @body['resourceSpans'].empty?
 
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.spanId', '^[A-Fa-f0-9]{16}$')
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.traceId', '^[A-Fa-f0-9]{32}$')

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -85,8 +85,8 @@ module Maze
           logs
         when 'metric', 'metrics'
           metrics
-        when 'p_value', 'p_values'
-          p_values
+        when 'sampling request', 'sampling requests'
+          sampling_requests
         when 'trace', 'traces'
           traces
         when 'upload', 'uploads'
@@ -116,9 +116,9 @@ module Maze
 
       # A list of p-value requests received
       #
-      # @return [RequestList] Received p-value requests
-      def p_values
-        @p_values ||= RequestList.new
+      # @return [RequestList] Received sampling requests
+      def sampling_requests
+        @sampling_requests ||= RequestList.new
       end
 
       # A list of trace requests received
@@ -261,7 +261,7 @@ module Maze
         builds.clear
         uploads.clear
         sourcemaps.clear
-        p_values.clear
+        sampling_requests.clear
         traces.clear
         logs.clear
         invalid_requests.clear

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -261,6 +261,7 @@ module Maze
         builds.clear
         uploads.clear
         sourcemaps.clear
+        p_values.clear
         traces.clear
         logs.clear
         invalid_requests.clear

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -85,8 +85,8 @@ module Maze
           logs
         when 'metric', 'metrics'
           metrics
-        when 'pvalue', 'pvalues'
-          pvalues
+        when 'p_value', 'p_values'
+          p_values
         when 'trace', 'traces'
           traces
         when 'upload', 'uploads'
@@ -116,9 +116,9 @@ module Maze
 
       # A list of p-value requests received
       #
-      # @return [RequestList] Received pvalue requests
-      def pvalues
-        @pvalues ||= RequestList.new
+      # @return [RequestList] Received p-value requests
+      def p_values
+        @p_values ||= RequestList.new
       end
 
       # A list of trace requests received

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -114,7 +114,7 @@ module Maze
         @sessions ||= RequestList.new
       end
 
-      # A list of p-value requests received
+      # A list of sampling requests received
       #
       # @return [RequestList] Received sampling requests
       def sampling_requests

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -85,6 +85,8 @@ module Maze
           logs
         when 'metric', 'metrics'
           metrics
+        when 'pvalue', 'pvalues'
+          pvalues
         when 'trace', 'traces'
           traces
         when 'upload', 'uploads'
@@ -107,14 +109,21 @@ module Maze
 
       # A list of session requests received
       #
-      # @return [RequestList] Received error requests
+      # @return [RequestList] Received session requests
       def sessions
         @sessions ||= RequestList.new
       end
 
+      # A list of p-value requests received
+      #
+      # @return [RequestList] Received pvalue requests
+      def pvalues
+        @pvalues ||= RequestList.new
+      end
+
       # A list of trace requests received
       #
-      # @return [RequestList] Received error requests
+      # @return [RequestList] Received trace requests
       def traces
         @traces ||= RequestList.new
       end

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -37,7 +37,6 @@ module Maze
       def initialize(server, request_type, schema=nil)
         super server
         @request_type = request_type
-        @requests = Server.list_for request_type
         @schema = JSONSchemer.schema(schema) unless schema.nil?
         @aspecto_repeater = Maze::Repeaters::AspectoRepeater.new(@request_type)
         @bugsnag_repeater = Maze::Repeaters::BugsnagRepeater.new(@request_type)
@@ -88,7 +87,7 @@ module Maze
           schema_errors = @schema.validate(hash[:body])
           hash[:schema_errors] = schema_errors.to_a
         end
-        @requests.add(hash)
+        add_request(hash)
 
         # For the response, delaying if configured to do so
         response_delay_ms = Server.response_delay_ms
@@ -143,6 +142,10 @@ module Maze
       end
 
       private
+
+      def add_request(request)
+        Server.list_for(@request_type).add(request)
+      end
 
       def log_request(request)
         $logger.trace "#{request.request_method} request received"

--- a/lib/maze/servlets/trace_servlet.rb
+++ b/lib/maze/servlets/trace_servlet.rb
@@ -15,14 +15,14 @@ module Maze
       private
 
       def add_request(request)
-        if p_value_request? request
-          Server.p_values.add request
+        if sampling_request? request
+          Server.sampling_requests.add request
         else
           Server.traces.add request
         end
       end
 
-      def p_value_request?(request)
+      def sampling_request?(request)
         body = request[:body]
         body.keys.eql?(['resourceSpans']) && body['resourceSpans'].empty?
       end

--- a/lib/maze/servlets/trace_servlet.rb
+++ b/lib/maze/servlets/trace_servlet.rb
@@ -11,6 +11,21 @@ module Maze
 
         header['Access-Control-Expose-Headers'] = 'Bugsnag-Sampling-Probability'
       end
+
+      private
+
+      def add_request(request)
+        if pvalue_request? request
+          Server.pvalues.add request
+        else
+          Server.traces.add request
+        end
+      end
+
+      def pvalue_request?(request)
+        body = request[:body]
+        body.keys.eql?(['resourceSpans']) && body['resourceSpans'].empty?
+      end
     end
   end
 end

--- a/lib/maze/servlets/trace_servlet.rb
+++ b/lib/maze/servlets/trace_servlet.rb
@@ -15,14 +15,14 @@ module Maze
       private
 
       def add_request(request)
-        if pvalue_request? request
-          Server.pvalues.add request
+        if p_value_request? request
+          Server.p_values.add request
         else
           Server.traces.add request
         end
       end
 
-      def pvalue_request?(request)
+      def p_value_request?(request)
         body = request[:body]
         body.keys.eql?(['resourceSpans']) && body['resourceSpans'].empty?
       end

--- a/test/fixtures/framework/features/support/env.rb
+++ b/test/fixtures/framework/features/support/env.rb
@@ -9,3 +9,4 @@ Maze.hooks.before do |scenario|
   Maze::Runner.environment['TEST_KEY'] = 'TEST_VALUE' if scenario.name == 'Set variable'
   $first_attempt = true unless Maze::RetryHandler.retried_previously? scenario
 end
+

--- a/test/fixtures/http-response/features/steps/steps.rb
+++ b/test/fixtures/http-response/features/steps/steps.rb
@@ -1,3 +1,3 @@
-When('I ignore invalid {word}') do |type|
+When('I ignore invalid {request_type}') do |type|
   Maze.config.captured_invalid_requests.delete(type.to_sym)
 end

--- a/test/fixtures/payload-helpers/features/traces_support.feature
+++ b/test/fixtures/payload-helpers/features/traces_support.feature
@@ -3,9 +3,9 @@ Feature: Testing support on traces endpoint
     Scenario: The traces endpoint can accept json payloads
         # A sampling trace
         When I send a "sampling-trace"-type request
-        Then I wait to receive a p_value
+        Then I wait to receive a sampling request
         And The HTTP response header "Bugsnag-Sampling-Probability" equals "1"
-        And I discard the oldest p_value
+        And I discard the oldest sampling request
 
         # A mobile trace
         Then I send a "trace"-type request

--- a/test/fixtures/payload-helpers/features/traces_support.feature
+++ b/test/fixtures/payload-helpers/features/traces_support.feature
@@ -3,9 +3,9 @@ Feature: Testing support on traces endpoint
     Scenario: The traces endpoint can accept json payloads
         # A sampling trace
         When I send a "sampling-trace"-type request
-        Then I wait to receive a trace
+        Then I wait to receive a pvalue
         And The HTTP response header "Bugsnag-Sampling-Probability" equals "1"
-        And I discard the oldest trace
+        And I discard the oldest pvalue
 
         # A mobile trace
         Then I send a "trace"-type request

--- a/test/fixtures/payload-helpers/features/traces_support.feature
+++ b/test/fixtures/payload-helpers/features/traces_support.feature
@@ -3,9 +3,9 @@ Feature: Testing support on traces endpoint
     Scenario: The traces endpoint can accept json payloads
         # A sampling trace
         When I send a "sampling-trace"-type request
-        Then I wait to receive a pvalue
+        Then I wait to receive a p_value
         And The HTTP response header "Bugsnag-Sampling-Probability" equals "1"
-        And I discard the oldest pvalue
+        And I discard the oldest p_value
 
         # A mobile trace
         Then I send a "trace"-type request


### PR DESCRIPTION
## Goal

Store trace sampling requests in their own list, allowing them to be inspected separately and avoiding flakes caused by race conditions between the receipt of them and regular trace requests.

## Design

The `Servlet` has been refactored slightly allowing the `TraceServlet` to put received requests into the appropriate list.

A custom Cucumber parameter type of `request_type` has been created, allowing arguments to have space in them without using speech marks (this can't be done with either `{word}` or `{string}` parameters).

## Documentation

Upgrading guide updated.

## Tests

CI tests updated and I've also updated the entire set of `bugsnag-android-performance` tests to run against it.