### PR TITLE
Retry creation of BitBar Appium sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-# 8.10.0 - 2023/10/24
+# 8.10.0 - 2023/10/25
 
 ## Enhancements
 
 - Add appium options in more than one place to work with older appium servers [599](https://github.com/bugsnag/maze-runner/pull/599)
-- Selectively retry creation of BitBar Appium sessions depending on the error encountered [6000](https://github.com/bugsnag/maze-runner/pull/600)
+- Selectively retry creation of BitBar Appium sessions depending on the error encountered [600](https://github.com/bugsnag/maze-runner/pull/600)
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# 8.9.1 - TBD
+# 8.10.0 - 2023/10/24
 
 ## Enhancements
 
 - Add appium options in more than one place to work with older appium servers [599](https://github.com/bugsnag/maze-runner/pull/599)
+- Selectively retry creation of BitBar Appium sessions depending on the error encountered [6000](https://github.com/bugsnag/maze-runner/pull/600)
 
 ## Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.9.1)
+    bugsnag-maze-runner (8.10.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.9.1'
+  VERSION = '8.10.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -75,7 +75,6 @@ module Maze
             begin
               Maze.driver = attempt_start_driver(config)
             rescue => error
-              Bugsnag.notify error
               $logger.error "Session creation failed: #{error}"
               start_error = error
             end
@@ -93,11 +92,10 @@ module Maze
                 Maze.config.os_version = version
               end
             else
-              interval = retry_interval(start_error)
+              interval = handle_error(start_error)
               if interval
-                $logger.warn
-                  sleep interval
-
+                $logger.warn "Failed to create Appium driver, retrying in #{interval} seconds"
+                sleep interval
               else
                 $logger.error 'Failed to create Appium driver, exiting'
                 exit(::Maze::Api::ExitCode::SESSION_CREATION_FAILURE)
@@ -106,7 +104,7 @@ module Maze
           end
         end
 
-        def retry_interval(error)
+        def handle_error(error)
           raise 'Method not implemented by this class'
         end
 

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -65,11 +65,11 @@ module Maze
           driver
         end
 
-        def start_driver(config)
+        def start_driver(config, max_attempts = 5)
 
           attempts = 0
 
-          while attempts < 5 && Maze.driver.nil?
+          while attempts < max_attempts && Maze.driver.nil?
             attempts += 1
             start_error = nil
             begin
@@ -95,7 +95,7 @@ module Maze
               interval = handle_error(start_error)
               if interval
                 $logger.warn "Failed to create Appium driver, retrying in #{interval} seconds"
-                sleep interval
+                Kernel::sleep interval
               else
                 $logger.error 'Failed to create Appium driver, exiting'
                 exit(::Maze::Api::ExitCode::SESSION_CREATION_FAILURE)

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -9,6 +9,7 @@ module Maze
 
         def initialize
           @session_ids = []
+          @start_attempts = 0
         end
 
         def start_session
@@ -47,51 +48,39 @@ module Maze
           raise 'Method not implemented by this class'
         end
 
+        def attempt_start_driver(config)
+          config.capabilities = device_capabilities
+          driver = Maze::Driver::Appium.new config.appium_server_url,
+                                            config.capabilities,
+                                            config.locator
+
+          result = driver.start_driver
+          if result
+            # Log details of this session
+            $logger.info "Created Appium session: #{driver.session_id}"
+            @session_ids << driver.session_id
+            udid = driver.session_capabilities['udid']
+            $logger.info "Running on device: #{udid}" unless udid.nil?
+          end
+          driver
+        end
+
         def start_driver(config)
-          retry_failure = retry_start_driver?
-          driver = nil
-          until Maze.driver
+
+          attempts = 0
+
+          while attempts < 5 && Maze.driver.nil?
+            attempts += 1
+            start_error = nil
             begin
+              Maze.driver = attempt_start_driver(config)
+            rescue => error
+              Bugsnag.notify error
+              $logger.error "Session creation failed: #{error}"
+              start_error = error
+            end
 
-
-              # Proc to start the driver
-              start_driver_closure = Proc.new do
-                begin
-                  config.capabilities = device_capabilities
-                  driver = Maze::Driver::Appium.new config.appium_server_url,
-                                                    config.capabilities,
-                                                    config.locator
-
-                  result = driver.start_driver
-                  if result
-                    # Log details of this session
-                    $logger.info "Created Appium session: #{driver.session_id}"
-                    @session_ids << driver.session_id
-                    udid = driver.session_capabilities['udid']
-                    $logger.info "Running on device: #{udid}" unless udid.nil?
-                  end
-                  result
-                rescue => error
-                  Bugsnag.notify error
-                  $logger.error "Session creation failed: #{error}"
-                  false
-                end
-              end
-
-
-              # Invoke the proc, with or without retries
-              if retry_failure
-                wait = Maze::Wait.new(interval: 10, timeout: 60)
-                success = wait.until(&start_driver_closure)
-              else
-                success = start_driver_closure.call
-              end
-
-              unless success
-                $logger.error 'Failed to create Appium driver, exiting'
-                exit(::Maze::Api::ExitCode::SESSION_CREATION_FAILURE)
-              end
-
+            if Maze.driver
               # Infer OS version if necessary when running locally
               if Maze.config.farm == :local && Maze.config.os_version.nil?
                 version = case Maze.config.os
@@ -103,21 +92,22 @@ module Maze
                 $logger.info "Inferred OS version to be #{version}"
                 Maze.config.os_version = version
               end
+            else
+              interval = retry_interval(start_error)
+              if interval
+                $logger.warn
+                  sleep interval
 
-              Maze.driver = driver
-            rescue ::Selenium::WebDriver::Error::UnknownError => original_exception
-              $logger.warn "Attempt to acquire #{config.device} device from farm #{config.farm} failed"
-              $logger.warn "Exception: #{original_exception.message}"
-              if config.device_list.empty?
-                $logger.error 'No further devices to try - raising original exception'
-                raise original_exception
               else
-                config.device = config.device_list.first
-                config.device_list = config.device_list.drop(1)
-                $logger.warn "Retrying driver initialisation using next device: #{config.device}"
+                $logger.error 'Failed to create Appium driver, exiting'
+                exit(::Maze::Api::ExitCode::SESSION_CREATION_FAILURE)
               end
             end
           end
+        end
+
+        def retry_interval(error)
+          raise 'Method not implemented by this class'
         end
 
         def start_scenario

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -93,12 +93,12 @@ module Maze
               end
             else
               interval = handle_error(start_error)
-              if interval
+              if interval && attempts < max_attempts
                 $logger.warn "Failed to create Appium driver, retrying in #{interval} seconds"
                 Kernel::sleep interval
               else
                 $logger.error 'Failed to create Appium driver, exiting'
-                exit(::Maze::Api::ExitCode::SESSION_CREATION_FAILURE)
+                Kernel::exit(::Maze::Api::ExitCode::SESSION_CREATION_FAILURE)
               end
             end
           end

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -17,22 +17,22 @@ module Maze
           # Retry interval depends on the error message
           return nil if error.nil?
 
+          interval = nil
+          notify = true
+
           if error.message.include? 'no sessionId in returned payload'
             # This will happen naturally due to a race condition in how we access devices
             # Do not notify, but wait long enough for most ghost sessions on BitBar to terminate.
-            return 60
+            interval = 60
+            notify = false
           elsif error.message.include? 'You reached the account concurrency limit'
             # In theory this shouldn't happen, but back off if it does
-            Bugsnag.notify error
-            return 300
+            interval = 300
           elsif error.message.include? 'There are no devices available'
-            Bugsnag.notify error
-            return 120
-          else
-            # No retries in unknown cases
-            Bugsnag.notify error
-            nil
+            interval = 120
           end
+          Bugsnag.notify error if notify
+          interval
         end
 
         def start_scenario

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -13,8 +13,20 @@ module Maze
           end
         end
 
-        def retry_start_driver?
-          false
+        def retry_interval(error)
+          # Retry interval depends on the error message
+          return nil if error.nil?
+
+          if error.message.include? 'no sessionId in returned payload'
+            # This will happen naturally due to a race condition in how we access devices
+            return 60
+          elsif error.message.include? 'You reached the account concurrency limit'
+            # In theory this shouldn't happen, but back off if it does
+            return 300
+          else
+            # No retries in unknown cases
+            nil
+          end
         end
 
         def start_scenario

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -30,7 +30,10 @@ module Maze
             interval = 300
           elsif error.message.include? 'There are no devices available'
             interval = 120
+          else
+            # Do not retry in any other case
           end
+
           Bugsnag.notify error if notify
           interval
         end

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -20,8 +20,7 @@ module Maze
               $logger.trace "Got group ids #{device_group_ids} for #{device_or_group_names}"
               group_count, device = api_client.find_device_in_groups(device_group_ids)
               if device.nil?
-                # TODO: Retry rather than fail, see PLAT-7377
-                Maze::Helper.error_exit 'There are no devices available'
+                raise 'There are no devices available'
               else
                 $logger.info "#{group_count} device(s) currently available in group(s) '#{device_or_group_names}'"
               end

--- a/lib/maze/client/appium/bs_client.rb
+++ b/lib/maze/client/appium/bs_client.rb
@@ -15,8 +15,17 @@ module Maze
           end
         end
 
-        def retry_start_driver?
-          Maze.config.device_list.nil? || Maze.config.device_list.empty?
+        # On BrowserStack, wait 10 seconds before retrying if there is another device in the list
+        def retry_interval(error)
+          if Maze.config.device_list.nil? || config.device_list.empty?
+            $logger.error 'No further devices to try'
+            nil
+          else
+            config.device = config.device_list.first
+            config.device_list = config.device_list.drop(1)
+            $logger.warn "Retrying driver initialisation using next device: #{config.device}"
+            10
+          end
         end
 
         def start_scenario

--- a/lib/maze/client/appium/bs_client.rb
+++ b/lib/maze/client/appium/bs_client.rb
@@ -16,7 +16,8 @@ module Maze
         end
 
         # On BrowserStack, wait 10 seconds before retrying if there is another device in the list
-        def retry_interval(error)
+        def handle_error(error)
+          Bugsnag.notify error unless error.nil?
           if Maze.config.device_list.nil? || config.device_list.empty?
             $logger.error 'No further devices to try'
             nil

--- a/test/client/appium/bb_client_test.rb
+++ b/test/client/appium/bb_client_test.rb
@@ -1,0 +1,84 @@
+require_relative '../../test_helper'
+require_relative '../../../lib/maze'
+require_relative '../../../lib/maze/configuration'
+require_relative '../../../lib/maze/driver/appium'
+require_relative '../../../lib/maze/client/bb_api_client'
+require_relative '../../../lib/maze/client/bb_client_utils'
+require_relative '../../../lib/maze/client/appium/base_client'
+require_relative '../../../lib/maze/client/appium/bb_client'
+require_relative '../../../lib/maze/client/appium/bb_devices'
+require_relative '../../../lib/utils/deep_merge'
+
+module Maze
+  module Client
+    module Appium
+      class BitBarClientTest < Test::Unit::TestCase
+
+        def setup
+          logger_mock = mock('logger')
+          $logger = logger_mock
+        end
+
+        def test_start_driver_success
+          Maze.driver = nil
+
+          # Setup inputs
+          client = BitBarClient.new
+          Maze.config.app = 'app'
+          Maze.config.access_key = 'apiKey'
+          Maze.config.appium_server_url = 'appium server'
+          Maze.config.capabilities_option = '{"config":"capabilities"}'
+          Maze.config.locator = :id
+
+          # Dashboard caps
+          dashboard_caps = {
+            'bitbar:options' => {
+              bitbar_project: 'project',
+              bitbar_testrun: 'test_run'
+            }
+          }
+          Maze::Client::BitBarClientUtils.expects(:dashboard_capabilities).returns dashboard_caps
+
+          # Device caps
+          device_caps = {
+            'platformName' => 'iOS'
+          }
+          Maze::Client::Appium::BitBarDevices.expects(:get_available_device).returns device_caps
+
+          # Driver creation
+          expected_caps = {
+            'appium:options' => {
+              'noReset' => true,
+              'newCommandTimeout' => 600
+            },
+            'bitbar:options' => {
+              'apiKey' => 'apiKey',
+              'app' => 'app',
+              'findDevice' => false,
+              'testTimeout' => 7200,
+              :bitbar_project => 'project',
+              :bitbar_testrun => 'test_run'},
+            'platformName' => 'iOS',
+            'config' => 'capabilities'
+          }
+          mock_driver = mock('driver')
+          Maze::Driver::Appium.expects(:new).with(Maze.config.appium_server_url,
+                                                  expected_caps,
+                                                  Maze.config.locator).returns mock_driver
+
+          # Starting of the driver
+          mock_driver.expects(:session_id).twice.returns 'session_id'
+          mock_driver.expects(:session_capabilities).returns({ 'uuid' => 'uuid' })
+          mock_driver.expects(:start_driver).returns true
+          BitBarApiClient.stubs(:new)
+
+          # Logging
+          $logger.expects(:info).with('Created Appium session: session_id')
+
+
+          client.start_driver Maze.config
+        end
+      end
+    end
+  end
+end

--- a/test/client/appium/bb_client_test.rb
+++ b/test/client/appium/bb_client_test.rb
@@ -1,3 +1,4 @@
+require 'bugsnag'
 require_relative '../../test_helper'
 require_relative '../../../lib/maze'
 require_relative '../../../lib/maze/api/exit_code'
@@ -33,6 +34,10 @@ module Maze
 
           # Driver creation
           expected_caps = {
+            'appium' => {
+              'noReset' => true,
+              'newCommandTimeout' => 600
+            },
             'appium:options' => {
               'noReset' => true,
               'newCommandTimeout' => 600
@@ -77,6 +82,7 @@ module Maze
           # Successful starting of the driver
           @mock_driver.expects(:session_id).twice.returns 'session_id'
           @mock_driver.expects(:session_capabilities).returns({ 'uuid' => 'uuid' })
+          Bugsnag.expects(:notify).never
 
           client = BitBarClient.new
           client.start_driver Maze.config
@@ -102,6 +108,7 @@ module Maze
           $logger.expects(:info).with('Created Appium session: session_id')
           @mock_driver.expects(:session_id).twice.returns 'session_id'
           @mock_driver.expects(:session_capabilities).returns({ 'uuid' => 'uuid' })
+          Bugsnag.expects(:notify).never
 
           client = BitBarClient.new
           client.start_driver Maze.config
@@ -129,6 +136,7 @@ module Maze
           $logger.expects(:error).with("Session creation failed: #{message_2}")
           Kernel.expects(:exit).with(::Maze::Api::ExitCode::SESSION_CREATION_FAILURE)
           $logger.expects(:error).with("Failed to create Appium driver, exiting")
+          Bugsnag.expects(:notify).twice
 
           client = BitBarClient.new
           client.start_driver Maze.config, 2

--- a/test/client/bb_client_utils_test.rb
+++ b/test/client/bb_client_utils_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative '../test_helper'
 require_relative '../../lib/maze'
 require_relative '../../lib/maze/client/bb_client_utils'
 require_relative '../../lib/maze/runner'


### PR DESCRIPTION
## Goal

Refactor the Appium client so that a different retry strategy can be employed for each device farm.  For BitBar, we will not retry after waiting for different times depending on the error that was experienced.

## Changeset

Relatively light refactor to push `handle_error` into each farm-specific client, allowing them to retry based on different logic.

## Tests

Some manual testing performed, but the retry logic is primarily covered by a new unit test.