### PR TITLE
Add retry case for BitBar Appium sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# 8.17.0 - TBD
+# 8.17.0 - 2024/01/24
 
 ## Enhancements
 
 - Split logging into STDOUT and File loggers, for more information during test runs [618](https://github.com/bugsnag/maze-runner/pull/618)
+- Retry BitBar device session creation for `Appium Settings app is not running` error [619](https://github.com/bugsnag/maze-runner/pull/619)
 
 # 8.16.0 - 2024/01/17
 

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -30,6 +30,8 @@ module Maze
             interval = 300
           elsif error.message.include? 'There are no devices available'
             interval = 120
+          elsif error.message.include? 'Appium Settings app is not running'
+            interval = 10
           else
             # Do not retry in any other case
           end


### PR DESCRIPTION
## Goal

Adds a retry case for failed BitBar Appium sessions.  

## Design

If this error occurs then it's likely to be an isolated issue on a specific device and a near immediate retry on another device will succeed.

## Tests

Covered by CI/peer review.