### PR TITLE
Improve presentation of BugSnags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.5.1 - TBD
+
+## Fixes
+
+- Improve grouping and presentation of BugSnagged errors [581](https://github.com/bugsnag/maze-runner/pull/581)
+
 # 8.5.0 - 2023/09/05
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.5.0)
+    bugsnag-maze-runner (8.5.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,11 +43,11 @@ Changed names:
 
 The following Cucumber steps have been reworded:
 
-Removed step | Replacement
----|---|
-`the {request_type} {string} header is not null` | `the {request_type} {string} header is present`
-`the {request_type} {string} header is null` | `the {request_type} {string} header is not present`
-`I set the HTTP status code for the next {string} requests to {string}` | `I set the HTTP status code for the next {string} request(s) to {int_array}`
+| Removed step                                                            | Replacement                                                                  |
+|-------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| `the {request_type} {string} header is not null`                        | `the {request_type} {string} header is present`                              |
+| `the {request_type} {string} header is null`                            | `the {request_type} {string} header is not present`                          |
+| `I set the HTTP status code for the next {string} requests to {string}` | `I set the HTTP status code for the next {string} request(s) to {int_array}` |
 
 ## v6 to v7
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.5.0'
+  VERSION = '8.5.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/plugins/bugsnag_reporting_plugin.rb
+++ b/lib/maze/plugins/bugsnag_reporting_plugin.rb
@@ -26,8 +26,15 @@ module Maze
 
           Bugsnag.notify(event.result.exception) do |bsg_event|
             unless @last_test_step.nil?
-              bsg_event.context = @last_test_step.location
-              bsg_event.grouping_hash = test_case.name + @last_test_step.location
+
+              repo = ENV['BUILDKITE_PIPELINE_SLUG']
+              bsg_event.context = if repo.nil?
+                                    @last_test_step.location
+                                  else
+                                    "#{slug}/#{@last_test_step.location}"
+                                  end
+              bsg_event.grouping_hash = @last_test_step.location
+
               bsg_event.add_metadata(:'scenario', {
                 'failing step': @last_test_step.to_s,
                 'failing step location': @last_test_step.location

--- a/lib/maze/plugins/bugsnag_reporting_plugin.rb
+++ b/lib/maze/plugins/bugsnag_reporting_plugin.rb
@@ -31,7 +31,7 @@ module Maze
               bsg_event.context = if repo.nil?
                                     @last_test_step.location
                                   else
-                                    "#{slug}/#{@last_test_step.location}"
+                                    "#{repo}/#{@last_test_step.location}"
                                   end
               bsg_event.grouping_hash = @last_test_step.location
 


### PR DESCRIPTION
## Goal

Tweaks the context and grouping hash to improve the presentation of reported errors in the BugSnag Maze Runner dashboard.

## Design

For now I have just changed the grouping hash to the current scenario steps.  So, for example, different scenarios failing on the same `Background:` step will be grouped together.  Looking at the errors currently being reported I believe this will make it easier to analyse, although we may wantto make the mechanism more sophisticated in the future, allowing individual repos to choose their grouping strategy.

I have also tweaked the Context to include the repo name, as the dashboard contains errors from many different repos.

## Tests

I forced an error to occur in a background step locally, which produced the following grouping and context in the dashboard.

![image](https://github.com/bugsnag/maze-runner/assets/5239394/60b015d4-237b-4eca-9dde-ab88bb1c323f)
