### PR TITLE
Only set HTTP response code for specific request types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Fixes
 
-- Only set HTTP response code for specific request types [564](https://github.com/bugsnag/maze-runner/pull/564)
+- Only set HTTP response code for specific request types [565](https://github.com/bugsnag/maze-runner/pull/565)
 
 # 8.1.1 - 2023/06/22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.1.2 - 2023/06/30
+
+## Fixes
+
+- Only set HTTP response code for specific request types [564](https://github.com/bugsnag/maze-runner/pull/564)
+
 # 8.1.1 - 2023/06/22
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.1.1)
+    bugsnag-maze-runner (8.1.2)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.1.1'
+  VERSION = '8.1.2'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -97,8 +97,9 @@ module Maze
           $logger.info "Waiting #{response_delay_ms} milliseconds before responding"
           sleep response_delay_ms / 1000.0
         end
+
         set_response_header response.header
-        response.status = Server.status_code('POST')
+        response.status = post_status_code
       rescue JSON::ParserError => e
         msg = "Unable to parse request as JSON: #{e.message}"
         if Maze.config.captured_invalid_requests.include? @request_type
@@ -125,6 +126,14 @@ module Maze
           })
         else
           $logger.warn "Invalid request: #{e.message}"
+        end
+      end
+
+      def post_status_code
+        if [:errors, :session, :builds, :uploads, :sourcemaps].include? @request_type
+          Server.status_code('POST')
+        else
+          200
         end
       end
 


### PR DESCRIPTION
## Goal

Only set HTTP response code for specific request types.  In particular, requests sent to `/metrics` should always return 200.

## Tests

Covered by CI and having rerun a test from `bugsnag-unity` that broke when trying to add metrics.