### PR TITLE
Fix bug in #571

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Add received span steps to allow greater flexibility in performance tests [571](https://github.com/bugsnag/maze-runner/pull/571)
+- Add received span steps to allow greater flexibility in performance tests [571](https://github.com/bugsnag/maze-runner/pull/571) [572](https://github.com/bugsnag/maze-runner/pull/572)
 
 # 8.2.0 - 2023/07/19
 

--- a/lib/features/steps/deprecated_steps.rb
+++ b/lib/features/steps/deprecated_steps.rb
@@ -4,5 +4,5 @@
 #
 # @step_input span_count [Integer] The number of spans to wait for
 When('I wait for {int} span(s)') do |span_count|
-  assert_received_spans span_count, Maze::Server.list_for('traces')
+  assert_received_spans Maze::Server.list_for('traces'), span_count
 end


### PR DESCRIPTION
## Goal

Fix bug a bug introduced in #571 due to the order of parameters to the function being changed.

## Tests

We added tests for the new steps in #571, but not the now deprecated step.  I've tested this change use bugsnag-cocoa-performance, which found the problem.
