### PR TITLE
Add warning for slow receipt of messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.31.0 - 2023/05/19
+
+- Add `Maze.config.receive_requests_slow_threshold` to warn for slow receipt of requests [531](https://github.com/bugsnag/maze-runner/pull/531)
+
 # 7.30.2 - 2023/05/18
 
 ## Fixes

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -19,10 +19,12 @@ def assert_received_requests(request_count, list, list_name, precise = true)
   received = wait.until do
 
     count_now = list.size_remaining
-    if count_now > last_count
-      $logger.info "Received #{count_now - last_count} requests after #{Time.now - start_time}"
+    elapsed = Time.now - start_time
+    if elapsed > Maze.config.receive_requests_slow_threshold
+      if count_now > last_count
+        $logger.warn "Received #{count_now - last_count} request(s) after #{elapsed.round(1)}s"
+      end
     end
-
     count_now >= request_count
   end
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.30.2'
+  VERSION = '7.31.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -8,6 +8,7 @@ module Maze
     def initialize
       self.receive_no_requests_wait = 30
       self.receive_requests_wait = 30
+      self.receive_requests_slow_threshold = 10
       self.enforce_bugsnag_integrity = true
       self.captured_invalid_requests = Set[:errors, :sessions, :builds, :uploads, :sourcemaps]
       @legacy_driver = false
@@ -48,6 +49,9 @@ module Maze
 
     # Maximum time in seconds to wait in the `I wait to receive {int} error(s)/session(s)/build(s)` steps
     attr_accessor :receive_requests_wait
+
+    # Time after which requests are deemed to be slow to be received and a warning is logged for
+    attr_accessor :receive_requests_slow_threshold
 
     # Whether presence of the Bugsnag-Integrity header should be enforced
     attr_accessor :enforce_bugsnag_integrity

--- a/lib/maze/wait.rb
+++ b/lib/maze/wait.rb
@@ -4,8 +4,8 @@ module Maze
   # Allows repeated attempts at something, until it is successful or the timeout
   # is exceed
   class Wait
-    # @param interval [Numeric] Optional. The time to sleep between attempts
-    # @param timeout [Numeric] The amount of time to spend on attempts before giving up
+    # @param interval [Float] Optional. The time to sleep between attempts
+    # @param timeout [Integer] The amount of time to spend on attempts before giving up
     def initialize(interval: 0.1, timeout:)
       raise "Interval must be greater than zero, got '#{interval}'" unless interval > 0
       raise "Timeout (#{timeout}) must be greater than interval (#{interval})" unless timeout > interval

--- a/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/test/fixtures/android-appium-test/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -4,6 +4,8 @@ import android.os.Build
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
 import android.widget.Button
@@ -14,6 +16,7 @@ import java.lang.Exception
 import java.lang.Thread
 import java.net.URL
 import kotlin.concurrent.thread
+import kotlin.random.Random
 import org.json.JSONObject
 import org.json.JSONTokener
 
@@ -33,7 +36,12 @@ class MainActivity : AppCompatActivity() {
 
             val metadata = findViewById<EditText>(R.id.metadata).text.toString()
             val text = if (metadata == "") "HandledException!" else metadata
-            Bugsnag.notify(Exception(text))
+
+            // Add a random delay to test the warning of slow messages
+            val delay = Random.nextLong(0, 5000)
+            Handler(Looper.getMainLooper()).postDelayed({
+                Bugsnag.notify(Exception(text))
+            }, delay)
         }
 
         // Run command button

--- a/test/fixtures/android-appium-test/features/support/env.rb
+++ b/test/fixtures/android-appium-test/features/support/env.rb
@@ -2,4 +2,6 @@ BeforeAll do
   $api_key = '12312312312312312312312312312312'
   ENV['BUGSNAG_API_KEY'] = $api_key
   Maze.config.enforce_bugsnag_integrity = false
+  # Deliberately low threshold to test the warning
+  Maze.config.receive_requests_slow_threshold = 1
 end


### PR DESCRIPTION
## Goal

Log a warning when requests are received slower than a configured threshold.

## Design

Updates the `I wait to receive {int} {word}` and `I wait to receive at least {int} {word}` steps to log a warning if any requests are received after a configured threshold.

## Changeset

Adds a new code-only (not command line) config option of `Maze.config.receive_requests_slow_threshold`, defaulting to 10 seconds.

## Tests

Covered by manual inspect of the logs on CI.