### PR TITLE
Reinstate removed method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.9.1 - TBD
+
+## Fixes
+
+- Reinstate `retry_start_driver?` in `LocalClient` [598](https://github.com/bugsnag/maze-runner/pull/598)
+
 # 8.9.0 - 2023/10/19
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.9.0)
+    bugsnag-maze-runner (8.9.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.9.0'
+  VERSION = '8.9.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/local_client.rb
+++ b/lib/maze/client/appium/local_client.rb
@@ -48,6 +48,10 @@ module Maze
           capabilities
         end
 
+        def retry_start_driver?
+          false
+        end
+
         def log_run_intro
           # Nothing to do
         end


### PR DESCRIPTION
## Goal

Reinstate a methods that was logically removed by a recent refactor.

## Testing

Basic local testing has been performed.  Local Appium mode may still not work fully (it is used infrequently and in fact may no longer be needed), but this resolves an obvious problem.

