### PR TITLE
Set capabilities for BitBar using Appium v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
+# 9.1.1 - TBD
+
+## Fixes
+
+- Set capabilities for BitBar using Appium v1 [625](https://github.com/bugsnag/maze-runner/pull/625)
+
 # 9.1.0 - 2024/01/26
+
+## Enhancements
 
 - Forward port 8.17.0 to 8.18.0 to v9 fork [625](https://github.com/bugsnag/maze-runner/pull/625)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (9.1.0)
+    bugsnag-maze-runner (9.1.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.1.0'
+  VERSION = '9.1.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -55,15 +55,13 @@ module Maze
           # Doubling up on capabilities in both the `appium:options` and `appium` sub dictionaries.
           # See PLAT-11087
           config = Maze.config
+          common_caps = {
+            'noReset' => true,
+            'newCommandTimeout' => 600
+          }
           capabilities = {
-            'appium:options' => {
-              'noReset' => true,
-              'newCommandTimeout' => 600
-            },
-            'appium' => {
-              'noReset' => true,
-              'newCommandTimeout' => 600
-            },
+            'appium:options' => common_caps,
+            'appium' => common_caps,
             'bitbar:options' => {
               # Some capabilities probably belong in the top level
               # of the hash, but BitBar picks them up from here.
@@ -73,6 +71,7 @@ module Maze
               'testTimeout' => 7200
             }
           }
+          capabilities.deep_merge! common_caps
           capabilities.deep_merge! BitBarClientUtils.dashboard_capabilities
           capabilities.deep_merge! BitBarDevices.get_available_device(config.device)
           capabilities['bitbar:options']['appiumVersion'] = config.appium_version unless config.appium_version.nil?


### PR DESCRIPTION
## Goal

Set capabilities for BitBar using Appium v1.

## Design

Appium v1 needs some capabilities set in the top level of the hash.  We thought we had moved on from Appium 1, but recently found that Appium 2 isn't as stable as we hoped yet.  

Capabilities are now set in the root of the hash and are yet ignored by Appium 2.

## Tests

Tested locally that the following scenario doesn't result in a session timeout.  Before this change it would consistently fail after the 65s sleep:
```
  Scenario: Timeout test
    When I wait for 55 seconds
    And I tap the screen 1 times
    And I wait for 65 seconds
    And I tap the screen 1 times
```

Appium 2 use is covered by CI.