### PR TITLE
Add BitBar selenium timeout extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Enhancements
 
 - Allow BB browser versions to be set via the command line [593](https://github.com/bugsnag/maze-runner/pull/593)
-- Set default test timeout on BitBar selenium runs to 3600 seconds [595](https://github.com/bugsnag/maze-runner/pull/595)
+- Set default test timeout on BitBar selenium runs to 900 seconds [595](https://github.com/bugsnag/maze-runner/pull/595)
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # 8.9.0 - TBD
 
+
 ## Enhancements
 
 - Allow BB browser versions to be set via the command line [593](https://github.com/bugsnag/maze-runner/pull/593)
+- Set default test timeout on BitBar selenium runs to 3600 seconds [584](https://github.com/bugsnag/maze-runner/pull/594)
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # 8.9.0 - TBD
 
-
 ## Enhancements
 
 - Allow BB browser versions to be set via the command line [593](https://github.com/bugsnag/maze-runner/pull/593)
-- Set default test timeout on BitBar selenium runs to 3600 seconds [584](https://github.com/bugsnag/maze-runner/pull/594)
+- Set default test timeout on BitBar selenium runs to 3600 seconds [595](https://github.com/bugsnag/maze-runner/pull/595)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     unf_ext (0.0.8.2)
     uri_template (0.7.0)
     webrick (1.7.0)
-    websocket (1.2.10)
+    websocket (1.2.9)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     unf_ext (0.0.8.2)
     uri_template (0.7.0)
     webrick (1.7.0)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -11,7 +11,7 @@ module Maze
           capabilities['version'] = config.browser_version unless config.browser_version.nil?
           capabilities.merge! browsers[config.browser]
           capabilities.merge! JSON.parse(config.capabilities_option)
-          capabilities['bitbar:options']['testTimeout'] = 3600
+          capabilities['bitbar:options']['testTimeout'] = 900
           config.capabilities = capabilities
 
           if Maze::Client::BitBarClientUtils.use_local_tunnel?

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -11,6 +11,7 @@ module Maze
           capabilities['version'] = config.browser_version unless config.browser_version.nil?
           capabilities.merge! browsers[config.browser]
           capabilities.merge! JSON.parse(config.capabilities_option)
+          capabilities['bitbar:options']['testTimeout'] = 3600
           config.capabilities = capabilities
 
           if Maze::Client::BitBarClientUtils.use_local_tunnel?


### PR DESCRIPTION
## Goal

Fixes PLAT-10842 by extending session timeouts to 900 seconds (15 minutes).
