### PR TITLE
Avoid shell interpretation of characters in file names in Maze::MacosUtils.capture_screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Allow BB browser versions to be set via the command line [593](https://github.com/bugsnag/maze-runner/pull/593)
 
+## Fixes
+
+- Avoid shell interpretation of characters in file names in `Maze::MacosUtils.capture_screen` [594](https://github.com/bugsnag/maze-runner/pull/594)
+
 # 8.8.0 - 2023/10/11
 
 ## Enhancements

--- a/lib/maze/macos_utils.rb
+++ b/lib/maze/macos_utils.rb
@@ -4,10 +4,10 @@ module Maze
   class MacosUtils
     class << self
       def capture_screen(scenario)
-        path = File.join(File.join(Dir.pwd, 'maze_output'), 'failed', Maze::Helper.to_friendly_filename(scenario.name))
-        FileUtils.makedirs(path)
+        path = Maze::MazeOutput.new(scenario).output_folder
+        FileUtils.makedirs(path) unless File.exist?(path)
 
-        system("/usr/sbin/screencapture #{path}/#{Maze::Helper.to_friendly_filename(scenario.name)}-screenshot.jpg")
+        system('/usr/sbin/screencapture', "#{path}/#{Maze::Helper.to_friendly_filename(scenario.name)}-screenshot.jpg")
       end
     end
   end

--- a/lib/maze/maze_output.rb
+++ b/lib/maze/maze_output.rb
@@ -97,8 +97,6 @@ module Maze
       end
     end
 
-    private
-
     # Determines the output folder for the scenario
     def output_folder
       folder1 = File.join(Dir.pwd, 'maze_output')

--- a/test/fixtures/framework/features/steps/steps.rb
+++ b/test/fixtures/framework/features/steps/steps.rb
@@ -14,13 +14,13 @@ end
 # @step_input key [String] The environment variable
 # @step_input value [String] The intended value of the environment variable
 Then('the Runner.environment entry for {string} equals {string}') do |key, expected_value|
-  assert_equal(expected_value, Maze::Runner.environment[key])
+  Maze.check.equal(expected_value, Maze::Runner.environment[key])
 end
 
 # Verifies that an environment variable is not set.
 #
 # @step_input key [String] The environment variable
 Then('the Runner.environment entry for {string} is null') do |key|
-  assert_nil(Maze::Runner.environment[key])
+  Maze.check.nil(Maze::Runner.environment[key])
 end
 


### PR DESCRIPTION
## Goal

Fixes an error on macOS when screenshots are taken for scenarios containing characters interpreted by the shell (such as `(`).

## Changeset

I've also taken the opportunity to reuse the code that determines the output folder for the scenario.

## Tests

Tested by temporarily changing one of the e2e tests to contain parenthesis and always take a screenshot.