### PR TITLE
Re-enable reporting on test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.19.0 - 2024/02/08
+
+## Enhancements
+
+- Re-enable bugsnag reporting test failures when MAZE_SCENARIO_BUGSNAG_API_KEY environment variable is present [626](https://github.com/bugsnag/maze-runner/pull/626)
+
 # 8.18.0 - 2024/01/26
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.18.0)
+    bugsnag-maze-runner (8.19.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -42,7 +42,7 @@ GEM
     appium_lib_core (5.4.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 4.2, < 4.6)
-    bugsnag (6.26.0)
+    bugsnag (6.26.3)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (4.1.0)
@@ -118,7 +118,7 @@ GEM
     minitest (5.18.1)
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.15.4-x86_64-darwin)
+    nokogiri (1.15.5-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -129,7 +129,7 @@ GEM
     rack (2.2.8)
     rake (12.3.3)
     redcarpet (3.6.0)
-    regexp_parser (2.8.2)
+    regexp_parser (2.9.0)
     rexml (3.2.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.5.0)
@@ -155,7 +155,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.2)
+    unf_ext (0.0.9.1)
     uri_template (0.7.0)
     webrick (1.7.0)
     websocket (1.2.10)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ x-common-environment: &common-environment
   BUILDKITE_RETRY_COUNT:
   BUILDKITE_STEP_KEY:
   MAZE_BUGSNAG_API_KEY:
+  MAZE_SCENARIO_BUGSNAG_KEY:
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ x-common-environment: &common-environment
   BUILDKITE_RETRY_COUNT:
   BUILDKITE_STEP_KEY:
   MAZE_BUGSNAG_API_KEY:
-  MAZE_SCENARIO_BUGSNAG_KEY:
+  MAZE_SCENARIO_BUGSNAG_API_KEY:
 
 services:
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -95,8 +95,8 @@ InstallPlugin do |config|
   # Add step logging
   config.filters << Maze::Plugins::LoggingScenariosPlugin.new(config)
 
-  # TODO: Reporting of test failures as errors deactivated pending PLAT-10963
-  #config.filters << Maze::Plugins::BugsnagReportingPlugin.new(config)
+  # Add bugsnag failed scenario reporting only if ENV['MAZE_SCENARIO_BUGSNAG_KEY'] is present
+  config.filters << Maze::Plugins::BugsnagReportingPlugin.new(config) unless ENV['MAZE_SCENARIO_BUGSNAG_KEY'].nil?
 end
 
 # Before each scenario

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -95,8 +95,8 @@ InstallPlugin do |config|
   # Add step logging
   config.filters << Maze::Plugins::LoggingScenariosPlugin.new(config)
 
-  # Add bugsnag failed scenario reporting only if ENV['MAZE_SCENARIO_BUGSNAG_KEY'] is present
-  config.filters << Maze::Plugins::BugsnagReportingPlugin.new(config) unless ENV['MAZE_SCENARIO_BUGSNAG_KEY'].nil?
+  # Add bugsnag failed scenario reporting only if ENV['MAZE_SCENARIO_BUGSNAG_API_KEY'] is present
+  config.filters << Maze::Plugins::BugsnagReportingPlugin.new(config) unless ENV['MAZE_SCENARIO_BUGSNAG_API_KEY'].nil?
 end
 
 # Before each scenario

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.18.0'
+  VERSION = '8.19.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -42,7 +42,7 @@ module Maze
                 default: true
 
             opt Option::BUGSNAG,
-                'Enables reporting to Bugsnag on scenario failure (requires MAZE_BUGSNAG_API_KEY for errors, MAZE_SCENARIO_BUGSNAG_KEY for test failures)',
+                'Enables reporting to Bugsnag on scenario failure (requires MAZE_BUGSNAG_API_KEY for errors, MAZE_SCENARIO_BUGSNAG_API_KEY for test failures)',
                 type: :boolean,
                 short: :none,
                 default: true

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -42,7 +42,7 @@ module Maze
                 default: true
 
             opt Option::BUGSNAG,
-                'Enables reporting to Bugsnag on scenario failure (requires MAZE_BUGSNAG_API_KEY)',
+                'Enables reporting to Bugsnag on scenario failure (requires MAZE_BUGSNAG_API_KEY for errors, MAZE_SCENARIO_BUGSNAG_KEY for test failures)',
                 type: :boolean,
                 short: :none,
                 default: true

--- a/lib/maze/plugins/bugsnag_reporting_plugin.rb
+++ b/lib/maze/plugins/bugsnag_reporting_plugin.rb
@@ -25,6 +25,8 @@ module Maze
           next unless event.test_case.eql?(test_case) && event.result.failed?
 
           Bugsnag.notify(event.result.exception) do |bsg_event|
+            bsg_event.api_key = ENV['MAZE_SCENARIO_BUGSNAG_KEY']
+
             unless @last_test_step.nil?
 
               repo = ENV['BUILDKITE_PIPELINE_SLUG']

--- a/lib/maze/plugins/bugsnag_reporting_plugin.rb
+++ b/lib/maze/plugins/bugsnag_reporting_plugin.rb
@@ -25,6 +25,7 @@ module Maze
           next unless event.test_case.eql?(test_case) && event.result.failed?
 
           Bugsnag.notify(event.result.exception) do |bsg_event|
+
             bsg_event.api_key = ENV['MAZE_SCENARIO_BUGSNAG_KEY']
 
             unless @last_test_step.nil?

--- a/lib/maze/plugins/bugsnag_reporting_plugin.rb
+++ b/lib/maze/plugins/bugsnag_reporting_plugin.rb
@@ -26,7 +26,7 @@ module Maze
 
           Bugsnag.notify(event.result.exception) do |bsg_event|
 
-            bsg_event.api_key = ENV['MAZE_SCENARIO_BUGSNAG_KEY']
+            bsg_event.api_key = ENV['MAZE_SCENARIO_BUGSNAG_API_KEY']
 
             unless @last_test_step.nil?
 


### PR DESCRIPTION
## Goal

Re-enables reporting failures as errors to bugsnag, provided a specific API key is present.

## Tests

Tested locally, confirming errors are reporting correctly.  They can be seen here:
https://app.bugsnag.com/bugsnag-test-projects/maze-runner-prime/errors/65ba7ddf7b68a4000717dece?filters[event.since]=all