### PR TITLE
Allow Bugsnag-Uncompressed-Content-Length in CORS header policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.4.1 - 2023/08/29
+
+## Fixes
+
+- Allow `Bugsnag-Uncompressed-Content-Length` in CORS header policy [581](https://github.com/bugsnag/maze-runner/pull/581)
+
 # 8.4.0 - 2023/08/18
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.4.0)
+    bugsnag-maze-runner (8.4.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.4.0'
+  VERSION = '8.4.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/servlets/base_servlet.rb
+++ b/lib/maze/servlets/base_servlet.rb
@@ -18,6 +18,7 @@ module Maze
           Bugsnag-Payload-Version
           Bugsnag-Sent-At
           Bugsnag-Span-Sampling
+          Bugsnag-Uncompressed-Content-Length
           Content-Type
           Origin
         ].join(',')


### PR DESCRIPTION
## Goal

Allow `Bugsnag-Uncompressed-Content-Length` in CORS header policy.

## Tests

Reran the bugsnag-unity-performance test that found the issue.