### PR TITLE
Allow push_file location for Android to be overidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 8.3.1 - 2023/08/18
+# 8.4.0 - 2023/08/18
+
+## Enhancements
+
+- Allow `FileManager.write_app_file` target location to be overwritten for Android  [580](https://github.com/bugsnag/maze-runner/pull/580)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.3.0)
+    bugsnag-maze-runner (8.4.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.3.1'
+  VERSION = '8.4.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/api/appium/file_manager.rb
+++ b/lib/maze/api/appium/file_manager.rb
@@ -9,7 +9,8 @@ module Maze
         end
 
         # Creates a file with the given contents on the device (using Appium).  The file will be located in the app's
-        # Documents directory for iOS and /sdcard/Android/data/<app-id>/ for Android.
+        # documents directory for iOS. On Android, it will be /sdcard/Android/data/<app-id>/files unless
+        # Maze.config.android_app_files_directory has been set.
         # @param contents [String] Content of the file to be written
         # @param filename [String] Name (with no path) of the file to be written on the device
         def write_app_file(contents, filename)
@@ -17,7 +18,7 @@ module Maze
                  when 'ios'
                    "@#{@driver.app_id}/Documents/#{filename}"
                  when 'android'
-                   "/sdcard/Android/data/#{@driver.app_id}/files/#{filename}"
+                   Maze.config.android_app_files_directory || "/sdcard/Android/data/#{@driver.app_id}/files/#{filename}"
                  end
 
           $logger.trace "Pushing file to '#{path}' with contents: #{contents}"

--- a/lib/maze/api/appium/file_manager.rb
+++ b/lib/maze/api/appium/file_manager.rb
@@ -18,7 +18,8 @@ module Maze
                  when 'ios'
                    "@#{@driver.app_id}/Documents/#{filename}"
                  when 'android'
-                   Maze.config.android_app_files_directory || "/sdcard/Android/data/#{@driver.app_id}/files/#{filename}"
+                   directory = Maze.config.android_app_files_directory || "/sdcard/Android/data/#{@driver.app_id}/files"
+                   "#{directory}/#{filename}"
                  end
 
           $logger.trace "Pushing file to '#{path}' with contents: #{contents}"

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -11,6 +11,7 @@ module Maze
       self.receive_requests_slow_threshold = 10
       self.enforce_bugsnag_integrity = true
       self.captured_invalid_requests = Set[:errors, :sessions, :builds, :uploads, :sourcemaps]
+      self.android_app_files_directory = nil
       @legacy_driver = false
     end
 
@@ -101,6 +102,9 @@ module Maze
 
     # Whether the device farm secure tunnel should be started
     attr_accessor :start_tunnel
+
+    # Folder to push app files to on Android
+    attr_accessor :android_app_files_directory
 
     #
     # Device farm specific configuration


### PR DESCRIPTION
## Goal

Allow push_file location for Android to be overidden.

## Changeset

Adds a new config value that can be set to push files to a different location on Android.  iOS have no other viable location to use, so there is no point in adding a config option for that.

## Tests

Tested using a RN Perf branch that needs to read for the temp folder.