### PR TITLE
Always use BITBAR_ACCESS_KEY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.6.1 - TBD
+
+## Fixes
+
+- Use `BITBAR_ACCESS_KEY` universally (only affects `purge-projects` entry point) [585](https://github.com/bugsnag/maze-runner/pull/585)
+
 # 8.6.0 - 2023/09/15
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.6.0)
+    bugsnag-maze-runner (8.6.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/bin/purge-projects
+++ b/bin/purge-projects
@@ -14,7 +14,7 @@ class PurgeProjectEntry
     p = Optimist::Parser.new do
       text 'Purge anonymous projects from BitBar'
       text ''
-      text 'Requires BITBAR_API_KEY'
+      text 'Requires BITBAR_ACCESS_KEY'
       text ''
       text 'Usage [OPTIONS]'
       text ''
@@ -29,10 +29,10 @@ class PurgeProjectEntry
       p.parse ARGV
     end
 
-    api_key = opts[:api_key] || ENV['BITBAR_API_KEY']
+    api_key = opts[:api_key] || ENV['BITBAR_ACCESS_KEY']
 
     if api_key.nil?
-      $logger.warn "API KEY has not been provided or BITBAR_API_KEY has not been set"
+      $logger.warn "API KEY has not been provided or BITBAR_ACCESS_KEY has not been set"
       Optimist::with_standard_exception_handling p do
         raise Optimist::HelpNeeded
       end

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.6.0'
+  VERSION = '8.6.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/test/option/processor_test.rb
+++ b/test/option/processor_test.rb
@@ -13,7 +13,7 @@ class ProcessorTest < Test::Unit::TestCase
     ENV.delete('MAZE_BS_LOCAL')
     ENV.delete('BROWSER_STACK_USERNAME')
     ENV.delete('BROWSER_STACK_ACCESS_KEY')
-    ENV.delete('BITBAR_API_KEY')
+    ENV.delete('BITBAR_ACCESS_KEY')
 
     Maze::Helper.stubs(:expand_path).with('/BrowserStackLocal').returns('/BrowserStackLocal')
   end

--- a/test/option/validator_test.rb
+++ b/test/option/validator_test.rb
@@ -16,7 +16,7 @@ class ValidatorTest < Test::Unit::TestCase
     ENV.delete('MAZE_BS_LOCAL')
     ENV.delete('BROWSER_STACK_USERNAME')
     ENV.delete('BROWSER_STACK_ACCESS_KEY')
-    ENV.delete('BITBAR_API_KEY')
+    ENV.delete('BITBAR_ACCESS_KEY')
 
     Maze::Helper.stubs(:expand_path).with('/BrowserStackLocal').returns('/BrowserStackLocal')
     Maze::Helper.stubs(:expand_path).with('my_app.apk').returns('my_app.apk')


### PR DESCRIPTION
## Goal

Resolves a minor annoyance with the `purge-projects` entry point, which was using a different environment variable for authenticating with BitBar.

## Design

Only affect the `purge-projects` entry point, not `maze-runner`.

## Tests

Tested locally.