### PR TITLE
Add missing retry logic for appium proxy error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Ensure app_id is set correctly on BrowserStack test runs [634](https://github.com/bugsnag/maze-runner/pull/634)
+- Add missing retry logic for appium downstream proxy error [635](https://github.com/bugsnag/maze-runner/pull/635)
 
 # 8.20.0 - 2024/02/16
 

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -32,6 +32,8 @@ module Maze
             interval = 120
           elsif error.message.include? 'Appium Settings app is not running'
             interval = 10
+          elsif error.message.include? 'Could not proxy command to the remote server'
+            interval = 10
           else
             # Do not retry in any other case
           end


### PR DESCRIPTION
## Goal

Adds an additional retry parameter for appium server proxy failures 