### PR TITLE
Include traces when setting HTTP response codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.1.3 - 2023/07/03
+
+## Fixes
+
+- Include traces in request types to set the HTTP response code for [566](https://github.com/bugsnag/maze-runner/pull/566)
+
 # 8.1.2 - 2023/06/30
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.1.2)
+    bugsnag-maze-runner (8.1.3)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.1.2'
+  VERSION = '8.1.3'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -130,7 +130,7 @@ module Maze
       end
 
       def post_status_code
-        if [:errors, :session, :builds, :uploads, :sourcemaps].include? @request_type
+        if [:errors, :session, :builds, :uploads, :sourcemaps, :traces].include? @request_type
           Server.status_code('POST')
         else
           200


### PR DESCRIPTION
## Goal

Trace requests got missed from #565 .

## Tests

Tested locally using a bugsnag-unity-performance test that found the issue.