### PR TITLE
Rename BrowserStack mobile browsers to OS and version format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Filter sampling requests into their own `RequestList` [537](https://github.com/bugsnag/maze-runner/pull/537)
 - Shorten BrowserStack Android device names for consistency [538](https://github.com/bugsnag/maze-runner/pull/538)
 - Reword header to `is present` rather than `is null` [540](https://github.com/bugsnag/maze-runner/pull/540)
+- Rename BrowserStack mobile browsers to OS and version format
 
 <!---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Filter sampling requests into their own `RequestList` [537](https://github.com/bugsnag/maze-runner/pull/537)
 - Shorten BrowserStack Android device names for consistency [538](https://github.com/bugsnag/maze-runner/pull/538)
 - Reword header to `is present` rather than `is null` [540](https://github.com/bugsnag/maze-runner/pull/540)
-- Rename BrowserStack mobile browsers to OS and version format
+- Rename BrowserStack mobile browsers to OS and version format [545](https://github.com/bugsnag/maze-runner/pull/545)
 
 <!---
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,6 +23,8 @@ The `VERBOSE` environment variable no longer has any effect on the log level.  U
 
 The names for each Android device on BrowserStack have been shortened, e.g. ANDROID_10_0 becomes ANDROID_10.  This is for consistency with BrowserStack iOS devices and BitBar device groups.  Run `bundle exec maze-runner --farm=bs --list-devices` for a full list of options.
 
+In addition, browsers running on mobile devices are now named after the OS and version, e.g. `android_nexus5` becomes `android_4`.  This should make the desired device/browser combination more obvious in future.
+
 ### Cucumber steps
 
 The following Cucumber steps have been reworded:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,6 +25,20 @@ The names for each Android device on BrowserStack have been shortened, e.g. ANDR
 
 In addition, browsers running on mobile devices are now named after the OS and version, e.g. `android_nexus5` becomes `android_4`.  This should make the desired device/browser combination more obvious in future.
 
+Changed names:
+
+- iphone_6s       -> ios_9
+- iphone_7        -> ios_10
+- iphone_x        -> ios_11
+- iphone_xs       -> ios_12
+- iphone_13       -> ios_15
+- iphone_14       -> ios_16
+- android_nexus5  -> android_4
+- android_s6      -> android_5
+- android_s7      -> android_6
+- android_s8      -> android_7
+- android_pixel_7 -> android_13
+
 ### Cucumber steps
 
 The following Cucumber steps have been reworded:

--- a/lib/maze/client/selenium/bs_browsers.yml
+++ b/lib/maze/client/selenium/bs_browsers.yml
@@ -96,77 +96,77 @@ safari_16:
   os: "OS X"
   osVersion: "Ventura"
 
-iphone_6s:
+ios_9:
   browserName: "iphone"
   device: "iPhone 6S"
   os: "ios"
   osVersion: "9.0"
   realMobile: true
 
-iphone_7:
+ios_10:
   browserName: "iphone"
   device: "iPhone 7"
   os: "ios"
   osVersion: "10.3"
   realMobile: true
 
-iphone_x:
+ios_11:
   browserName: "iphone"
   device: "iPhone X"
   os: "ios"
   osVersion: "11"
   realMobile: true
 
-iphone_xs:
+ios_12:
   browserName: "iphone"
   device: "iPhone XS"
   os: "ios"
   osVersion: "12"
   realMobile: true
 
-iphone_13:
+ios_15:
   browserName: "iphone"
   device: "iPhone 13"
   os: "ios"
   osVersion: "15.4"
   realMobile: true
 
-iphone_14:
+ios_16:
   browserName: "iphone"
   device: "iPhone 14"
   os: "ios"
   osVersion: "16"
   realMobile: true
 
-android_nexus5:
+android_4:
   browserName: "Android Browser"
   device: "Google Nexus 5"
   os: "android"
   osVersion: "4.4"
   realMobile: true
 
-android_s6:
+android_5:
   browserName: "Android Browser"
   device: "Samsung Galaxy S6"
   os: "android"
   osVersion: "5.0"
   realMobile: true
 
-android_s7:
+android_6:
   browserName: "Android Browser"
   device: "Samsung Galaxy S7"
   os: "android"
   osVersion: "6.0"
   realMobile: true
 
-android_s8:
+android_7:
   browserName: "Android Browser"
   device: "Samsung Galaxy S8 Plus"
   os: "android"
   osVersion: "7.0"
   realMobile: true
 
-android_pixel_7:
+android_13:
   browserName: "Android Browser"
   device: "Google Pixel 7"
   os: "android"


### PR DESCRIPTION
## Goal

To make it clearer which devices and versions are being targeted when running tests on mobile browsers, the existing browsers have been renamed to an `os_version` format.
