### PR TITLE
Apply fix for app_id missing in BrowserStack tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,6 +35,7 @@ steps:
       queue: 'macos-12-arm'
     command:
       - cd bugsnag-cocoa
+      - bundle install
       - make test-fixtures
     plugins:
       artifacts#v1.9.0:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # 9.3.0 - TBD
 
-# Enhancements
+## Enhancements
 
 - Add new span validation steps [630](https://github.com/bugsnag/maze-runner/pull/630)
+
+## Fixes
+
+- Ensure app_id is set correctly on BrowserStack test runs [633](https://github.com/bugsnag/maze-runner/pull/633)
 
 # 9.2.1 - 2024/02/16
 

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -25,6 +25,8 @@ module Maze
                                  Maze.driver.session_capabilities['CFBundleIdentifier'] # Present on BS and locally
                                end
 
+          pp "App id is set to #{Maze.driver.app_id}"
+
           # Ensure the device is unlocked
           begin
             Maze.driver.unlock

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -18,10 +18,12 @@ module Maze
           start_driver(Maze.config)
 
           # Set bundle/app id for later use
+          pp "Current platform is #{Maze::Helper.get_current_platform}"
           Maze.driver.app_id = case Maze::Helper.get_current_platform
                                when 'android'
                                  Maze.driver.session_capabilities['appPackage']
                                when 'ios'
+                                 pp Maze.driver.session_capabilities
                                  Maze.driver.session_capabilities['CFBundleIdentifier'] # Present on BS and locally
                                end
 

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -18,16 +18,15 @@ module Maze
           start_driver(Maze.config)
 
           # Set bundle/app id for later use
-          pp "Current platform is #{Maze::Helper.get_current_platform}"
           Maze.driver.app_id = case Maze::Helper.get_current_platform
                                when 'android'
                                  Maze.driver.session_capabilities['appPackage']
                                when 'ios'
-                                 pp Maze.driver.session_capabilities
-                                 Maze.driver.session_capabilities['CFBundleIdentifier'] # Present on BS and locally
+                                 unless app_id = Maze.driver.session_capabilities['CFBundleIdentifier']
+                                    app_id = Maze.driver.session_capabilities['bundleID']
+                                 end
+                                 app_id
                                end
-
-          pp "App id is set to #{Maze.driver.app_id}"
 
           # Ensure the device is unlocked
           begin


### PR DESCRIPTION
## Goal

When running BrowserStack appium tests we've been seeing errors with the test fixture trying to access the config file that should be present on the device.  This is caused by the `app_id` being missing when uploaded the config file, causing it to upload in the wrong location.

It appears the session capabilities which would normally indicate the app_id are now missing in BrowserStack, namely the `CFBundleIdentifier` capability, so a check has been added to see if this is present, and if not will use the `bundleID` capability.

## Releasing

I've added this as a fix, but I'd like it to go out with #632 if possible, so once this is merged I'll rebase that PR and prepare the release in there.
