### PR TITLE
Output received traces when scenario fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Fixes
 
-- Output received traces to stdout when a scenario fails [5xx](https://github.com/bugsnag/maze-runner/pull/5xx)
+- Output received traces to stdout when a scenario fails [543](https://github.com/bugsnag/maze-runner/pull/543)
 
 # 7.32.0 - 2023/05/19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.32.1 - TBD
+
+## Fixes
+
+- Output received traces to stdout when a scenario fails [5xx](https://github.com/bugsnag/maze-runner/pull/5xx)
+
 # 7.32.0 - 2023/05/19
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.32.0)
+    bugsnag-maze-runner (7.32.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -145,6 +145,7 @@ After do |scenario|
     $stdout.puts '^^^ +++'
     output_received_requests('errors')
     output_received_requests('sessions')
+    output_received_requests('traces')
     output_received_requests('builds')
     output_received_requests('logs')
     output_received_requests('invalid requests')

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.32.0'
+  VERSION = '7.32.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

Output the traces that were received to stdout when a scenario fails on CI.

## Design

We do his for all other request types, it just got missed when traces were added.

## Tests

Tested locally by artificially causing a scenario to fail and setting `BUILDKITE=1`.