### PR TITLE
Do not use driver.reset with BitBar devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.0.0 - TBD
+
+## Enhancements
+
+- Remove use of deprecated `Maze.driver.reset` in BitBar Appium tests [606](https://github.com/bugsnag/maze-runner/pull/606)
+
 # 8.12.1 - 2023/11/09
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 GIT
   remote: https://github.com/bugsnag/yard-cucumber
-  revision: 44663c8a5ee53eceaa873fbe5c6f5e127ca34ecf
+  revision: 4e01273cf2ac197da487a9267e2a5f3d769c27db
   specs:
     yard-cucumber (4.0.0)
       cucumber (>= 2.0, < 9.0)
-      yard (~> 0.8, >= 0.8.1)
+      yard (~> 0.9.20, >= 0.9.20)
 
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.12.1)
+    bugsnag-maze-runner (9.0.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -30,10 +30,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.6)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     appium_lib (12.0.1)
       appium_lib_core (~> 5.0)
@@ -42,11 +47,14 @@ GEM
     appium_lib_core (5.4.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 4.2, < 4.6)
+    base64 (0.2.0)
+    bigdecimal (3.1.4)
     bugsnag (6.26.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (4.1.0)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     cucumber (7.1.0)
       builder (~> 3.2, >= 3.2.4)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -81,13 +89,15 @@ GEM
     curb (0.9.11)
     diff-lcs (1.5.0)
     dogstatsd-ruby (5.5.0)
+    drb (2.2.0)
+      ruby2_keywords
     ecma-re-validator (0.4.0)
       regexp_parser (~> 2.2)
     eventmachine (1.2.7)
     faye-websocket (0.11.3)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.15.5)
+    ffi (1.16.3)
     hana (1.3.7)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -112,12 +122,13 @@ GEM
       kramdown (>= 1.5.0)
       props (>= 1.1.2)
       textutils (>= 0.10.0)
-    mime-types (3.4.1)
+    mime-types (3.5.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0218.1)
-    minitest (5.18.1)
+    mime-types-data (3.2023.1003)
+    minitest (5.20.0)
     mocha (1.13.0)
     multi_test (0.1.2)
+    mutex_m (0.2.0)
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
@@ -130,7 +141,8 @@ GEM
     rake (12.3.3)
     redcarpet (3.6.0)
     regexp_parser (2.8.2)
-    rexml (3.2.5)
+    rexml (3.2.6)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
@@ -149,7 +161,7 @@ GEM
       props (>= 1.1.2)
       rubyzip (>= 1.0.0)
     thor (1.0.1)
-    timecop (0.9.6)
+    timecop (0.9.8)
     tomlrb (2.0.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -169,7 +181,6 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
-  x86_64-darwin-20
 
 DEPENDENCIES
   bugsnag-maze-runner!

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,11 @@
 # Upgrading Guide
 
+## v8 to v9
+
+### Clearing app data between test scenarios
+
+Use of the deprecated Appium `driver.reset` method has been removed and replaced with `terminate_app` and `activate_app` calls (when using BitBar only).  This means that responsibility for clearing app files between scenarios passes to the individual test fixtures (most of which already do it anyway).
+
 ## v7 to v8
 
 ### Command line options

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.12.1'
+  VERSION = '9.0.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -30,13 +30,18 @@ module Maze
         elsif [:bb, :bs, :local].include? Maze.config.farm
           write_device_logs(scenario) if scenario.failed?
 
-          # TODO: PLAT-10300 - Review our general approach to resetting the app between scenarios
-          re = Regexp.new('^1\.1[56]\.\d$')
-          if re.match? Maze.config.appium_version
-            Maze.driver.close_app
-            Maze.driver.launch_app
+          # Cautiously only applying the new way of resetting the app to BitBar
+          if Maze.config.farm == :bb
+            Maze.driver.terminate_app Maze.driver.app_id
+            Maze.driver.activate_app Maze.driver.app_id
           else
-            Maze.driver.reset
+            re = Regexp.new('^1\.1[56]\.\d$')
+            if re.match? Maze.config.appium_version
+              Maze.driver.close_app
+              Maze.driver.launch_app
+            else
+              Maze.driver.reset
+            end
           end
         end
       rescue => error


### PR DESCRIPTION
## Goal

Remove use of the deprecated Appium `driver.reset` method.

## Design

This means that test fixtures and scenarios will need to take responsibility for clearing any persistent files between scenarios. The Android fixture already does this to a large extent, I just found a couple of extra files needed to be deleted.

## Documentation

Upgrading guide updated.

## Changeset

For BitBar devices only, `Maze.driver.reset` replaced with:
```
Maze.driver.terminate_app <app_id>
Maze.driver.activate_app <app_id>
```

## Tests

Covered by CI.  