### PR TITLE
Remove deprecated Galaxy S8 Plus device from BS devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Check that required trace headers are present and valid [573](https://github.com/bugsnag/maze-runner/pull/573)
 - Create zip archive of `maze_output` folder [575](https://github.com/bugsnag/maze-runner/pull/575)
 
+## Fixes
+
+- Replace deprecated BrowserStack Samsung Galaxy S8 Plus device with Samsung Galaxy S8 [576](https://github.com/bugsnag/maze-runner/pull/576)
+
 # 8.2.0 - 2023/07/19
 
 ## Enhancements

--- a/lib/maze/client/appium/bs_devices.rb
+++ b/lib/maze/client/appium/bs_devices.rb
@@ -108,7 +108,6 @@ module Maze
             add_android 'Samsung Galaxy A8', '7.1', hash                      # ANDROID_7_1_SAMSUNG_GALAXY_A8
             add_android 'Samsung Galaxy Note 8', '7.1', hash                  # ANDROID_7_1_SAMSUNG_GALAXY_NOTE_8
             add_android 'Samsung Galaxy S8', '7.0', hash                      # ANDROID_7_0_SAMSUNG_GALAXY_S8
-            add_android 'Samsung Galaxy S8 Plus', '7.0', hash                 # ANDROID_7_0_SAMSUNG_GALAXY_S8_PLUS
 
             # Specific iOS devices
             add_ios 'iPhone 14 Plus', '16.0', hash                            # IOS_16_0_IPHONE_14_PLUS

--- a/lib/maze/client/selenium/bs_browsers.yml
+++ b/lib/maze/client/selenium/bs_browsers.yml
@@ -161,7 +161,7 @@ android_6:
 
 android_7:
   browserName: "Android Browser"
-  device: "Samsung Galaxy S8 Plus"
+  device: "Samsung Galaxy S8"
   os: "android"
   osVersion: "7.0"
   realMobile: true


### PR DESCRIPTION
## Goal

Samsung Galaxy S8 Plus has been deprecated by Browserstack but is still in use in the JS pipeline - this PR switches to using regular Samsung Galaxy S8 (which is still available as of writing: https://www.browserstack.com/list-of-browsers-and-platforms/automate) 
