### PR TITLE
Remove trace request check on `service.version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.3.1 - 2024/03/06
+
+## Fixes
+
+- Remove blanket check on `service.version` in trace requests [637](https://github.com/bugsnag/maze-runner/pull/637)
+
 # 9.3.0 - 2024/02/28
 
 ## Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (9.3.0)
+    bugsnag-maze-runner (9.3.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.3.0'
+  VERSION = '9.3.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -39,7 +39,6 @@ module Maze
         element_int_in_range('resourceSpans.0.scopeSpans.0.spans.0.kind', 0..5)
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano', '^[0-9]+$')
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano', '^[0-9]+$')
-        element_contains('resourceSpans.0.resource.attributes', 'service.version')
         element_contains('resourceSpans.0.resource.attributes', 'device.id')
         each_element_contains('resourceSpans.0.scopeSpans.0.spans', 'attributes', 'bugsnag.sampling.p')
         element_contains('resourceSpans.0.resource.attributes', 'deployment.environment')

--- a/test/fixtures/payload-helpers/features/fixtures/maze-harness/features/scripts/send_trace.sh
+++ b/test/fixtures/payload-helpers/features/fixtures/maze-harness/features/scripts/send_trace.sh
@@ -126,12 +126,6 @@ templates = {
                 }
               },
               {
-                "key":"service.version",
-                "value":{
-                  "stringValue":"1.0"
-                }
-              },
-              {
                 "key":"telemetry.sdk.name",
                 "value":{
                   "stringValue":"bugsnag.performance.cocoa"

--- a/test/fixtures/payload-helpers/features/scripts/send_gzip.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_gzip.sh
@@ -74,12 +74,6 @@ payload = {
         'resource' => {
           'attributes' => [
             {
-              "key":"service.version",
-              "value":{
-                "stringValue":"1.0.0"
-              }
-            },
-            {
               "key":"device.id",
               "value":{
                 "stringValue":"cd5c48566a5ba0b8597dca328c392e1a7f98ce86"

--- a/test/fixtures/payload-helpers/features/scripts/send_spans.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_spans.sh
@@ -72,12 +72,6 @@ payload = {
         'resource' => {
           'attributes' => [
             {
-              "key":"service.version",
-              "value":{
-                "stringValue":"1.0.0"
-              }
-            },
-            {
               "key":"device.id",
               "value":{
                 "stringValue":"123456"

--- a/test/fixtures/payload-helpers/features/support/send_request.rb
+++ b/test/fixtures/payload-helpers/features/support/send_request.rb
@@ -267,12 +267,6 @@ def send_request(request_type, mock_api_port = 9339)
                   }
                 },
                 {
-                  "key":"service.version",
-                  "value":{
-                    "stringValue":"1.0"
-                  }
-                },
-                {
                   "key":"telemetry.sdk.name",
                   "value":{
                     "stringValue":"bugsnag.performance.cocoa"
@@ -324,12 +318,6 @@ def send_request(request_type, mock_api_port = 9339)
                   "key":"device.id",
                   "value":{
                     "stringValue":"cd5c48566a5ba0b8597dca328c392e1a7f98ce86"
-                  }
-                },
-                {
-                  "key":"service.version",
-                  "value":{
-                    "stringValue":"1.0"
                   }
                 },
                 {

--- a/test/fixtures/payload-helpers/features/traces_support.feature
+++ b/test/fixtures/payload-helpers/features/traces_support.feature
@@ -71,8 +71,8 @@ Feature: Testing support on traces endpoint
         And I send a gzipped trace request
         And I wait to receive a trace
         Then the trace Bugsnag-Integrity header is valid
-        And the trace payload field "resourceSpans.0.resource.attributes.1.key" equals "device.id"
-        And the trace payload field "resourceSpans.0.resource.attributes.1.value.stringValue" equals "cd5c48566a5ba0b8597dca328c392e1a7f98ce86"
+        And the trace payload field "resourceSpans.0.resource.attributes.0.key" equals "device.id"
+        And the trace payload field "resourceSpans.0.resource.attributes.0.value.stringValue" equals "cd5c48566a5ba0b8597dca328c392e1a7f98ce86"
 
     Scenario: The trace endpoint can identify an invalid request
        Given I set up the maze-harness console


### PR DESCRIPTION
## Goal

Remove trace request check on `service.version`, as not all our libraries will include it.

## Tests

Tests updated to removed the payload elements that were previously required and would have caused validation to fail if not present.