### PR TITLE
Fix and improve logging of received requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.1.0 - 2023/06/16
+
+## Enhancements
+
+- Fixes and enhancements to logging of received requests [558](https://github.com/bugsnag/maze-runner/pull/558)
+
 # 8.0.2 - 2023/06/15
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.0.2)
+    bugsnag-maze-runner (8.1.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -176,7 +176,19 @@ def output_received_requests(request_type)
     $logger.info "#{count} #{request_type} were received:"
     request_queue.all.each.with_index(1) do |request, number|
       $stdout.puts "--- #{request_type} #{number} of #{count}"
-      Maze::LogUtil.log_hash(Logger::Severity::INFO, request)
+
+      $logger.info 'Request body:'
+      Maze::LogUtil.log_hash(Logger::Severity::INFO, request[:body])
+
+      $logger.info 'Request headers:'
+      Maze::LogUtil.log_hash(Logger::Severity::INFO, request[:request].header)
+
+      $logger.info 'Request digests:'
+      Maze::LogUtil.log_hash(Logger::Severity::INFO, request[:digests])
+
+      $logger.info "Response body: #{request[:response].body}"
+      $logger.info 'Response headers:'
+      Maze::LogUtil.log_hash(Logger::Severity::INFO, request[:response].header)
     end
   end
 end

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.0.2'
+  VERSION = '8.1.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/logger.rb
+++ b/lib/maze/logger.rb
@@ -79,7 +79,8 @@ module Maze
             log_hash_by_field severity, data
           end
         rescue Encoding::UndefinedConversionError
-          log_hash_by_field severity, data
+          # Just give up, we don't want to risk a further error trying to log garbage
+          $logger.error 'Unable to log hash as JSON'
         end
       end
 

--- a/lib/maze/maze_output.rb
+++ b/lib/maze/maze_output.rb
@@ -26,6 +26,8 @@ module Maze
         File.open(filepath, 'w+') do |file|
           list.each do |request|
             file.puts "=== Request #{counter} of #{list.size} ==="
+            file.puts
+
             if request[:invalid]
               invalid_request = true
               uri = request[:request][:request_uri]
@@ -37,13 +39,18 @@ module Maze
               headers = request[:request].header
               body = request[:body]
             end
+
             file.puts "URI: #{uri}"
-            file.puts "HEADERS:"
+            file.puts
+
+            # Request
+            file.puts "Request:"
             headers.each do |key, values|
               file.puts "  #{key}: #{values.map {|v| "'#{v}'"}.join(' ')}"
             end
             file.puts
-            file.puts "BODY:"
+
+            file.puts "Request body:"
             if !invalid_request && headers["content-type"].first == 'application/json'
               file.puts JSON.pretty_generate(body)
             else
@@ -55,6 +62,22 @@ module Maze
               file.puts request[:reason]
               file.puts
             end
+            file.puts
+
+            file.puts "Digests:"
+            file.puts JSON.pretty_generate(request[:digests])
+            file.puts
+
+            # Response
+            response = request[:response]
+            file.puts "Response headers:"
+            file.puts JSON.pretty_generate(request[:digests])
+            file.puts
+
+            file.puts "Response body: #{response.body}"
+            file.puts
+            file.puts
+
             counter += 1
           end
         end

--- a/lib/maze/maze_output.rb
+++ b/lib/maze/maze_output.rb
@@ -64,7 +64,7 @@ module Maze
             end
             file.puts
 
-            file.puts "Digests:"
+            file.puts "Request digests:"
             file.puts JSON.pretty_generate(request[:digests])
             file.puts
 

--- a/lib/maze/maze_output.rb
+++ b/lib/maze/maze_output.rb
@@ -71,7 +71,7 @@ module Maze
             # Response
             response = request[:response]
             file.puts "Response headers:"
-            file.puts JSON.pretty_generate(request[:digests])
+            file.puts JSON.pretty_generate(response.header)
             file.puts
 
             file.puts "Response body: #{response.body}"

--- a/lib/maze/servlets/log_servlet.rb
+++ b/lib/maze/servlets/log_servlet.rb
@@ -22,7 +22,8 @@ module Maze
       def do_POST(request, response)
         hash = {
           body: JSON.parse(request.body),
-          request: request
+          request: request,
+          response: response
         }
         @requests.add(hash)
 
@@ -34,6 +35,7 @@ module Maze
         Server.invalid_requests.add({
           reason: msg,
           request: request,
+          response: response,
           body: request.body
         })
       rescue StandardError => e
@@ -45,7 +47,8 @@ module Maze
             request_uri: request.request_uri,
             header: request.header.to_h,
             body: request.inspect
-          }
+          },
+          response: response
         })
       end
 

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -62,7 +62,7 @@ module Maze
         @bugsnag_repeater.repeat request
 
         # Turn the WEBrick HttpRequest into our internal HttpRequest delegate
-        request = HttpRequest.new(request)
+        request = Maze::HttpRequest.new(request)
 
         content_type = request['Content-Type']
         if %r{^multipart/form-data; boundary=([^;]+)}.match(content_type)
@@ -70,7 +70,8 @@ module Maze
           body = WEBrick::HTTPUtils.parse_form_data(request.body, boundary)
           hash = {
             body: body,
-            request: request
+            request: request,
+            response: response
           }
         else
           # "content-type" is assumed to be JSON (which mimics the behaviour of
@@ -80,6 +81,7 @@ module Maze
           hash = {
             body: JSON.parse(request.body),
             request: request,
+            response: response,
             digests: digests
           }
         end


### PR DESCRIPTION
## Goal

Fixes a crash when trying to log gzipped trace requests, as well as making general improvements to the logging of requests.

## Design

Previous we tried to log the whole raw request in addition to the JSON formatted payload.  This failed for gzipped payloads, as the `request.body` was still in its binary form, but really logged the raw request wasn't that useful anyway.  Instead I've opted for logging specific fields within it, meaning we have more control of what is being logged.

Responses sent back from Maze Runner are now stored in the `RequestList`, allow us to log their headers and bodies too.

## Tests

Tested locally, inspecting the `maze_output` contents and by forcing failures in a couple of pipelines:
[Android Performance (traces)](https://buildkite.com/bugsnag/bugsnag-android-performance/builds/999#0188c486-b214-4f34-9d93-a51f4373a0d6/461)
[Unity (errors)](https://buildkite.com/bugsnag/bugsnag-unity/builds/3974#0188c478-f1b6-434f-979e-a0efe29a8708)
 