### PR TITLE
[PLAT-11498] Setup for dSYM integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 9.1.1 - TBD
+# 9.2.0 - TBD
 
 ## Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.1.1 - TBD
+
+## Enhancements
+
+- Add additional symbol file upload endpoint [629](https://github.com/bugsnag/maze-runner/pull/629)
+
 # 9.1.0 - 2024/01/26
 
 - Forward port 8.17.0 to 8.18.0 to v9 fork [625](https://github.com/bugsnag/maze-runner/pull/625)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (9.1.0)
+    bugsnag-maze-runner (9.1.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -42,7 +42,7 @@ GEM
     appium_lib_core (5.4.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 4.2, < 4.6)
-    bugsnag (6.26.0)
+    bugsnag (6.26.3)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (4.1.0)
@@ -115,10 +115,12 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
+    mini_portile2 (2.8.5)
     minitest (5.18.1)
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.15.4-x86_64-darwin)
+    nokogiri (1.15.5)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -129,7 +131,7 @@ GEM
     rack (2.2.8)
     rake (12.3.3)
     redcarpet (3.6.0)
-    regexp_parser (2.8.2)
+    regexp_parser (2.9.0)
     rexml (3.2.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.5.0)
@@ -155,7 +157,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.2)
+    unf_ext (0.0.9.1)
     uri_template (0.7.0)
     webrick (1.7.0)
     websocket (1.2.10)
@@ -168,6 +170,7 @@ GEM
     yard (0.9.34)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
   x86_64-darwin-20
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (9.1.1)
+    bugsnag-maze-runner (9.2.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.1.1'
+  VERSION = '9.2.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.1.0'
+  VERSION = '9.1.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -221,6 +221,7 @@ module Maze
             server.mount '/dart-symbol', Servlets::Servlet, :sourcemaps
             server.mount '/ndk-symbol', Servlets::Servlet, :sourcemaps
             server.mount '/proguard', Servlets::Servlet, :sourcemaps
+            server.mount '/dsym', Servlets::Servlet, :sourcemaps
             server.mount '/command', Servlets::CommandServlet
             server.mount '/commands', Servlets::AllCommandsServlet
             server.mount '/logs', Servlets::LogServlet

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -50,6 +50,7 @@ module Maze
       mock_http_server.expects(:mount).with('/dart-symbol', any_parameters).once
       mock_http_server.expects(:mount).with('/ndk-symbol', any_parameters).once
       mock_http_server.expects(:mount).with('/proguard', any_parameters).once
+      mock_http_server.expects(:mount).with('/dsym', any_parameters).once
       mock_http_server.expects(:mount).with('/command', any_parameters).once
       mock_http_server.expects(:mount).with('/commands', any_parameters).once
       mock_http_server.expects(:mount).with('/logs', any_parameters).once
@@ -100,6 +101,7 @@ module Maze
       mock_http_server.expects(:mount).with('/dart-symbol', any_parameters).once
       mock_http_server.expects(:mount).with('/ndk-symbol', any_parameters).once
       mock_http_server.expects(:mount).with('/proguard', any_parameters).once
+      mock_http_server.expects(:mount).with('/dsym', any_parameters).once
       mock_http_server.expects(:mount).with('/logs', any_parameters).once
       mock_http_server.expects(:mount).with('/reflect', any_parameters).once
       mock_http_server.expects(:mount).with('/command', any_parameters).once


### PR DESCRIPTION
## Goal

A basic endpoint `/dsym` added to the mock server for integration testing scenarios for dSYM uploads via BugSnag CLI.

## Design

This change follows the same what we had done previously for other symbol file upload endpoints. ([See here](https://github.com/bugsnag/maze-runner/pull/570/files))

## Documentation

N/A

## Changeset

Add the following endpoint to the mock server:
`/dsym`

## Tests

Updated tests, covered by CI
