### PR TITLE
Reword header checking steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Upgrade Docker image to Ruby 3 [534](https://github.com/bugsnag/maze-runner/pull/534)
 - Update logger to provide a real TRACE level [536](https://github.com/bugsnag/maze-runner/pull/536)
 - Filter sampling requests into their own `RequestList` [537](https://github.com/bugsnag/maze-runner/pull/537)
-
+- Reword header to `is present` rather than `is null` [540](https://github.com/bugsnag/maze-runner/pull/540)
 
 <!---
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,6 +19,15 @@ With this change, the step `I receive and discard the initial p-value request` i
 
 The `VERBOSE` environment variable no longer has any effect on the log level.  Use `TRACE` or `DEBUG` for the two log levels.
 
+### Cucumber steps
+
+The following Cucumber steps have been reworded:
+
+Removed step | Replacement
+---|---|
+`the {request_type} {string} header is not null` | `the {request_type} {string} header is present`
+`the {request_type} {string} header is null` | `the {request_type} {string} header is not present`
+
 ## v6 to v7
 
 Support for Sauce Labs has been removed as we are no longer able to test it.

--- a/lib/features/steps/header_steps.rb
+++ b/lib/features/steps/header_steps.rb
@@ -6,20 +6,24 @@
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
-Then('the {request_type} {string} header is not null') do |request_type, header_name|
+Then('the {request_type} {string} header is present') do |request_type, header_name|
   Maze.check.not_nil(Maze::Server.list_for(request_type).current[:request][header_name],
                      "The #{request_type} '#{header_name}' header should not be null")
+
+  request = Maze::Server.list_for(request_type).current[:request]
+  Maze.check.true(request.header.key?(header_name.downcase),
+                  "The #{request_type} '#{header_name}' header should be present")
 end
 
 # Tests that a request header is null
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)
 # @step_input header_name [String] The header to test
-Then('the {request_type} {string} header is null') do |request_type, header_name|
+Then('the {request_type} {string} header is not present') do |request_type, header_name|
   request = Maze::Server.list_for(request_type).current[:request]
 
-  Maze.check.nil(request[header_name],
-                 "The #{request_type} '#{header_name}' header should be null")
+  Maze.check.false(request.header.key?(header_name.downcase),
+                   "The #{request_type} '#{header_name}' header should not be present")
 end
 
 # Tests that request header equals a string

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -89,18 +89,11 @@ end
 
 # Assert that the test Server hasn't received any requests - of a specific, or any, type.
 #
-# @step_input request_type [String] The type of request ('error', 'session', build, etc), or 'requests' to assert on all
-#   request types.
+# @step_input request_type [String] The type of request ('error', 'session', 'trace', sampling request', etc)
 Then('I should receive no {request_type}') do |request_type|
   sleep Maze.config.receive_no_requests_wait
-  if request_type == 'requests'
-    # Assert that the test Server hasn't received any requests at all.
-    Maze.check.equal(0, Maze::Server.errors.size_remaining, "#{Maze::Server.errors.size_remaining} errors received")
-    Maze.check.equal(0, Maze::Server.sessions.size_remaining, "#{Maze::Server.sessions.size_remaining} sessions received")
-  else
-    list = Maze::Server.list_for(request_type)
-    Maze.check.equal(0, list.size_remaining, "#{list.size_remaining} #{request_type} received")
-  end
+  list = Maze::Server.list_for(request_type)
+  Maze.check.equal(0, list.size_remaining, "#{list.size_remaining} #{request_type} received")
 end
 
 # Moves to the next request

--- a/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
+++ b/test/fixtures/payload-helpers/features/compare_requests_json_fixtures.feature
@@ -4,6 +4,8 @@ Feature: Testing helper methods respond correctly
         When I send a "payload"-type request
         Then I wait to receive an error
         And the error is valid for the error reporting API version "4.0" for the "Maze-runner" notifier
+        And the error "Content-Type" header is present
+        And the error "Made-Up" header is not present
 
     Scenario: The request body matches an expected session payload
         When I send a "session"-type request


### PR DESCRIPTION
## Goal

A slightly pedantic clarification that the steps verify that the header is present/not present at all, as opposed to being present with some null value.

## Tests

CI tests updated.  I also checked that the steps fail as expected by modifying the scenarios locally.