### PR TITLE
Move appium outro logging to at_exit method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.17.1 - 2024/01/24
+
+## Fixes
+
+- Move appium session information to at_exit block to always run, even on maze-runner crash [623](https://github.com/bugsnag/maze-runner/pull/623)
+
 # 8.17.0 - 2024/01/24
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.17.0)
+    bugsnag-maze-runner (8.17.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.17.0'
+  VERSION = '8.17.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -46,7 +46,6 @@ module Maze
       end
 
       def after_all
-        @client&.log_run_outro
         if $success
           Maze::Plugins::DatadogMetricsPlugin.send_increment('appium.test_succeeded')
         else
@@ -60,6 +59,7 @@ module Maze
 
       def at_exit
         if @client
+          @client.log_run_outro
           $logger.info 'Stopping the Appium session'
           @client.stop_session
         end


### PR DESCRIPTION
## Goal

When an internal error occurs in maze-runner the existing `after_all` hooks won't be run, meaning we won't get appium clients outputting the session(s) information for easy linking.

This moves the hook into the `at_exit` hook, ensuring it will always be run if possible.