### PR TITLE
Update the delete method for purging projects on bitbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Fix order of assertion parameters [559](https://github.com/bugsnag/maze-runner/pull/559)
+- Fix delete project function in `purge-projects` command [560](https://github.com/bugsnag/maze-runner/pull/560)
 
 # 8.1.0 - 2023/06/16
 

--- a/lib/maze/client/bb_api_client.rb
+++ b/lib/maze/client/bb_api_client.rb
@@ -111,7 +111,7 @@ module Maze
       end
 
       def delete_project (id)
-        response = query_api "projects/#{id}"
+        response = query_api "projects/#{id}", nil, USER_SPECIFIC_URI, "delete"
       end
 
       private


### PR DESCRIPTION
## Goal

Add the `delete` method to the API request within the `delete_project` function

## Tests

Built and tested locally