### PR TITLE
Auto-accept alerts on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.13.2 - 2023/11/29
+
+## Fixes
+
+- Set `autoAcceptAlerts` in iOS Appium tests [611](https://github.com/bugsnag/maze-runner/pull/611)
+
 # 8.13.1 - 2023/11/20
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.13.1)
+    bugsnag-maze-runner (8.13.2)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.13.1'
+  VERSION = '8.13.2'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -117,7 +117,8 @@ module Maze
             # See PLAT-11087
             appium_options = {
               'automationName' => 'XCUITest',
-              'shouldTerminateApp' => 'true'
+              'shouldTerminateApp' => 'true',
+              'autoAcceptAlerts' => 'true'
             }
             hash = {
               'platformName' => 'iOS',

--- a/lib/maze/client/appium/bs_devices.rb
+++ b/lib/maze/client/appium/bs_devices.rb
@@ -50,6 +50,7 @@ module Maze
 
           def make_ios_hash(device, version)
             {
+              'appium:autoAcceptAlerts' => 'true',
               'platformName' => 'ios',
               'platformVersion' => version,
               'deviceName' => device


### PR DESCRIPTION
## Goal

Auto accept iOS alert this this one:
<img width="449" alt="image" src="https://github.com/bugsnag/maze-runner/assets/5239394/9d1c0522-7e45-4cd5-a75f-d76195bc8c65">

## Tests

Tested locally with both BrowserStack and BitBar, verifying that the alert is dismissed in the video recording.