### PR TITLE
Fix crash when BUILDKITE_JOB_ID is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 8.10.2 - 2023/10/27
+
+## Fixes
+
+- Fix crash when logging message for invalid requests [602](https://github.com/bugsnag/maze-runner/pull/602)
+- Fix crash when BUILDKITE_JOB_ID is not set [603](https://github.com/bugsnag/maze-runner/pull/603)
+
 # 8.10.1 - 2023/10/25
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.10.1)
+    bugsnag-maze-runner (8.10.2)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.10.1'
+  VERSION = '8.10.2'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/bugsnag_config.rb
+++ b/lib/maze/bugsnag_config.rb
@@ -17,16 +17,22 @@ module Maze
             'device farm': Maze.config.farm,
             'capabilities': Maze.config.capabilities
           }) if Maze.driver
-          config.add_metadata(:'buildkite', {
-            'pipeline': ENV['BUILDKITE_PIPELINE_NAME'],
-            'repo': ENV['BUILDKITE_REPO'],
-            'build url': ENV['BUILDKITE_BUILD_URL'],
-            'job url': ENV['BUILDKITE_BUILD_URL'] + "#" + ENV['BUILDKITE_JOB_ID'],
-            'branch': ENV['BUILDKITE_BRANCH'],
-            'builder': ENV['BUILDKITE_BUILD_CREATOR'],
-            'message': ENV['BUILDKITE_MESSAGE'],
-            'step': ENV['BUILDKITE_LABEL']
-          }) if ENV['BUILDKITE']
+
+          if ENV['BUILDKITE']
+            metadata = {
+              'pipeline': ENV['BUILDKITE_PIPELINE_NAME'],
+              'repo': ENV['BUILDKITE_REPO'],
+              'build url': ENV['BUILDKITE_BUILD_URL'],
+              'branch': ENV['BUILDKITE_BRANCH'],
+              'builder': ENV['BUILDKITE_BUILD_CREATOR'],
+              'message': ENV['BUILDKITE_MESSAGE'],
+              'step': ENV['BUILDKITE_LABEL']
+            }
+            if ENV['BUILDKITE_JOB_ID']
+              metadata['job url'] = ENV['BUILDKITE_BUILD_URL'] + "#" + ENV['BUILDKITE_JOB_ID']
+            end
+          end
+          config.add_metadata(:'buildkite', metadata)
           config.project_root = Dir.pwd
         end
 


### PR DESCRIPTION
## Goal

Fixes a crash when the `BUILDKITE` environment variable was set but `BUILDKITE_JOB_ID` was not.

## Tests

The crash was easily reproduced by setting a couple of variables to arbitrary values:
```
cd test/fixtures/browser
MAZE_BUGSNAG_API_KEY=1 BUILDKITE=1 bundle exec maze-runner
```

The crash goes away with this change.