### PR TITLE
Add endpoints for bugsnag-cli testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.1.5 - TBD
+
+- Add additional sourcemap endpoints [570](https://github.com/bugsnag/maze-runner/pull/570)
+
 # 8.1.4 - 2023/07/05
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# 8.1.5 - TBD
+# 8.2.0 - 2023/07/18
+
+## Enhancements
 
 - Add additional sourcemap endpoints [570](https://github.com/bugsnag/maze-runner/pull/570)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,8 +118,6 @@ GEM
     minitest (5.18.1)
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.15.3-arm64-darwin)
-      racc (~> 1.4)
     nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
@@ -170,7 +168,6 @@ GEM
     yard (0.9.34)
 
 PLATFORMS
-  arm64-darwin-21
   x86_64-darwin-20
 
 DEPENDENCIES
@@ -184,4 +181,4 @@ DEPENDENCIES
   yard-cucumber!
 
 BUNDLED WITH
-   2.3.18
+   2.4.8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.1.4)
+    bugsnag-maze-runner (8.2.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -118,7 +118,9 @@ GEM
     minitest (5.18.1)
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.15.2-x86_64-darwin)
+    nokogiri (1.15.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -168,6 +170,7 @@ GEM
     yard (0.9.34)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
 
 DEPENDENCIES
@@ -181,4 +184,4 @@ DEPENDENCIES
   yard-cucumber!
 
 BUNDLED WITH
-   2.4.8
+   2.3.18

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.1.5'
+  VERSION = '8.2.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.1.4'
+  VERSION = '8.1.5'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -215,9 +215,12 @@ module Maze
             server.mount '/sessions', Servlets::Servlet, :sessions
             server.mount '/builds', Servlets::Servlet, :builds
             server.mount '/uploads', Servlets::Servlet, :uploads
-            server.mount '/sourcemap', Servlets::Servlet, :sourcemaps
             server.mount '/traces', Servlets::TraceServlet, :traces, Maze::Schemas::TRACE_SCHEMA
+            server.mount '/sourcemap', Servlets::Servlet, :sourcemaps
             server.mount '/react-native-source-map', Servlets::Servlet, :sourcemaps
+            server.mount '/dart-symbol', Servlets::Servlet, :sourcemaps
+            server.mount '/ndk-symbol', Servlets::Servlet, :sourcemaps
+            server.mount '/proguard', Servlets::Servlet, :sourcemaps
             server.mount '/command', Servlets::CommandServlet
             server.mount '/logs', Servlets::LogServlet
             server.mount '/metrics', Servlets::Servlet, :metrics

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -46,6 +46,9 @@ module Maze
       mock_http_server.expects(:mount).with('/sourcemap', any_parameters).once
       mock_http_server.expects(:mount).with('/traces', any_parameters).once
       mock_http_server.expects(:mount).with('/react-native-source-map', any_parameters).once
+      mock_http_server.expects(:mount).with('/dart-symbol', any_parameters).once
+      mock_http_server.expects(:mount).with('/ndk-symbol', any_parameters).once
+      mock_http_server.expects(:mount).with('/proguard', any_parameters).once
       mock_http_server.expects(:mount).with('/command', any_parameters).once
       mock_http_server.expects(:mount).with('/logs', any_parameters).once
       mock_http_server.expects(:mount).with('/reflect', any_parameters).once
@@ -92,6 +95,9 @@ module Maze
       mock_http_server.expects(:mount).with('/sourcemap', any_parameters).once
       mock_http_server.expects(:mount).with('/traces', any_parameters).once
       mock_http_server.expects(:mount).with('/react-native-source-map', any_parameters).once
+      mock_http_server.expects(:mount).with('/dart-symbol', any_parameters).once
+      mock_http_server.expects(:mount).with('/ndk-symbol', any_parameters).once
+      mock_http_server.expects(:mount).with('/proguard', any_parameters).once
       mock_http_server.expects(:mount).with('/logs', any_parameters).once
       mock_http_server.expects(:mount).with('/reflect', any_parameters).once
       mock_http_server.expects(:mount).with('/command', any_parameters).once


### PR DESCRIPTION
## Goal

Add additional sourcemaps endpoints so that we can use MazeRunner to test the Bugsnag CLI.

## Changeset

Add the following endpoints to the mock server:
`/dart-symbol`
`/ndk-symbol`
`/proguard`

## Tests

Updated tests, covered by CI