### PR TITLE
Add appium options capabilities for compatibility with older appium servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 8.9.1 - TBD
 
+## Enhancements
+
+- Add appium options in more than one place to work with older appium servers [599](https://github.com/bugsnag/maze-runner/pull/599)
+
 ## Fixes
 
 - Reinstate `retry_start_driver?` in `LocalClient` [598](https://github.com/bugsnag/maze-runner/pull/598)

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -29,9 +29,15 @@ module Maze
         end
 
         def device_capabilities
+          # Doubling up on capabilities in both the `appium:options` and `appium` sub dictionaries.
+            # See PLAT-11087
           config = Maze.config
           capabilities = {
             'appium:options' => {
+              'noReset' => true,
+              'newCommandTimeout' => 600
+            },
+            'appium' => {
               'noReset' => true,
               'newCommandTimeout' => 600
             },

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -30,7 +30,7 @@ module Maze
 
         def device_capabilities
           # Doubling up on capabilities in both the `appium:options` and `appium` sub dictionaries.
-            # See PLAT-11087
+          # See PLAT-11087
           config = Maze.config
           capabilities = {
             'appium:options' => {

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -92,10 +92,17 @@ module Maze
           end
 
           def make_android_hash(device)
+            # Doubling up on capabilities in both the `appium:options` and `appium` sub dictionaries.
+            # See PLAT-11087
             hash = {
               'platformName' => 'Android',
               'deviceName' => 'Android Phone',
               'appium:options' => {
+                'automationName' => 'UiAutomator2',
+                'autoGrantPermissions' => true,
+                'uiautomator2ServerInstallTimeout' => 60000
+              },
+              'appium' => {
                 'automationName' => 'UiAutomator2',
                 'autoGrantPermissions' => true,
                 'uiautomator2ServerInstallTimeout' => 60000
@@ -108,10 +115,16 @@ module Maze
           end
 
           def make_ios_hash(device)
+            # Doubling up on capabilities in both the `appium:options` and `appium` sub dictionaries.
+            # See PLAT-11087
             {
               'platformName' => 'iOS',
               'deviceName' => 'iPhone device',
               'appium:options' => {
+                'automationName' => 'XCUITest',
+                'shouldTerminateApp' => 'true'
+              },
+              'appium' => {
                 'automationName' => 'XCUITest',
                 'shouldTerminateApp' => 'true'
               },


### PR DESCRIPTION
## Goal

On certain older appium servers in BitBar we're getting `'automationName' can't be blank` errors when starting sessions.  Upon contacting support we've been advised to add the `appium:options` capabilities under the main capabilities listing.

## Testing

[Tested here](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/7208#018b5cf3-afca-40cc-9020-1147a44e6a7d), certain tests are failing there, but not because of this change.

