### PR TITLE
Allow Appium versions to be set on BitBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.18.0 - 2024/01/26
+
+## Enhancements
+
+- Allow Appium version to be set on BitBar [624](https://github.com/bugsnag/maze-runner/pull/624)
+
 # 8.17.1 - 2024/01/24
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.17.1)
+    bugsnag-maze-runner (8.18.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.17.1'
+  VERSION = '8.18.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -75,7 +75,9 @@ module Maze
           }
           capabilities.deep_merge! BitBarClientUtils.dashboard_capabilities
           capabilities.deep_merge! BitBarDevices.get_available_device(config.device)
+          capabilities['bitbar:options']['appiumVersion'] = config.appium_version unless config.appium_version.nil?
           capabilities.deep_merge! JSON.parse(config.capabilities_option)
+
           capabilities
         end
 


### PR DESCRIPTION
## Goal

Allow Appium versions to be set on BitBar (within the bounds of what BitBar supports).

## Tests

Tested locally using the `--appium-version` option, inspecting the version in the appium.log in the dashboard.