### PR TITLE
Rationalise BitBar CI concurrency group

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -320,8 +320,8 @@ steps:
           - "--no-tunnel"
     env:
       RUBY_VERSION: "2"
-    concurrency: 5
-    concurrency_group: 'bitbar-web'
+    concurrency: 25
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android'
@@ -353,7 +353,7 @@ steps:
     env:
       RUBY_VERSION: "3"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - wait


### PR DESCRIPTION
## Goal

NOTE: Please let me merge this PR myself, it needs to be merged as the same time as several others to avoid unnecessary failures on CI.

Rationalise the Buildkite concurrency group used to control access to BitBar across all of our repos.

## Design

We were using separate groups fro web and device usage, when in fact they are counted towards the same usage limit.  All groups are now being renamed to simply 'bitbar' with a limit of 25.

The main mistake that I could make here is missing an instance of the old groups (`bitbar-app` and `bitbar-web`, so I am using the global find and replace function of my IDE.

## Changeset

Buildkite concurrency group changes only.

## Testing

Verified by peer review.  
