### PR TITLE
Allow more time for Appium apps to be installed

### DIFF
--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -30,10 +30,11 @@ module Maze
 
         def device_capabilities
           config = Maze.config
-          prefix = BitBarDevices.caps_prefix(config.appium_version)
           capabilities = {
-            "#{prefix}noReset" => true,
-            "#{prefix}newCommandTimeout" => 600,
+            'appium:options' => {
+              'noReset' => true,
+              'newCommandTimeout' => 600
+            },
             'bitbar:options' => {
               # Some capabilities probably belong in the top level
               # of the hash, but BitBar picks them up from here.

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -41,16 +41,9 @@ module Maze
             Maze.config.os = platform
             Maze.config.os_version = platform_version.to_f.floor
 
-            prefix = caps_prefix(Maze.config.appium_version)
-
             case platform
             when 'android'
-              automation_name = if platform_version.start_with?('5')
-                                  'UiAutomator1'
-                                else
-                                  'UiAutomator2'
-                                end
-              make_android_hash(device_name, automation_name, prefix)
+              make_android_hash(device_name, prefix)
             when 'ios'
               make_ios_hash(device_name, prefix)
             else
@@ -98,9 +91,9 @@ module Maze
             end
           end
 
-          def make_android_hash(device, automation_name, prefix='appium:')
+          def make_android_hash(device, prefix='appium:')
             hash = {
-              'automationName' => automation_name,
+              'automationName' => 'UiAutomator2',
               'platformName' => 'Android',
               'deviceName' => 'Android Phone',
               'bitbar:options' => {

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -97,7 +97,8 @@ module Maze
               'deviceName' => 'Android Phone',
               'appium:options' => {
                 'automationName' => 'UiAutomator2',
-                'autoGrantPermissions' => true
+                'autoGrantPermissions' => true,
+                'uiautomator2ServerInstallTimeout' => 60000
               },
               'bitbar:options' => {
                 'device' => device,

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -94,9 +94,9 @@ module Maze
           def make_android_hash(device)
             hash = {
               'platformName' => 'Android',
+              'deviceName' => 'Android Phone',
               'appium:options' => {
                 'automationName' => 'UiAutomator2',
-                'deviceName' => 'Android Phone',
                 'autoGrantPermissions' => true
               },
               'bitbar:options' => {
@@ -109,9 +109,9 @@ module Maze
           def make_ios_hash(device)
             {
               'platformName' => 'iOS',
+              'deviceName' => 'iPhone device',
               'appium:options' => {
                 'automationName' => 'XCUITest',
-                'deviceName' => 'iPhone device',
                 'shouldTerminateApp' => 'true'
               },
               'bitbar:options' => {

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -43,9 +43,9 @@ module Maze
 
             case platform
             when 'android'
-              make_android_hash(device_name, prefix)
+              make_android_hash(device_name)
             when 'ios'
-              make_ios_hash(device_name, prefix)
+              make_ios_hash(device_name)
             else
               throw "Invalid device platform specified #{platform}"
             end
@@ -91,33 +91,33 @@ module Maze
             end
           end
 
-          def make_android_hash(device, prefix='appium:')
+          def make_android_hash(device)
             hash = {
-              'automationName' => 'UiAutomator2',
-              'platformName' => 'Android',
-              'deviceName' => 'Android Phone',
+              'appium:options' => {
+                'automationName' => 'UiAutomator2',
+                'platformName' => 'Android',
+                'deviceName' => 'Android Phone',
+                'autoGrantPermissions' => true
+              },
               'bitbar:options' => {
-                "#{prefix}autoGrantPermissions" => true,
                 'device' => device,
               }
             }
             hash.freeze
           end
 
-          def make_ios_hash(device, prefix='appium:')
+          def make_ios_hash(device)
             {
-              'automationName' => 'XCUITest',
-              'deviceName' => 'iPhone device',
-              'platformName' => 'iOS',
-              "#{prefix}shouldTerminateApp" => 'true',
+              'appium:options' => {
+                'automationName' => 'XCUITest',
+                'deviceName' => 'iPhone device',
+                'platformName' => 'iOS',
+                'shouldTerminateApp' => 'true'
+              },
               'bitbar:options' => {
                 'device' => device
               }
             }.freeze
-          end
-
-          def caps_prefix(appium_version)
-            appium_version.nil? || (appium_version.to_i >= 2) ? 'appium:' : ''
           end
         end
       end

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -93,9 +93,9 @@ module Maze
 
           def make_android_hash(device)
             hash = {
+              'platformName' => 'Android',
               'appium:options' => {
                 'automationName' => 'UiAutomator2',
-                'platformName' => 'Android',
                 'deviceName' => 'Android Phone',
                 'autoGrantPermissions' => true
               },
@@ -108,10 +108,10 @@ module Maze
 
           def make_ios_hash(device)
             {
+              'platformName' => 'iOS',
               'appium:options' => {
                 'automationName' => 'XCUITest',
                 'deviceName' => 'iPhone device',
-                'platformName' => 'iOS',
                 'shouldTerminateApp' => 'true'
               },
               'bitbar:options' => {

--- a/test/capabilities/devices_test.rb
+++ b/test/capabilities/devices_test.rb
@@ -14,11 +14,4 @@ class DevicesTest < Test::Unit::TestCase
       assert_match(regex, platform_version) unless %w(sl_android sl_ios).include?(key)
     end
   end
-
-  def test_bb_caps_prefix
-    assert_equal('appium:', Maze::Client::Appium::BitBarDevices.caps_prefix(nil))
-    assert_equal('', Maze::Client::Appium::BitBarDevices.caps_prefix('1.9'))
-    assert_equal('appium:', Maze::Client::Appium::BitBarDevices.caps_prefix('2.0'))
-    assert_equal('appium:', Maze::Client::Appium::BitBarDevices.caps_prefix('5.4.1'))
-  end
 end


### PR DESCRIPTION
## Goal

Try to avoid provisioning failures on BitBar due to slow installation times of apps needed by UIAutomator2 on Adnoird.

## Design

Increases the `uiautomator2ServerInstallTimeout` from the default 20s to 60s.

## Changeset

I've also tidied up the code a little to use only Appium 2 style capabilities on BitBar, where it is now the default Appium version.

## Tests

Covered by CI and inspection of the BitBar dashboard.  I've checked in the Appium logs that there are no errors being caused by the capabilities now set.