### PR TITLE
Only enforce integrity header for sessions, errors and traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.30.2 - 2023/05/18
+
+## Fixes
+
+- Only enforce Bugsnag integrity header on session, error and trace requests [539](https://github.com/bugsnag/maze-runner/pull/539)
+
 # 7.30.1 - 2023/05/13
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.30.1)
+    bugsnag-maze-runner (7.30.2)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.30.1'
+  VERSION = '7.30.2'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -170,8 +170,9 @@ module Maze
       # if configuration says so.
       def check_digest(request)
         header = request['Bugsnag-Integrity']
-        if header.nil? && Maze.config.enforce_bugsnag_integrity
-          raise 'Bugsnag-Integrity header must be present according to Maze.config.enforce_bugsnag_integrity'
+
+        if header.nil? && Maze.config.enforce_bugsnag_integrity && %i[sessions errors traces].include?(@request_type)
+          raise "Bugsnag-Integrity header must be present for #{@request_type} according to Maze.config.enforce_bugsnag_integrity"
         end
         return if header.nil?
 


### PR DESCRIPTION
## Goal

Avoid surprising failures to collect requests by only enforcing the `Bugsnag-Integrity` header on session, error and trace requests.

## Tests

Ran a quick test locally using the payload helper tests and some temporary debug code to show which request types were being enforced.