### PR TITLE
Add JS performance required BS devices to driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Enhancements
+
+- Add iOS 16 and an up to date Android device browsers to the available BS devices [544](https://github.com/bugsnag/maze-runner/pull/544)
+
 # 7.32.0 - 2023/05/19
 
 ## Enhancements

--- a/lib/maze/client/selenium/bs_browsers.yml
+++ b/lib/maze/client/selenium/bs_browsers.yml
@@ -131,6 +131,13 @@ iphone_13:
   osVersion: "15.4"
   realMobile: true
 
+iphone_14:
+  browserName: "iphone"
+  device: "iPhone 14"
+  os: "ios"
+  osVersion: "16"
+  realMobile: true
+
 android_nexus5:
   browserName: "Android Browser"
   device: "Google Nexus 5"

--- a/lib/maze/client/selenium/bs_browsers.yml
+++ b/lib/maze/client/selenium/bs_browsers.yml
@@ -166,6 +166,13 @@ android_s8:
   osVersion: "7.0"
   realMobile: true
 
+android_pixel_7:
+  browserName: "Android Browser"
+  device: "Google Pixel 7"
+  os: "android"
+  osVersion: "13.0"
+  realMobile: true
+
 firefox_30:
   browserName: "firefox"
   browserVersion: "30"


### PR DESCRIPTION
## Goal

Adds two devices required for testing JS performance to the BS driver:
- iphone_14, providing iOS 16
- Pixel 7, providing an up-to-date chrome driver

This _doesn't_ add an iOS 11 device, as that is already covered by the `iphone_x` device.

(Thoughts on changing the naming convention as a v8 release feature (in a separate PR)?  I was thinking just changing them to the OS version, so `iphone_14` just becomes `iOS_16` etc)