### PR TITLE
Fix app_id missing issue in v8

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,6 +35,7 @@ steps:
       queue: 'macos-12-arm'
     command:
       - cd bugsnag-cocoa
+      - bundle install
       - make test-fixtures
     plugins:
       artifacts#v1.9.0:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.20.1 - 2024/02/29
+
+## Fixes
+
+- Ensure app_id is set correctly on BrowserStack test runs [634](https://github.com/bugsnag/maze-runner/pull/634)
+
 # 8.20.0 - 2024/02/16
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Ensure app_id is set correctly on BrowserStack test runs [634](https://github.com/bugsnag/maze-runner/pull/634)
+- Add missing retry logic for appium downstream proxy error [635](https://github.com/bugsnag/maze-runner/pull/635)
 
 # 8.20.0 - 2024/02/16
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (8.20.0)
+    bugsnag-maze-runner (8.20.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '8.20.0'
+  VERSION = '8.20.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -22,7 +22,10 @@ module Maze
                                when 'android'
                                  Maze.driver.session_capabilities['appPackage']
                                when 'ios'
-                                 Maze.driver.session_capabilities['CFBundleIdentifier'] # Present on BS and locally
+                                unless app_id = Maze.driver.session_capabilities['CFBundleIdentifier']
+                                  app_id = Maze.driver.session_capabilities['bundleID']
+                                end
+                                app_id
                                end
 
           # Ensure the device is unlocked

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -32,6 +32,8 @@ module Maze
             interval = 120
           elsif error.message.include? 'Appium Settings app is not running'
             interval = 10
+          elsif error.message.include? 'Could not proxy command to the remote server'
+            interval = 10
           else
             # Do not retry in any other case
           end


### PR DESCRIPTION
## Goal

Fixes the issue outlined in https://github.com/bugsnag/maze-runner/pull/633 in the v8 version