### PR TITLE
Incorporate reporting of internal errors to BugSnag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 8.6.1 - TBD
+# 8.7.0 - 2023/09/26
+
+## Enhancements
+
+- Incorporate reporting of internal errors to BugSnag [586](https://github.com/bugsnag/maze-runner/pull/586)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.6.1)
+    bugsnag-maze-runner (8.7.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -168,6 +168,7 @@ GEM
     yard (0.9.34)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -91,7 +91,9 @@ InstallPlugin do |config|
 
   # Only add the retry plugin if --retry is not used on the command line
   config.filters << Maze::Plugins::GlobalRetryPlugin.new(config) if config.options[:retry].zero?
-  config.filters << Maze::Plugins::BugsnagReportingPlugin.new(config)
+
+  # TODO: Reporting of test failures as errors deactivated pending PLAT-10963
+  #config.filters << Maze::Plugins::BugsnagReportingPlugin.new(config)
 end
 
 # Before each scenario

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.6.1'
+  VERSION = '8.7.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/aws_public_ip.rb
+++ b/lib/maze/aws_public_ip.rb
@@ -1,3 +1,5 @@
+require 'bugsnag'
+
 module Maze
   # Determines the public IP address and port when running on Buildkite with the Elastic CI Stack for AWS
   class AwsPublicIp

--- a/lib/maze/aws_public_ip.rb
+++ b/lib/maze/aws_public_ip.rb
@@ -52,7 +52,8 @@ module Maze
             json_string = result[0][0].strip
             json_result = JSON.parse(json_string)
             port = json_result['NetworkSettings']['Ports']["#{local_port}/tcp"][0]['HostPort']
-          rescue StandardError
+          rescue StandardError => error
+            Bugsnag.notify error
             $logger.error "Unable to parse public port from: #{json_string}"
             return 0
           end

--- a/lib/maze/bugsnag_config.rb
+++ b/lib/maze/bugsnag_config.rb
@@ -35,7 +35,6 @@ module Maze
             Bugsnag.notify($!)
           end
         end
-
       end
     end
   end

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -1,3 +1,4 @@
+require 'bugsnag'
 require 'json'
 
 module Maze

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -26,8 +26,9 @@ module Maze
           # Ensure the device is unlocked
           begin
             Maze.driver.unlock
-          rescue => e
-            $logger.warn "Failed to unlock device: #{e}"
+          rescue => error
+            Bugsnag.notify error
+            $logger.warn "Failed to unlock device: #{error}"
           end
 
           log_run_intro
@@ -69,8 +70,9 @@ module Maze
                     $logger.info "Running on device: #{udid}" unless udid.nil?
                   end
                   result
-                rescue => start_error
-                  $logger.error "Session creation failed: #{start_error}"
+                rescue => error
+                  Bugsnag.notify error
+                  $logger.error "Session creation failed: #{error}"
                   false
                 end
               end
@@ -85,7 +87,6 @@ module Maze
               end
 
               unless success
-                # TODO Bugsnag notify
                 $logger.error 'Failed to create Appium driver, exiting'
                 exit(::Maze::Api::ExitCode::SESSION_CREATION_FAILURE)
               end

--- a/lib/maze/client/bb_api_client.rb
+++ b/lib/maze/client/bb_api_client.rb
@@ -103,8 +103,7 @@ module Maze
             end
           end
         rescue StandardError => e
-          $logger.error "Error getting projects from BitBar"
-          $logger.error e
+          $logger.error "Error getting projects from BitBar: #{e}"
           raise
         end
         projects

--- a/lib/maze/client/bb_client_utils.rb
+++ b/lib/maze/client/bb_client_utils.rb
@@ -49,7 +49,8 @@ module Maze
                 $logger.error "Unexpected response body: #{response}"
                 raise 'App upload failed'
               end
-            rescue JSON::ParserError
+            rescue JSON::ParserError => error
+              Bugsnag.notify error
               $logger.error "Expected JSON response, received: #{res}"
               raise
             end

--- a/lib/maze/client/bb_client_utils.rb
+++ b/lib/maze/client/bb_client_utils.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'bugsnag'
 require 'open3'
 require 'fileutils'
 require 'json'

--- a/lib/maze/client/bs_client_utils.rb
+++ b/lib/maze/client/bs_client_utils.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bugsnag'
+
 module Maze
   module Client
     # Utils supporting the BrowserStack device farm integration

--- a/lib/maze/client/bs_client_utils.rb
+++ b/lib/maze/client/bs_client_utils.rb
@@ -42,9 +42,11 @@ module Maze
                   # Successful upload
                   break
                 end
-              rescue Net::ReadTimeout
+              rescue Net::ReadTimeout => error
+                Bugsnag.notify error
                 $logger.error "Upload failed due to ReadTimeout"
-              rescue JSON::ParserError
+              rescue JSON::ParserError => error
+                Bugsnag.notify error
                 $logger.error "Unexpected JSON response, received: #{body}"
               end
 

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -56,6 +56,8 @@ module Maze
           super
           $logger.info "Appium driver started in #{(Time.now - time).to_i}s"
         rescue => error
+          Bugsnag.notify(error)
+
           $logger.warn "Appium driver failed to start in #{(Time.now - time).to_i}s"
           $logger.warn "#{error.class} occurred with message: #{error.message}"
           raise error

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -1,4 +1,5 @@
 require 'appium_lib'
+require 'bugsnag'
 require 'json'
 require 'open3'
 require 'securerandom'

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -122,6 +122,7 @@ module Maze
           $logger.info "Selenium driver started in #{(Time.now - time).to_i}s"
           @driver = driver
         rescue => error
+          Bugsnag.notify error
           $logger.warn "Selenium driver failed to start in #{(Time.now - time).to_i}s"
           raise error
         end

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bugsnag'
 require 'selenium-webdriver'
 
 module Maze

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -43,7 +43,10 @@ module Maze
       end
 
       def at_exit
-        @client&.stop_session
+        if @client
+          $logger.info 'Stopping the Appium session'
+          @client.stop_session
+        end
       end
 
       private

--- a/lib/maze/logger.rb
+++ b/lib/maze/logger.rb
@@ -78,8 +78,9 @@ module Maze
           else
             log_hash_by_field severity, data
           end
-        rescue Encoding::UndefinedConversionError
+        rescue Encoding::UndefinedConversionError => error
           # Just give up, we don't want to risk a further error trying to log garbage
+          Bugsnag.notify error
           $logger.error 'Unable to log hash as JSON'
         end
       end

--- a/lib/maze/logger.rb
+++ b/lib/maze/logger.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bugsnag'
 require 'logger'
 require 'singleton'
 

--- a/lib/maze/proxy.rb
+++ b/lib/maze/proxy.rb
@@ -82,10 +82,11 @@ module Maze
             config[:ProxyAuthProc] = authenticator.method(:authenticate).to_proc
           end
 
-          # Crwate and start the proxy
+          # Create and start the proxy
           proxy = WEBrick::HTTPProxyServer.new config
           proxy.start
         rescue StandardError => e
+          Bugsnag.notify e
           $logger.warn "Failed to start proxy server: #{e.message}"
         ensure
           proxy&.shutdown

--- a/lib/maze/proxy.rb
+++ b/lib/maze/proxy.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bugsnag'
 require 'json'
 require 'singleton'
 require 'webrick'

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bugsnag'
 require 'json'
 require 'securerandom'
 require 'webrick'

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -227,6 +227,7 @@ module Maze
             server.mount '/reflect', Servlets::ReflectiveServlet
             server.start
           rescue StandardError => e
+            Bugsnag.notify e
             $logger.warn "Failed to start mock server: #{e.message}"
           ensure
             server&.shutdown

--- a/lib/maze/servlets/log_servlet.rb
+++ b/lib/maze/servlets/log_servlet.rb
@@ -30,6 +30,7 @@ module Maze
         response.header['Access-Control-Allow-Origin'] = '*'
         response.status = Server.status_code('POST')
       rescue JSON::ParserError => e
+        Bugsnag.notify e
         msg = "Unable to parse request as JSON: #{e.message}"
         $logger.error msg
         Server.invalid_requests.add({
@@ -39,6 +40,7 @@ module Maze
           body: request.body
         })
       rescue StandardError => e
+        Bugsnag.notify e
         $logger.error "Invalid request: #{e.message}"
         Server.invalid_requests.add({
           invalid: true,

--- a/lib/maze/servlets/log_servlet.rb
+++ b/lib/maze/servlets/log_servlet.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bugsnag'
+
 module Maze
   module Servlets
 

--- a/lib/maze/servlets/reflective_servlet.rb
+++ b/lib/maze/servlets/reflective_servlet.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'bugsnag'
 require 'rack'
 
 module Maze

--- a/lib/maze/servlets/reflective_servlet.rb
+++ b/lib/maze/servlets/reflective_servlet.rb
@@ -41,10 +41,12 @@ module Maze
 
         reflect response, delay_ms, status
       rescue JSON::ParserError => e
+        Bugsnag.notify e
         msg = "Unable to parse request as JSON: #{e.message}"
         $logger.error msg
         response.status = 418
       rescue StandardError => e
+        Bugsnag.notify e
         $logger.error "Invalid request: #{e.message}"
         response.status = 500
       end

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bugsnag'
 require 'zlib'
 require 'stringio'
 require 'json_schemer'

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -101,6 +101,7 @@ module Maze
         set_response_header response.header
         response.status = post_status_code
       rescue JSON::ParserError => e
+        Bugsnag.notify e
         msg = "Unable to parse request as JSON: #{e.message}"
         if Maze.config.captured_invalid_requests.include? @request_type
           $logger.error msg
@@ -113,6 +114,7 @@ module Maze
           $logger.warn msg
         end
       rescue StandardError => e
+        Bugsnag.notify e
         if Maze.config.captured_invalid_requests.include? @request_type
           $logger.error "Invalid request: #{e.message}"
           Server.invalid_requests.add({

--- a/lib/maze/terminating_server.rb
+++ b/lib/maze/terminating_server.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bugsnag'
 require 'socket'
 
 module Maze

--- a/lib/maze/terminating_server.rb
+++ b/lib/maze/terminating_server.rb
@@ -33,6 +33,7 @@ module Maze
               end_connection(socket)
             }
           rescue StandardError => e
+            Bugsnag.notify e
             $logger.warn "Terminating server error: #{e.message}"
           end
 


### PR DESCRIPTION
## Goal

Incorporate reporting of internal errors to BugSnag

## Design

The BugSnag integration is already in Maze Runner, so we can just call notify.

For now I have also disabled the feature that reports test failures as errors.  Although it works well, no one is currently using it and now we are sending internal errors, test failures will need to be routed to different dashboards.

## Tests

It's not viable to test this outright at this stage, but I'll be monitoring the dashboard over the coming days to ensure it's presenting information as expected.