### PR TITLE
Move maze_output.zip so that it can be easily accessed from docker containers

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -157,7 +157,6 @@ steps:
           upload:
             - test/fixtures/payload-helpers/maze_output/**/*
             - test/fixtures/payload-helpers/maze_output/*
-            - test/fixtures/payload-helpers/maze_output.zip
     env:
       RUBY_VERSION: "2"
       USE_LEGACY_DRIVER: "1"
@@ -211,7 +210,6 @@ steps:
         download: "bugsnag-android-performance/build/test-fixture.apk"
         upload:
           - "bugsnag-android-performance/maze_output/**/*"
-          - "bugsnag-android-performance/maze_output.zip"
       docker-compose#v4.14.0:
         pull: appium-test-bs-legacy
         run: appium-test-bs-legacy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 8.4.0 - TBD
+# 8.3.1 - 2023/08/18
 
-## Enhancements
+## Fixes
 
 - Move the `maze_output.zip` file to the `maze_output` folder once created [579](https://github.com/bugsnag/maze-runner/pull/579)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.4.0 - TBD
+
+## Enhancements
+
+- Move the `maze_output.zip` file to the `maze_output` folder once created [579](https://github.com/bugsnag/maze-runner/pull/579)
+
 # 8.3.0 - 2023/08/14
 
 ## Enhancements

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -234,7 +234,7 @@ AfterAll do
   end
 
   # Move the zip file to the maze_output folder
-  Fileutils.mv(maze_output_zip, maze_output)
+  FileUtils.mv(maze_output_zip, maze_output)
 
   metrics = Maze::MetricsProcessor.new(Maze::Server.metrics)
   metrics.process

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -233,6 +233,9 @@ AfterAll do
     end
   end
 
+  # Move the zip file to the maze_output folder
+  Fileutils.mv(maze_output_zip, maze_output)
+
   metrics = Maze::MetricsProcessor.new(Maze::Server.metrics)
   metrics.process
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.3.0'
+  VERSION = '8.4.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.4.0'
+  VERSION = '8.3.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

Make the `maze_output.zip` easily accessible from docker containers

## Changeset

Move the `maze_output.zip` to the `maze_output` folder when completed so that it can be easily accessed from within docker containers.

## Tests

Covered via CI