### PR TITLE
Add appium options to the base capabilities dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+
+- Add appium options to the base capabilities dictionary [606](https://github.com/bugsnag/maze-runner/pull/606)
+
 # 8.12.0 - 2023/11/07
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# TBD
+# 8.12.1 - 2023/11/09
+
+## Fixes
 
 - Add appium options to the base capabilities dictionary [606](https://github.com/bugsnag/maze-runner/pull/606)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.12.0)
+    bugsnag-maze-runner (8.12.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -125,11 +125,11 @@ GEM
     power_assert (2.0.3)
     props (1.2.0)
       iniparser (>= 0.1.0)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.8)
     rake (12.3.3)
     redcarpet (3.6.0)
-    regexp_parser (2.8.1)
+    regexp_parser (2.8.2)
     rexml (3.2.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.5.0)
@@ -158,7 +158,7 @@ GEM
     unf_ext (0.0.8.2)
     uri_template (0.7.0)
     webrick (1.7.0)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.12.0'
+  VERSION = '8.12.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -91,46 +91,44 @@ module Maze
           end
 
           def make_android_hash(device)
-            # Doubling up on capabilities in both the `appium:options` and `appium` sub dictionaries.
+            # Tripling up on capabilities in the `appium:options`, `appium` sub dictionaries and base dictionary.
             # See PLAT-11087
+            appium_options = {
+              'automationName' => 'UiAutomator2',
+              'autoGrantPermissions' => true,
+              'uiautomator2ServerInstallTimeout' => 60000
+            }
             hash = {
               'platformName' => 'Android',
               'deviceName' => 'Android Phone',
-              'appium:options' => {
-                'automationName' => 'UiAutomator2',
-                'autoGrantPermissions' => true,
-                'uiautomator2ServerInstallTimeout' => 60000
-              },
-              'appium' => {
-                'automationName' => 'UiAutomator2',
-                'autoGrantPermissions' => true,
-                'uiautomator2ServerInstallTimeout' => 60000
-              },
+              'appium:options' => appium_options,
+              'appium' => appium_options,
               'bitbar:options' => {
                 'device' => device,
               }
             }
+            hash.merge!(appium_options)
             hash.freeze
           end
 
           def make_ios_hash(device)
-            # Doubling up on capabilities in both the `appium:options` and `appium` sub dictionaries.
+            # Tripling up on capabilities in the `appium:options`, `appium` sub dictionaries and base dictionary.
             # See PLAT-11087
-            {
+            appium_options = {
+              'automationName' => 'XCUITest',
+              'shouldTerminateApp' => 'true'
+            }
+            hash = {
               'platformName' => 'iOS',
               'deviceName' => 'iPhone device',
-              'appium:options' => {
-                'automationName' => 'XCUITest',
-                'shouldTerminateApp' => 'true'
-              },
-              'appium' => {
-                'automationName' => 'XCUITest',
-                'shouldTerminateApp' => 'true'
-              },
+              'appium:options' => appium_options,
+              'appium' => appium_options,
               'bitbar:options' => {
                 'device' => device
               }
-            }.freeze
+            }
+            hash.merge!(appium_options)
+            hash.freeze
           end
         end
       end


### PR DESCRIPTION
## Goal
Further adds the appium options capabilities to the base hash of capabilities to attempt fixing of our `automationName` missing errors.