### PR TITLE
Correct logic for use of BUILDKITE_RETRY_COUNT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.14.1 - 2023/12/21
+
+## Fixes
+
+- Use Buildkite retry count correctly in BitBar test run names [614](https://github.com/bugsnag/maze-runner/pull/614)
+
 # 8.14.0 - 2023/12/18
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.14.0)
+    bugsnag-maze-runner (8.14.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.14.0'
+  VERSION = '8.14.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/bb_client_utils.rb
+++ b/lib/maze/client/bb_client_utils.rb
@@ -155,7 +155,7 @@ module Maze
           # Test run
           if ENV['BUILDKITE']
             bk_retry = ENV['BUILDKITE_RETRY_COUNT']
-            retry_string = if !bk_retry.nil? && bk_retry.to_i > 1
+            retry_string = if !bk_retry.nil? && bk_retry.to_i > 0
                              " (#{bk_retry})"
                            else
                              ''


### PR DESCRIPTION
## Goal

Correct logic for use of BUILDKITE_RETRY_COUNT - it is zero based, so the first attempt of a job has a value of 0 for it.

## Tests

Covered by CI.