### PR TITLE
Clear request lists while the app is stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# 9.0.0 - TBD
+# 9.0.0 - 2024/01/17
 
 ## Enhancements
 
 - Remove use of deprecated `Maze.driver.reset` in BitBar Appium tests [607](https://github.com/bugsnag/maze-runner/pull/607)
+- Clear request lists while the app is stopped [619](https://github.com/bugsnag/maze-runner/pull/619)
 
 # 8.16.0 - TBD
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,7 +4,7 @@
 
 ### Clearing app data between test scenarios
 
-Use of the deprecated Appium `driver.reset` method has been removed and replaced with `terminate_app` and `activate_app` calls (when using BitBar only).  This means that responsibility for clearing app files between scenarios passes to the individual test fixtures (most of which already do it anyway).
+Use of the deprecated Appium `driver.reset` method has been removed and replaced with `terminate_app` and `activate_app` calls.  This means that responsibility for clearing app files between scenarios passes to the individual test fixtures (most of which already do it anyway).
 
 ## v7 to v8
 

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -30,19 +30,11 @@ module Maze
         elsif [:bb, :bs, :local].include? Maze.config.farm
           write_device_logs(scenario) if scenario.failed?
 
-          # Cautiously only applying the new way of resetting the app to BitBar
-          if Maze.config.farm == :bb
-            Maze.driver.terminate_app Maze.driver.app_id
-            Maze.driver.activate_app Maze.driver.app_id
-          else
-            re = Regexp.new('^1\.1[56]\.\d$')
-            if re.match? Maze.config.appium_version
-              Maze.driver.close_app
-              Maze.driver.launch_app
-            else
-              Maze.driver.reset
-            end
-          end
+          # Reset the server to ensure that test fixtures cannot fetch
+          # commands from the previous scenario (in idempotent mode).
+          Maze.driver.terminate_app Maze.driver.app_id
+          Maze::Server.reset!
+          Maze.driver.activate_app Maze.driver.app_id
         end
       rescue => error
         # Notify and re-raise for Cucumber to handle


### PR DESCRIPTION
## Goal

Reset the `Maze::Server` while the app is stopped.

## Design

There's a problem with idempotent Commands when it comes to moving onto the following scenario.  If the list of commands is reset while the fixture is still polling with a UUID, then warnings will be continually logged that there is no command with the given UUID.  Conversely, if the app is restarted before we clear the list then the scenario will get the command intended for the previous scenario and everything gets messed up.

One way to handle this is to reset the lists after we terminate the app but before we start it again for the next scenario.

## Changeset

I've also changed the calls used for stopping/starting the app to be consistent across all device farms and Appium versions.  It was getting confusing trying to remember each combination and the difference is only likely to surprise engineers when hopping between device farms.  We'd be better off just updating fixtures to fit with this approach (and we have the major version bump in place already).

Note that the `v8` branch needs to be released and merged into `main` before it can be released as v9.  Currently the `main` branch only have the unreleased set of changes in it.

## Tests

Covered by CI and I've tested that the issue with idempotent command is fixed by running the set of Cocoa Performance tests against it.