### PR TITLE
Remove speech marks from status codes list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Reword header to `is present` rather than `is null` [540](https://github.com/bugsnag/maze-runner/pull/540)
 - Rename BrowserStack mobile browsers to OS and version format [545](https://github.com/bugsnag/maze-runner/pull/545)
 - Set `--expand` Cucumber option by default [548](https://github.com/bugsnag/maze-runner/pull/548)
+- Avoid the need for quotes around integer lists [550](https://github.com/bugsnag/maze-runner/pull/550)
 
 <!---
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -47,6 +47,7 @@ Removed step | Replacement
 ---|---|
 `the {request_type} {string} header is not null` | `the {request_type} {string} header is present`
 `the {request_type} {string} header is null` | `the {request_type} {string} header is not present`
+`I set the HTTP status code for the next {string} requests to {string}` | `I set the HTTP status code for the next {string} requests to {int_array}`
 
 ## v6 to v7
 

--- a/lib/features/steps/network_steps.rb
+++ b/lib/features/steps/network_steps.rb
@@ -12,10 +12,9 @@ end
 #
 # @step_input http_verb [String] The type of request this code will be used for
 # @step_input status_codes [String] A comma separated list of status codes to return
-When('I set the HTTP status code for the next {string} requests to {string}') do |http_verb, status_codes|
+When('I set the HTTP status code for the next {string} requests to {int_array}') do |http_verb, status_codes|
   raise("Invalid HTTP verb: #{http_verb}") unless Maze::Server::ALLOWED_HTTP_VERBS.include?(http_verb)
-  codes = status_codes.split(',').map(&:strip)
-  Maze::Server.set_status_code_generator(create_defaulting_generator(codes, Maze::Server::DEFAULT_STATUS_CODE), http_verb)
+  Maze::Server.set_status_code_generator(create_defaulting_generator(status_codes, Maze::Server::DEFAULT_STATUS_CODE), http_verb)
 end
 
 # Sets the HTTP status code to be used for all subsequent requests for a given connection type
@@ -53,8 +52,8 @@ end
 # Sets the HTTP status code to be used for the next set of POST requests
 #
 # @step_input status_codes [String] A comma separated list of status codes to return
-When('I set the HTTP status code for the next requests to {string}') do |status_codes|
-  step %{I set the HTTP status code for the next "POST" requests to "#{status_codes}"}
+When('I set the HTTP status code for the next requests to {int_array}') do |status_codes|
+  step %{I set the HTTP status code for the next "POST" requests to #{status_codes.join ','}}
 end
 
 # Sets the sampling probability to be used for all subsequent trace responses

--- a/lib/features/support/cucumber_types.rb
+++ b/lib/features/support/cucumber_types.rb
@@ -9,5 +9,5 @@ ParameterType(
   name:        'int_array',
   regexp:      /\d+(?:, ?\d+)+/,
   type:        String,
-  transformer: ->(s) { s.split(',').map(&:strip) }
+  transformer: ->(s) { s.split(',').map(&:strip).map(&:to_i) }
 )

--- a/lib/features/support/cucumber_types.rb
+++ b/lib/features/support/cucumber_types.rb
@@ -4,3 +4,10 @@ ParameterType(
   type:        String,
   transformer: ->(s) { s }
 )
+
+ParameterType(
+  name:        'int_array',
+  regexp:      /\d+(?:, ?\d+)+/,
+  type:        String,
+  transformer: ->(s) { s.split(',').map(&:strip) }
+)

--- a/test/fixtures/http-response/features/set_different_responses.feature
+++ b/test/fixtures/http-response/features/set_different_responses.feature
@@ -36,7 +36,7 @@ Feature: Setting different response codes
         And the error payload field "second_code" equals "200"
 
     Scenario: Server response code can be set for multiple requests
-        Given I set the HTTP status code for the next requests to "501,502"
+        Given I set the HTTP status code for the next requests to 501,502
         When I run the script "features/scripts/send_four_requests.rb" using ruby synchronously
         And I wait to receive 4 errors
         Then the error payload field "req" equals "first!"
@@ -84,7 +84,7 @@ Feature: Setting different response codes
         And the error payload field "second_post_code" equals "200"
 
     Scenario: A list of codes without a verb defaults to POST requests
-        Given I set the HTTP status code for the next requests to "501,502"
+        Given I set the HTTP status code for the next requests to 501,502
         And I run the script "features/scripts/send_verbed_requests.rb" using ruby synchronously
         And I wait to receive 3 errors
         Then the error payload field "first_options_code" equals "200"


### PR DESCRIPTION
## Goal

Avoid the need for speech marks around the list of status codes, making it consistent with the Cucumber steps that accept 
just a single integer.

## Documentation

UPGRADING guide updated.

## Tests

Covered by CI.