### PR TITLE
Fix crash when logging message for invalid requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.10.2 - 2023/10/27
+
+## Fixes
+
+- Fix crash when logging message for invalid requests [602](https://github.com/bugsnag/maze-runner/pull/602)
+
 # 8.10.1 - 2023/10/25
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.10.1)
+    bugsnag-maze-runner (8.10.2)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.10.1'
+  VERSION = '8.10.2'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -118,7 +118,7 @@ module Maze
         msg = "Invalid #{@request_type} request: #{e.message}"
         if Maze.config.captured_invalid_requests.include? @request_type
           Bugsnag.notify e
-          $logger.msg
+          $logger.error msg
           Server.invalid_requests.add({
             invalid: true,
             reason: e.message,


### PR DESCRIPTION
## Goal

Fixes a crash when logging the message for invalid requests received.

## Tests

Verified by peer review.
