### PR TITLE
Guard against Maze.driver.unlock raising and error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Correct capability for Chrome 43 on BitBar [556](https://github.com/bugsnag/maze-runner/pull/556)
+- Prevent `Maze.driver.unlock` from raising an error [557](https://github.com/bugsnag/maze-runner/pull/557)
 
 # 8.0.1 - 2023/06/14
 

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -22,8 +22,13 @@ module Maze
                                when 'ios'
                                  Maze.driver.session_capabilities['CFBundleIdentifier'] # Present on BS and locally
                                end
+
           # Ensure the device is unlocked
-          Maze.driver.unlock
+          begin
+            Maze.driver.unlock
+          rescue => e
+            $logger.warn "Failed to unlock device: #{e}"
+          end
 
           log_run_intro
         end

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -132,8 +132,6 @@ module Maze
       # Unlocks the device
       def unlock
         @driver.unlock
-      rescue StandardError => e
-        $logger.warn "Failed to unlock device: #{e}"
       end
 
       # Sends keys to a given element

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -132,6 +132,8 @@ module Maze
       # Unlocks the device
       def unlock
         @driver.unlock
+      rescue StandardError => e
+        $logger.warn "Failed to unlock device: #{e}"
       end
 
       # Sends keys to a given element


### PR DESCRIPTION
## Goal

Prevent failed calls to `Maze.driver.unlock` from crashing Maze Runner.

## Tests

Tested locally using bugsnag-cocoa with iOS 11 and the legacy driver mode (which found the issue).