### PR TITLE
Increase `uiautomator2ServerLaunchTimeout` to 60s on BitBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.13.1 - 2023/11/20
+
+## Fixes
+
+- Increase `uiautomator2ServerLaunchTimeout` to 60s on BitBar [6XX](https://github.com/bugsnag/maze-runner/pull/6XX)
+
 # 8.13.0 - 2023/11/17
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Fixes
 
-- Increase `uiautomator2ServerLaunchTimeout` to 60s on BitBar [6XX](https://github.com/bugsnag/maze-runner/pull/6XX)
+- Increase `uiautomator2ServerLaunchTimeout` to 60s on BitBar [610](https://github.com/bugsnag/maze-runner/pull/610)
 
 # 8.13.0 - 2023/11/17
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.13.0)
+    bugsnag-maze-runner (8.13.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.13.0'
+  VERSION = '8.13.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -96,7 +96,8 @@ module Maze
             appium_options = {
               'automationName' => 'UiAutomator2',
               'autoGrantPermissions' => true,
-              'uiautomator2ServerInstallTimeout' => 60000
+              'uiautomator2ServerInstallTimeout' => 60000,
+              'uiautomator2ServerLaunchTimeout' => 60000
             }
             hash = {
               'platformName' => 'Android',


### PR DESCRIPTION
## Goal

Analogy of #590 for launching Android apps on BitBar.

Try to avoid mid-run test failures on BitBar caused by slow launch times of Android apps.

## Design

Increases the `uiautomator2ServerLaunchTimeout` from the default 20s to 60s.

## Tests

Covered by CI and inspection of the BitBar dashboard.  I've checked in the Appium logs that there are no errors being caused by the capabilities now set.