### PR TITLE
Create zip archive for maze_output directory

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -157,6 +157,7 @@ steps:
           upload:
             - test/fixtures/payload-helpers/maze_output/**/*
             - test/fixtures/payload-helpers/maze_output/*
+            - test/fixtures/payload-helpers/maze_output.zip
     env:
       RUBY_VERSION: "2"
       USE_LEGACY_DRIVER: "1"
@@ -208,7 +209,9 @@ steps:
     plugins:
       artifacts#v1.9.0:
         download: "bugsnag-android-performance/build/test-fixture.apk"
-        upload: "bugsnag-android-performance/maze_output/**/*"
+        upload:
+          - "bugsnag-android-performance/maze_output/**/*"
+          - "bugsnag-android-performance/maze_output.zip"
       docker-compose#v4.14.0:
         pull: appium-test-bs-legacy
         run: appium-test-bs-legacy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add received span steps to allow greater flexibility in performance tests [571](https://github.com/bugsnag/maze-runner/pull/571) [572](https://github.com/bugsnag/maze-runner/pull/572)
 - Check that required trace headers are present and valid [573](https://github.com/bugsnag/maze-runner/pull/573)
+- Create zip archive of `maze_output` folder [575](https://github.com/bugsnag/maze-runner/pull/575)
 
 # 8.2.0 - 2023/07/19
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -30,12 +30,14 @@ BeforeAll do
   end
   $logger.info "Running in #{Maze.mode.to_s} mode"
 
-  # Clear out maze_output folder
+  # Clear out maze_output folder and zip
   maze_output = Dir.glob(File.join(Dir.pwd, 'maze_output', '*'))
   if Maze.config.file_log && !maze_output.empty?
     maze_output.each { |path| $logger.info "Clearing contents of #{path}" }
     FileUtils.rm_rf(maze_output)
   end
+  maze_output_zip = Dir.glob(File.join(Dir.pwd, 'maze_output.zip'))
+  FileUtils.rm_rf(maze_output_zip)
 
   # Record the local server starting time
   Maze.start_time = Time.now.strftime('%Y-%m-%d %H:%M:%S')
@@ -222,6 +224,14 @@ end
 
 # After all tests
 AfterAll do
+  maze_output = File.join(Dir.pwd, 'maze_output')
+  maze_output_zip = File.join(Dir.pwd, 'maze_output.zip')
+  # zip a folder with files and subfolders
+  Zip::File.open(maze_output_zip, Zip::File::CREATE) do |zipfile|
+    Dir["#{maze_output}/**/**"].each do |file|
+      zipfile.add(file.sub(Dir.pwd + '/', ''), file)
+    end
+  end
 
   metrics = Maze::MetricsProcessor.new(Maze::Server.metrics)
   metrics.process


### PR DESCRIPTION
## Goal

Make it easier for Buildkite pipelines to upload all test results, by creating a zip archive of the `maze_output` folder.

## Tests

Covered by CI and I've also tested locally that an existing file is deleted at the start of a run.