### PR TITLE
Add validation of trace request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Enhancements
 
 - Add received span steps to allow greater flexibility in performance tests [571](https://github.com/bugsnag/maze-runner/pull/571) [572](https://github.com/bugsnag/maze-runner/pull/572)
-- Check that required trace headers are present and valid [533](https://github.com/bugsnag/maze-runner/pull/533)
+- Check that required trace headers are present and valid [573](https://github.com/bugsnag/maze-runner/pull/573)
 
 # 8.2.0 - 2023/07/19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Add received span steps to allow greater flexibility in performance tests [571](https://github.com/bugsnag/maze-runner/pull/571) [572](https://github.com/bugsnag/maze-runner/pull/572)
+- Check that required trace headers are present and valid [533](https://github.com/bugsnag/maze-runner/pull/533)
 
 # 8.2.0 - 2023/07/19
 

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -47,11 +47,6 @@ module Maze
         )
       end
 
-      def check(date)
-        Date.iso8601(date)
-      rescue Date::Error
-      end
-
       def validate_header(name)
         value = @headers[name]
         if value.nil? || value.size > 1

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -7,7 +7,8 @@ module Maze
 
     HEX_STRING_16 = '^[A-Fa-f0-9]{16}$'
     HEX_STRING_32 = '^[A-Fa-f0-9]{32}$'
-    SAMPLING_HEADER = '^(1(.0)?|0(\.[0-9]+)?):[0-9]+$'
+    SAMPLING_HEADER_ENTRY = '((1(.0)?|0(\.[0-9]+)?):[0-9]+)'
+    SAMPLING_HEADER = "^#{SAMPLING_HEADER_ENTRY}(;#{SAMPLING_HEADER_ENTRY})*$"
 
     # Contains a set of pre-defined validations for ensuring traces are correct
     class TraceValidator

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -67,7 +67,7 @@ module Maze
           expected = Regexp.new(HEX_STRING_32)
           unless expected.match(api_key)
             @success = false
-            @errors << "bugsnag-api-key header was expected to match the regex '#{HEX_STRING_32}', but was '#{value}'"
+            @errors << "bugsnag-api-key header was expected to match the regex '#{HEX_STRING_32}', but was '#{api_key}'"
           end
         end
 

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -7,7 +7,7 @@ module Maze
 
     HEX_STRING_16 = '^[A-Fa-f0-9]{16}$'
     HEX_STRING_32 = '^[A-Fa-f0-9]{32}$'
-    SAMPLING_HEADER = '^(1|0(\.[0-9]+)?):[0-9]+$'
+    SAMPLING_HEADER = '^(1(.0)?|0(\.[0-9]+)?):[0-9]+$'
 
     # Contains a set of pre-defined validations for ensuring traces are correct
     class TraceValidator

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -30,6 +30,8 @@ module Maze
 
       # Runs the validation against the trace given
       def validate
+        @success = true
+
         validate_headers
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.spanId', HEX_STRING_16)
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.traceId', HEX_STRING_32)

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -24,7 +24,7 @@ module Maze
       def initialize(request)
         @headers = request[:request].header
         @body = request[:body]
-        @success = true
+        @success = nil
         @errors = []
       end
 
@@ -91,13 +91,6 @@ module Maze
             end
           end
         end
-      end
-
-      def validate_date(date)
-        Date.iso8601(date)
-      rescue Date::Error
-        @errors << "'#{date}' is not a valid ISO 8601 date string"
-        false
       end
 
       def regex_comparison(path, regex)

--- a/lib/maze/schemas/validator.rb
+++ b/lib/maze/schemas/validator.rb
@@ -49,7 +49,7 @@ module Maze
 
           if validator_class
             validators = list.all.map do |request|
-              validator = validator_class.new(request[:body])
+              validator = validator_class.new(request)
               validator.validate
               validator
             end

--- a/test/fixtures/payload-helpers/features/fixtures/maze-harness/features/scripts/send_trace.sh
+++ b/test/fixtures/payload-helpers/features/fixtures/maze-harness/features/scripts/send_trace.sh
@@ -11,7 +11,11 @@ request['Content-Type'] = 'application/json'
 
 templates = {
   'valid' => {
-    'headers' => {},
+    'headers' => {
+      'Bugsnag-Api-Key' => '12312312312312312313212312312312',
+      'Bugsnag-Sent-At' => Time.now().iso8601(3),
+      'Bugsnag-Span-Sampling' => '1:1'
+    },
     'body' => {
       "resourceSpans":[
         {

--- a/test/fixtures/payload-helpers/features/scripts/send_gzip.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_gzip.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-curl -H 'Content-Encoding: gzip' -H 'Bugsnag-Integrity: sha1 bd1cbbd2ab9b05a96cbb83a6bcac829ff255a9fe' --data-binary @features/fixtures/file.json.gz http://localhost:9339/traces
+curl -H 'Content-Encoding: gzip' -H 'Bugsnag-Integrity: sha1 bd1cbbd2ab9b05a96cbb83a6bcac829ff255a9fe' -H 'Bugsnag-Sent-At: 2023-06-30T08:31:46.016Z' -H 'Bugsnag-Api-Key: 12312312312312312312312312312312' --data-binary @features/fixtures/file.json.gz http://localhost:9339/traces

--- a/test/fixtures/payload-helpers/features/scripts/send_gzip.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_gzip.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-curl -H 'Content-Encoding: gzip' -H 'Bugsnag-Integrity: sha1 bd1cbbd2ab9b05a96cbb83a6bcac829ff255a9fe' -H 'Bugsnag-Sent-At: 2023-06-30T08:31:46.016Z' -H 'Bugsnag-Api-Key: 12312312312312312312312312312312' --data-binary @features/fixtures/file.json.gz http://localhost:9339/traces
+curl -H 'Content-Encoding: gzip' -H 'Bugsnag-Integrity: sha1 bd1cbbd2ab9b05a96cbb83a6bcac829ff255a9fe' -H 'Bugsnag-Sent-At: 2023-06-30T08:31:46.016Z' -H 'Bugsnag-Span-Sampling: 1:4' -H 'Bugsnag-Api-Key: 12312312312312312312312312312312' --data-binary @features/fixtures/file.json.gz http://localhost:9339/traces

--- a/test/fixtures/payload-helpers/features/scripts/send_spans.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_spans.sh
@@ -49,6 +49,7 @@ payload = {
   'headers' => {
     'Bugsnag-Api-Key' => ENV['TEST_API_KEY'],
     'Bugsnag-Payload-Version' => '1.0',
+    'Bugsnag-Span-Sampling' => '1:1',
     'Bugsnag-Sent-At' => Time.now().iso8601(3)
   },
   'body' => {

--- a/test/fixtures/payload-helpers/features/support/send_request.rb
+++ b/test/fixtures/payload-helpers/features/support/send_request.rb
@@ -81,7 +81,8 @@ def send_request(request_type, mock_api_port = 9339)
       'headers' => {
         'Bugsnag-Api-Key' => $api_key,
         'Bugsnag-Payload-Version' => '1.0',
-        'Bugsnag-Sent-At' => Time.now().iso8601(3)
+        'Bugsnag-Sent-At' => Time.now().iso8601(3),
+        'Bugsnag-Span-Sampling' => '1:1'
       },
       'body' => {
         "resourceSpans": []
@@ -91,7 +92,8 @@ def send_request(request_type, mock_api_port = 9339)
       'headers' => {
         'Bugsnag-Api-Key' => $api_key,
         'Bugsnag-Payload-Version' => '1.0',
-        'Bugsnag-Sent-At' => Time.now().iso8601(3)
+        'Bugsnag-Sent-At' => Time.now().iso8601(3),
+        'Bugsnag-Span-Sampling' => '1:1'
       },
       'body' => {
         "resourceSpans":[
@@ -289,7 +291,8 @@ def send_request(request_type, mock_api_port = 9339)
       'headers' => {
         'Bugsnag-Api-Key' => $api_key,
         'Bugsnag-Payload-Version' => '1.0',
-        'Bugsnag-Sent-At' => Time.now().iso8601(3)
+        'Bugsnag-Sent-At' => Time.now().iso8601(3),
+        'Bugsnag-Span-Sampling' => '1:1'
       },
       'body' => {
         "resourceSpans": [

--- a/test/schemas/trace_validation_test.rb
+++ b/test/schemas/trace_validation_test.rb
@@ -28,12 +28,14 @@ class TraceValidationTest < Test::Unit::TestCase
     assert_not_nil(regex.match('1.0:1'))
     assert_not_nil(regex.match('0:10'))
     assert_not_nil(regex.match('1:1'))
+    assert_not_nil(regex.match('1:1;1:2;0.3:5'))
 
     assert_nil(regex.match('1,1'))
     assert_nil(regex.match('0..0:1'))
     assert_nil(regex.match('0.0:1.0'))
     assert_nil(regex.match('1.1:1'))
     assert_nil(regex.match('.0:3'))
+    assert_nil(regex.match('1:1;;1:2'))
   end
   
   def test_valid_headers
@@ -71,7 +73,7 @@ class TraceValidationTest < Test::Unit::TestCase
     validator.validate_headers
     assert_false(validator.success)
     assert_equal(1, validator.errors.size, format_errors(validator.errors))
-    assert_equal("bugsnag-span-sampling header was expected to match the regex '^(1(.0)?|0(\\.[0-9]+)?):[0-9]+$', but was '2:2'", validator.errors.first)
+    assert_equal("bugsnag-span-sampling header was expected to match the regex '^((1(.0)?|0(\\.[0-9]+)?):[0-9]+)(;((1(.0)?|0(\\.[0-9]+)?):[0-9]+))*$', but was '2:2'", validator.errors.first)
   end
 
   def test_regex_success

--- a/test/schemas/trace_validation_test.rb
+++ b/test/schemas/trace_validation_test.rb
@@ -1,74 +1,128 @@
 require 'test_helper'
 require_relative '../../lib/maze/schemas/trace_validator'
 
+class MockRequest
+  attr_accessor :header
+end
+
 class TraceValidationTest < Test::Unit::TestCase
-  def set_valid_headers(hash)
 
-  end
-
-  def create_request(body)
+  def create_basic_request(body)
+    request = MockRequest.new
+    request.header = {
+      'bugsnag-api-key' => ['12345678901234567890123456789012'],
+      'bugsnag-sent-at' => ['2023-06-12T14:24:48.755Z'],
+      'bugsnag-span-sampling' => ['0.1:4']
+    }
     {
-      :header
+      :request => request,
       :body => body
     }
   end
 
-  def test_initial_conditions
-    validator = Maze::Schemas::TraceValidator.new({})
-    assert_nil(validator.success)
-    assert(validator.errors.empty?)
+  def test_sampling_span_regex
+    regex = Regexp.new(Maze::Schemas::SAMPLING_HEADER)
+    # assert_true(regex.match('0.0:1'))
+    assert_not_nil(regex.match('0.1111:7'))
+    assert_not_nil(regex.match('1:10'))
+    assert_not_nil(regex.match('0:10'))
+    assert_not_nil(regex.match('1:1'))
+
+    assert_nil(regex.match('1,1'))
+    assert_nil(regex.match('0..0:1'))
+    assert_nil(regex.match('0.0:1.0'))
+    assert_nil(regex.match('1.0:1'))
+    assert_nil(regex.match('1.1:1'))
+    assert_nil(regex.match('.0:3'))
+  end
+  
+  def test_valid_headers
+    request = create_basic_request({ 'value' => 'abc123' })
+    validator = Maze::Schemas::TraceValidator.new(request)
+    validator.validate_headers
+    assert_true(validator.success)
+    assert_equal(0, validator.errors.size, format_errors(validator.errors))
+  end
+
+  def test_invalid_bugsnag_api_key
+    request = create_basic_request({ 'value' => 'abc123' })
+    request[:request].header['bugsnag-api-key'] = ['bad api key']
+    validator = Maze::Schemas::TraceValidator.new(request)
+    validator.validate_headers
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size, format_errors(validator.errors))
+    assert_equal("bugsnag-api-key header was expected to match the regex '^[A-Fa-f0-9]{32}$', but was 'bad api key'", validator.errors.first)
+  end
+
+  def test_invalid_bugsnag_sent_at
+    request = create_basic_request({ 'value' => 'abc123' })
+    request[:request].header['bugsnag-sent-at'] = ['having a bad time']
+    validator = Maze::Schemas::TraceValidator.new(request)
+    validator.validate_headers
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size, format_errors(validator.errors))
+    assert_equal("bugsnag-sent-at header was expected to be an IOS 8601 date, but was 'having a bad time'", validator.errors.first)
+  end
+
+  def test_invalid_span_sampling
+    request = create_basic_request({ 'value' => 'abc123' })
+    request[:request].header['bugsnag-span-sampling'] = ['2:2']
+    validator = Maze::Schemas::TraceValidator.new(request)
+    validator.validate_headers
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size, format_errors(validator.errors))
+    assert_equal("bugsnag-span-sampling header was expected to match the regex '^(1|0(\\.[0-9]+)?):[0-9]+$', but was '2:2'", validator.errors.first)
   end
 
   def test_regex_success
-    validator = Maze::Schemas::TraceValidator.new({
-      'value' => 'abc123'
-    })
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({ 'value' => 'abc123' }))
     validator.regex_comparison('value', '[abc123]{6}')
-    assert_nil(validator.success)
+    assert_true(validator.success)
     assert(validator.errors.empty?)
   end
 
+  def format_errors(errors)
+    list = errors.join("\n")
+    "Errors given:\n#{list}"
+  end
+
   def test_regex_failure
-    validator = Maze::Schemas::TraceValidator.new({
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'value' => 'abc123'
-    })
+    }))
     validator.regex_comparison('value', '[ab12]{6}')
     assert_false(validator.success)
-    assert_equal(validator.errors.size, 1)
+    assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'value' was expected to match the regex '[ab12]{6}', but was 'abc123'")
   end
 
   def test_element_int_in_range_success
-    validator = Maze::Schemas::TraceValidator.new({
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'value' => 2
-    })
+    }))
     validator.element_int_in_range('value', 1..3)
-    assert_nil(validator.success)
+    assert_true(validator.success)
     assert(validator.errors.empty?)
   end
 
   def test_element_int_in_range_failure
-    validator = Maze::Schemas::TraceValidator.new({
-      'value' => 4
-    })
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({ 'value' => 4 }))
     validator.element_int_in_range('value', 1..3)
     assert_false(validator.success)
-    assert_equal(validator.errors.size, 1)
+    assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'value':'4' was expected to be in the range '1..3'")
   end
 
   def test_element_int_in_range_no_int_failure
-    validator = Maze::Schemas::TraceValidator.new({
-      'value' => 'abc'
-    })
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({ 'value' => 'abc' }))
     validator.element_int_in_range('value', 1..3)
     assert_false(validator.success)
-    assert_equal(validator.errors.size, 1)
+    assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'value' was expected to be an integer, was 'abc'")
   end
 
   def test_contains_key_success
-    validator = Maze::Schemas::TraceValidator.new({
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'value' => [
         {
           'key' => 'placeholder',
@@ -83,14 +137,14 @@ class TraceValidationTest < Test::Unit::TestCase
           }
         }
       ]
-    })
+    }))
     validator.element_contains('value', 'correct')
-    assert_nil(validator.success)
+    assert_true(validator.success)
     assert(validator.errors.empty?)
   end
 
   def test_contains_key_failure
-    validator = Maze::Schemas::TraceValidator.new({
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'value' => [
         {
           'key' => 'placeholder',
@@ -105,25 +159,23 @@ class TraceValidationTest < Test::Unit::TestCase
           }
         }
       ]
-    })
+    }))
     validator.element_contains('value', 'incorrect')
     assert_false(validator.success)
-    assert_equal(validator.errors.size, 1)
+    assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'value' did not contain a value with the key 'incorrect'")
   end
 
   def test_contains_not_array
-    validator = Maze::Schemas::TraceValidator.new({
-      'value' => '1234'
-    })
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({ 'value' => '1234' }))
     validator.element_contains('value', 'incorrect')
     assert_false(validator.success)
-    assert_equal(validator.errors.size, 1)
+    assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'value' was expected to be an array, was '1234'")
   end
 
   def test_contains_key_value_and_options_success
-    validator = Maze::Schemas::TraceValidator.new({
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'value' => [
         {
           'key' => 'placeholder',
@@ -138,14 +190,14 @@ class TraceValidationTest < Test::Unit::TestCase
           }
         }
       ]
-    })
+    }))
     validator.element_contains('value', 'correct', 'stringValue', ['good', 'done'])
-    assert_nil(validator.success)
+    assert_true(validator.success)
     assert(validator.errors.empty?)
   end
 
   def test_contains_key_value_and_options_failure
-    validator = Maze::Schemas::TraceValidator.new({
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'value' => [
         {
           'key' => 'placeholder',
@@ -160,15 +212,15 @@ class TraceValidationTest < Test::Unit::TestCase
           }
         }
       ]
-    })
+    }))
     validator.element_contains('value', 'correct', 'stringValue', ['good', 'one'])
     assert_false(validator.success)
-    assert_equal(validator.errors.size, 1)
+    assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'value':'{\"key\"=>\"correct\", \"value\"=>{\"stringValue\"=>\"done\"}}' did not contain a value of 'stringValue' from '[\"good\", \"one\"]'")
   end
 
   def test_contains_key_value_and_options_value_type_missing_failure
-    validator = Maze::Schemas::TraceValidator.new({
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'value' => [
         {
           'key' => 'placeholder',
@@ -183,44 +235,44 @@ class TraceValidationTest < Test::Unit::TestCase
           }
         }
       ]
-    })
+    }))
     validator.element_contains('value', 'correct', 'intValue', ['good', 'one'])
     assert_false(validator.success)
-    assert_equal(validator.errors.size, 1)
+    assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'value':'{\"key\"=>\"correct\", \"value\"=>{\"stringValue\"=>\"done\"}}' did not contain a value of 'intValue' from '[\"good\", \"one\"]'")
   end
 
   def test_greater_than_success
-    validator = Maze::Schemas::TraceValidator.new({
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'smaller' => 1,
       'unit' => 1,
       'larger' => 5
-    })
+    }))
     validator.element_a_greater_or_equal_element_b('larger', 'smaller')
-    assert_nil(validator.success)
+    assert_true(validator.success)
     assert(validator.errors.empty?)
   end
 
   def test_greater_than_success_equals
-    validator = Maze::Schemas::TraceValidator.new({
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'smaller' => 1,
       'unit' => 1,
       'larger' => 5
-    })
+    }))
     validator.element_a_greater_or_equal_element_b('smaller', 'unit')
-    assert_nil(validator.success)
+    assert_true(validator.success)
     assert(validator.errors.empty?)
   end
 
   def test_greater_than_failure_lesser
-    validator = Maze::Schemas::TraceValidator.new({
+    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'smaller' => 1,
       'unit' => 1,
       'larger' => 5
-    })
+    }))
     validator.element_a_greater_or_equal_element_b('smaller', 'larger')
     assert_false(validator.success)
-    assert_equal(validator.errors.size, 1)
+    assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'smaller':'1' was expected to be greater than or equal to 'larger':'5'")
   end
 end

--- a/test/schemas/trace_validation_test.rb
+++ b/test/schemas/trace_validation_test.rb
@@ -25,13 +25,13 @@ class TraceValidationTest < Test::Unit::TestCase
     # assert_true(regex.match('0.0:1'))
     assert_not_nil(regex.match('0.1111:7'))
     assert_not_nil(regex.match('1:10'))
+    assert_not_nil(regex.match('1.0:1'))
     assert_not_nil(regex.match('0:10'))
     assert_not_nil(regex.match('1:1'))
 
     assert_nil(regex.match('1,1'))
     assert_nil(regex.match('0..0:1'))
     assert_nil(regex.match('0.0:1.0'))
-    assert_nil(regex.match('1.0:1'))
     assert_nil(regex.match('1.1:1'))
     assert_nil(regex.match('.0:3'))
   end
@@ -71,7 +71,7 @@ class TraceValidationTest < Test::Unit::TestCase
     validator.validate_headers
     assert_false(validator.success)
     assert_equal(1, validator.errors.size, format_errors(validator.errors))
-    assert_equal("bugsnag-span-sampling header was expected to match the regex '^(1|0(\\.[0-9]+)?):[0-9]+$', but was '2:2'", validator.errors.first)
+    assert_equal("bugsnag-span-sampling header was expected to match the regex '^(1(.0)?|0(\\.[0-9]+)?):[0-9]+$', but was '2:2'", validator.errors.first)
   end
 
   def test_regex_success

--- a/test/schemas/trace_validation_test.rb
+++ b/test/schemas/trace_validation_test.rb
@@ -42,7 +42,7 @@ class TraceValidationTest < Test::Unit::TestCase
     request = create_basic_request({ 'value' => 'abc123' })
     validator = Maze::Schemas::TraceValidator.new(request)
     validator.validate_headers
-    assert_true(validator.success)
+    assert_nil(validator.success)
     assert_equal(0, validator.errors.size, format_errors(validator.errors))
   end
 
@@ -79,7 +79,7 @@ class TraceValidationTest < Test::Unit::TestCase
   def test_regex_success
     validator = Maze::Schemas::TraceValidator.new(create_basic_request({ 'value' => 'abc123' }))
     validator.regex_comparison('value', '[abc123]{6}')
-    assert_true(validator.success)
+    assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
 
@@ -103,7 +103,7 @@ class TraceValidationTest < Test::Unit::TestCase
       'value' => 2
     }))
     validator.element_int_in_range('value', 1..3)
-    assert_true(validator.success)
+    assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
 
@@ -141,7 +141,7 @@ class TraceValidationTest < Test::Unit::TestCase
       ]
     }))
     validator.element_contains('value', 'correct')
-    assert_true(validator.success)
+    assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
 
@@ -194,7 +194,7 @@ class TraceValidationTest < Test::Unit::TestCase
       ]
     }))
     validator.element_contains('value', 'correct', 'stringValue', ['good', 'done'])
-    assert_true(validator.success)
+    assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
 
@@ -251,7 +251,7 @@ class TraceValidationTest < Test::Unit::TestCase
       'larger' => 5
     }))
     validator.element_a_greater_or_equal_element_b('larger', 'smaller')
-    assert_true(validator.success)
+    assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
 
@@ -262,7 +262,7 @@ class TraceValidationTest < Test::Unit::TestCase
       'larger' => 5
     }))
     validator.element_a_greater_or_equal_element_b('smaller', 'unit')
-    assert_true(validator.success)
+    assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
 

--- a/test/schemas/trace_validation_test.rb
+++ b/test/schemas/trace_validation_test.rb
@@ -2,6 +2,17 @@ require 'test_helper'
 require_relative '../../lib/maze/schemas/trace_validator'
 
 class TraceValidationTest < Test::Unit::TestCase
+  def set_valid_headers(hash)
+
+  end
+
+  def create_request(body)
+    {
+      :header
+      :body => body
+    }
+  end
+
   def test_initial_conditions
     validator = Maze::Schemas::TraceValidator.new({})
     assert_nil(validator.success)


### PR DESCRIPTION
## Goal

Adds validation of the following headers on every trace request received
- Bugsnag-Api-Key – 32 hex char guid
- Bugsnag-Sent-At – ISO 8601 date
- Bugsnag-Span-Sampling – of the format x:y where
  - x is a decimal between 0 and 1 (inclusive)
  - y is an integer 

## Design

Existing mechanism extended to include steps for validating headers.

## Tests

Unit and e2e tests updated and I've also run the whole set of Android and Cocoa performance e2e tests against it.