### PR TITLE
Notify errors that occur in Appium or Browser hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 8.11.0 - 2023/11/15 
+# 8.12.0 - 2023/11/07
+
+## Enhancements
+
+- Notify errors that occur in Appium or Browser hooks [605](https://github.com/bugsnag/maze-runner/pull/605)
+
+# 8.11.0 - 2023/11/03
 
 ## Enhancements
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.11.0)
+    bugsnag-maze-runner (8.12.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.11.0'
+  VERSION = '8.12.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -8,10 +8,18 @@ module Maze
       def before_all
         Maze::Plugins::DatadogMetricsPlugin.send_increment('appium.test_started')
         @client = Maze::Client::Appium.start
+      rescue => error
+        # Notify and re-raise for Cucumber to handle
+        Bugsnag.notify error
+        raise
       end
 
       def before(scenario)
         @client.start_scenario
+      rescue => error
+        # Notify and re-raise for Cucumber to handle
+        Bugsnag.notify error
+        raise
       end
 
       def after(scenario)
@@ -31,6 +39,10 @@ module Maze
             Maze.driver.reset
           end
         end
+      rescue => error
+        # Notify and re-raise for Cucumber to handle
+        Bugsnag.notify error
+        raise
       end
 
       def after_all
@@ -40,6 +52,10 @@ module Maze
         else
           Maze::Plugins::DatadogMetricsPlugin.send_increment('appium.test_failed')
         end
+      rescue => error
+        # Notify and re-raise for Cucumber to handle
+        Bugsnag.notify error
+        raise
       end
 
       def at_exit

--- a/lib/maze/hooks/browser_hooks.rb
+++ b/lib/maze/hooks/browser_hooks.rb
@@ -5,10 +5,18 @@ module Maze
     class BrowserHooks < InternalHooks
       def before_all
         @client = Maze::Client::Selenium.start
+      rescue => error
+        # Notify and re-raise for Cucumber to handle
+        Bugsnag.notify error
+        raise
       end
 
       def after_all
         @client&.log_run_outro
+      rescue => error
+        # Notify and re-raise for Cucumber to handle
+        Bugsnag.notify error
+        raise
       end
 
       def at_exit


### PR DESCRIPTION
## Goal

Notify errors that occur in Appium or Browser hooks, to provide better visibility of device farm issues occurring in e2e tests.

## Tests

Tested by temporarily adding explicit `raise` statements to force an error condition.  In each case the error was reported to BugSnag, with an error still being output to the console and causing the test run to fail.