### PR TITLE
Expand Scenario Outlines by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Shorten BrowserStack Android device names for consistency [538](https://github.com/bugsnag/maze-runner/pull/538)
 - Reword header to `is present` rather than `is null` [540](https://github.com/bugsnag/maze-runner/pull/540)
 - Rename BrowserStack mobile browsers to OS and version format [545](https://github.com/bugsnag/maze-runner/pull/545)
-- Set `--expand` Cucumber option by default [5](https://github.com/bugsnag/maze-runner/pull/5)
+- Set `--expand` Cucumber option by default [548](https://github.com/bugsnag/maze-runner/pull/548)
 
 <!---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Shorten BrowserStack Android device names for consistency [538](https://github.com/bugsnag/maze-runner/pull/538)
 - Reword header to `is present` rather than `is null` [540](https://github.com/bugsnag/maze-runner/pull/540)
 - Rename BrowserStack mobile browsers to OS and version format [545](https://github.com/bugsnag/maze-runner/pull/545)
+- Set `--expand` Cucumber option by default [5](https://github.com/bugsnag/maze-runner/pull/5)
 
 <!---
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.0.0.pre.rc2)
+    bugsnag-maze-runner (8.0.0.pre.rc3)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -117,6 +117,15 @@ class MazeRunnerEntry
       @args << '--strict-undefined' << '--strict-pending' << '--no-strict-flaky'
     end
 
+    # Expand by default
+    if @args.include?('--no-expand')
+      # Just remove it
+      @args = @args - ["--no-expand"]
+    else
+      # Expand
+      @args << "--expand"
+    end
+
     # Load internal steps and helper functions
     load_dir = File.expand_path(File.dirname(File.dirname(__FILE__))).freeze
     paths = Dir.glob("#{load_dir}/lib/features/**/*.rb")

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.0.0-rc2'
+  VERSION = '8.0.0-rc3'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -22,6 +22,9 @@ module Maze
                 'Print this help.'
             opt :version,
                 'Display Maze Runner and Cucumber versions'
+            opt :expand,
+                'Output for Scenario Outlines is expanded by default, suppress using --no-expand',
+            short: :none
 
             text ''
             text 'General options:'


### PR DESCRIPTION
## Goal

Set the `--expand` Cucumber option by default, causing `Scenario Outline`s to be written out in full, as opposed to a single line for each instance of the scenario.

## Tests

Tested locally by supplying each option on the command line - `--expand`, `--no-expand` and neither.