### PR TITLE
Set a sensible timeout for BitBar Appium sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.33.1 - 2023/06/22
+
+## Fixes
+
+- Sensible timeout for BitBar Appium sessions [563](https://github.com/bugsnag/maze-runner/pull/563)
+
 # 7.33.0 - 2023/05/25
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (7.33.0)
+    bugsnag-maze-runner (7.33.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '7.33.0'
+  VERSION = '7.33.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -29,7 +29,7 @@ module Maze
           prefix = BitBarDevices.caps_prefix(config.appium_version)
           capabilities = {
             "#{prefix}noReset" => true,
-            "#{prefix}newCommandTimeout" => 0,
+            "#{prefix}newCommandTimeout" => 600,
             'bitbar:options' => {
               # Some capabilities probably belong in the top level
               # of the hash, but BitBar picks them up from here.


### PR DESCRIPTION
## Goal

Set a timeout of ten minutes for BitBar Appium sessions if no operation is received.

## Design

There are a couple of reasons why indefinite timeouts are not a good idea:
- Docker containers running on our Buildkite CI instances terminate immediate on cancellation, meaning that cleanup code designed to terminate the Appium session is not invoked.
- The Ruby client can sometimes throw an error when creating a session, but leaving a session running.  Because of the error we don't have a handle on the session to close it.  Hopefully setting this capability will mean that it will take care of itself.

## Tests

Tested using a build of bugsnag-cocoa here: https://buildkite.com/bugsnag/bugsnag-cocoa/builds/6967#_.  I cancelled two steps and observed the concurrent usage the BitBar dashboard drop down after 10 minutes.  I then let the full build run by itself, to be sure that ten minutes is not too short for a normal test run (each scenario should only take a minute or two).