### PR TITLE
Add command line options to set appActivity and appPackage capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.15.0 - 2024/01/03
+
+## Enhancements
+
+- Add `--app-package` and `--app-activity` options (used for BitBar Appium tests only) [615](https://github.com/bugsnag/maze-runner/pull/615)
+
 # 8.14.1 - 2023/12/21
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.14.1)
+    bugsnag-maze-runner (8.15.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -146,7 +146,7 @@ After do |scenario|
 
   # Log all received requests to the console if the scenario fails and/or config says to
   if (scenario.failed? && Maze.config.log_requests) || Maze.config.always_log
-    $stdout.puts '^^^ +++'
+    $stdout.puts '^^^ +++' if ENV['BUILDKITE']
     output_received_requests('errors')
     output_received_requests('sessions')
     output_received_requests('traces')

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.14.1'
+  VERSION = '8.15.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -99,6 +99,8 @@ module Maze
               'uiautomator2ServerInstallTimeout' => 60000,
               'uiautomator2ServerLaunchTimeout' => 60000
             }
+            appium_options['appActivity'] = Maze.config.app_activity unless Maze.config.app_activity.nil?
+            appium_options['appPackage'] = Maze.config.app_package unless Maze.config.app_package.nil?
             hash = {
               'platformName' => 'Android',
               'deviceName' => 'Android Phone',

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -137,6 +137,12 @@ module Maze
     # Test browser version
     attr_accessor :browser_version
 
+    # The appActivity to be set in the Appium capabilities
+    attr_accessor :app_activity
+
+    # The appPackage to be set in the Appium capabilities
+    attr_accessor :app_package
+
     # Appium version to use
     attr_accessor :appium_version
 

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -21,7 +21,9 @@ module Maze
 
     # Generic device farm options
     ACCESS_KEY = 'access-key'
+    APP_ACTIVITY = 'app-activity'
     APP_BUNDLE_ID = 'app-bundle-id'
+    APP_PACKAGE = 'app-package'
     APPIUM_VERSION = 'appium-version'
     BROWSER = 'browser'
     BROWSER_VERSION = 'browser-version'

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -134,6 +134,14 @@ module Maze
                 'Device farm access key. Consumes env var from environment based on farm set',
                 short: :none,
                 type: :string
+            opt Option::APP_ACTIVITY,
+                'The appActivity to set in the Appium capabilities (for BitBar only)',
+                short: :none,
+                type: :string
+            opt Option::APP_PACKAGE,
+                'The appPackage to set in the Appium capabilities (for BitBar only)',
+                short: :none,
+                type: :string
             opt Option::APPIUM_VERSION,
                 'The Appium version to use',
                 short: :none,

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -47,6 +47,8 @@ module Maze
                         end
           config.locator = options[Maze::Option::A11Y_LOCATOR] ? :accessibility_id : :id
           config.capabilities_option = options[Maze::Option::CAPABILITIES]
+          config.app_activity = options[Maze::Option::APP_ACTIVITY]
+          config.app_package = options[Maze::Option::APP_PACKAGE]
           config.legacy_driver = !ENV['USE_LEGACY_DRIVER'].nil?
           config.start_tunnel = options[Maze::Option::TUNNEL]
 

--- a/test/option/parser_test.rb
+++ b/test/option/parser_test.rb
@@ -41,6 +41,8 @@ class ParserTest < Test::Unit::TestCase
     assert_nil(options[Maze::Option::USERNAME])
     assert_nil(options[Maze::Option::ACCESS_KEY])
     assert_nil(options[Maze::Option::APPIUM_VERSION])
+    assert_nil(options[Maze::Option::APP_ACTIVITY])
+    assert_nil(options[Maze::Option::APP_PACKAGE])
     assert_true(options[Maze::Option::TUNNEL])
 
     # Local-only options
@@ -77,6 +79,8 @@ class ParserTest < Test::Unit::TestCase
       --browser-version=ARG_BROWSER_VERSION
       --username=ARG_USERNAME
       --access-key=ARG_ACCESS_KEY
+      --app-activity=ARG_APP_ACTIVITY
+      --app-package=ARG_APP_PACKAGE
       --appium-version=ARG_APPIUM_VERSION
       --os=ARG_OS
       --os-version=ARG_OS_VERSION
@@ -103,6 +107,8 @@ class ParserTest < Test::Unit::TestCase
     assert_equal('ARG_BROWSER_VERSION', options[Maze::Option::BROWSER_VERSION])
     assert_equal('ARG_USERNAME', options[Maze::Option::USERNAME])
     assert_equal('ARG_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])
+    assert_equal('ARG_APP_ACTIVITY', options[Maze::Option::APP_ACTIVITY])
+    assert_equal('ARG_APP_PACKAGE', options[Maze::Option::APP_PACKAGE])
     assert_equal('ARG_APPIUM_VERSION', options[Maze::Option::APPIUM_VERSION])
     assert_false(options[Maze::Option::TUNNEL])
 


### PR DESCRIPTION
## Goal

Add command line options to set `appActivity` and `appPackage` capabilities.

## Design

Android apps have regularly failed to start with Appium 2, the fix for which is to set the `appActivity` and `appPackage` capabilities.  This is 

## Documentation

Included in the `help` output for the command line options.

## Changeset

New command line options and associated processing added.  Capabilities set in BitBar appium sessions when provided.

## Tests

Mostly covered by unit tests and I've also run a simple test locally to verify that the the capabilities are actually set in the session.
