### PR TITLE
Fall back to close_app if terminate_app fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Fixes
 
-- Fall back to `close_app` if `terminate_app` fails [630](https://github.com/bugsnag/maze-runner/pull/630)
+- Fall back to `close_app` if `terminate_app` fails [631](https://github.com/bugsnag/maze-runner/pull/631)
 
 # 9.2.0 - 2024/02/15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 9.2.0 - TBD
+# 9.2.1 - 2024/02/16
+
+## Fixes
+
+- Fall back to `close_app` if `terminate_app` fails [630](https://github.com/bugsnag/maze-runner/pull/630)
+
+# 9.2.0 - 2024/02/15
 
 ## Enhancements
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (9.2.0)
+    bugsnag-maze-runner (9.2.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -121,6 +121,8 @@ GEM
     multi_test (0.1.2)
     nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.15.5-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.2.0'
+  VERSION = '9.2.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -32,7 +32,12 @@ module Maze
 
           # Reset the server to ensure that test fixtures cannot fetch
           # commands from the previous scenario (in idempotent mode).
-          Maze.driver.terminate_app Maze.driver.app_id
+          begin
+            Maze.driver.terminate_app Maze.driver.app_id
+          rescue Selenium::WebDriver::Error::UnknownError
+            $logger.warn 'terminate_app failed, using the slower but more forceful close_app instead'
+            Maze.driver.close_app
+          end
           Maze::Server.reset!
           Maze.driver.activate_app Maze.driver.app_id
         end


### PR DESCRIPTION
## Goal

Avoid failures from `terminate_app` not closing the app in sufficient time.

## Design

We have found that in some isolated test scenarios `terminate_app` does not stop the app from running in the 500ms that Appium allows, resulting in the test run failing.  This change catches the error and falls back to the slower but more forceful close_app instead.

## Tests

Tested against the branch of `bugsnag-android` that discovered the issue.