### PR TITLE
Work around Event Machine issue on ARM macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-# TBD
+# 8.13.0 - 2023/11/17
 
 ## Enhancements
 
 - Modify retry logic for app upload failures and BitBar appium failures [608](https://github.com/bugsnag/maze-runner/pull/608)
+
+## Fixes
+
+- Work around Event Machine issues on ARM macOS [606](https://github.com/bugsnag/maze-runner/pull/609)
 
 # 8.12.1 - 2023/11/09
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.12.1)
+    bugsnag-maze-runner (8.13.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/bin/download-logs
+++ b/bin/download-logs
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Workaround for running on ARM macOS machines
+require 'em/pure_ruby'
+
 require_relative '../lib/maze'
 require_relative '../lib/maze/client/bs_client_utils'
 require_relative '../lib/maze/logger'

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Workaround for running on ARM macOS machines
+require 'em/pure_ruby'
+
 require 'cucumber/cli/main'
 
 require_relative '../lib/utils/deep_merge'

--- a/bin/purge-projects
+++ b/bin/purge-projects
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Workaround for running on ARM macOS machines
+require 'em/pure_ruby'
+
 require_relative '../lib/maze'
 require_relative '../lib/maze/client/bb_api_client'
 require_relative '../lib/maze/logger'

--- a/bin/upload-app
+++ b/bin/upload-app
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Workaround for running on ARM macOS machines
+require 'em/pure_ruby'
+
 require_relative '../lib/maze'
 require_relative '../lib/maze/client/bs_client_utils'
 require_relative '../lib/maze/client/bb_client_utils'

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.12.1'
+  VERSION = '8.13.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

Works around the following crash on ARM-based macOS machines:
```
bash-3.2$ bundle exec maze-runner --version
Unable to load the EventMachine C extension; To use the pure-ruby reactor, require 'em/pure_ruby'
bundler: failed to load command: maze-runner (/Users/administrator/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/bin/maze-runner)
```

## Design

Previously we can manually added this to the installed Gem on our ARM build servers, but we're changing how Gems and managed and so Maze Runner needs to work out of the box.

## Tests

Covered by CI and by running the tool locally on an ARM machine.