### PR TITLE
Enable logging captured reflect requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.5.0 - TBD
+
+## Enhancements
+
+- Update reflective server to output received requests [639](https://github.com/bugsnag/maze-runner/pull/639)
+
 # 9.4.0 - 2024/03/07
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 9.5.0 - TBD
+# 9.5.0 - 2024/03/12
 
 ## Enhancements
 
-- Update reflective server to output received requests [639](https://github.com/bugsnag/maze-runner/pull/639)
+- Update reflective server to store and output received requests [639](https://github.com/bugsnag/maze-runner/pull/639)
 
 # 9.4.0 - 2024/03/07
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (9.4.0)
+    bugsnag-maze-runner (9.5.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -115,10 +115,12 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
+    mini_portile2 (2.8.5)
     minitest (5.18.1)
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.15.5-x86_64-darwin)
+    nokogiri (1.15.5)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -126,7 +128,7 @@ GEM
     props (1.2.0)
       iniparser (>= 0.1.0)
     racc (1.7.3)
-    rack (2.2.8)
+    rack (2.2.8.1)
     rake (12.3.3)
     redcarpet (3.6.0)
     regexp_parser (2.9.0)

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -149,3 +149,17 @@ Then('the received errors match:') do |table|
   end
   Maze.check.equal(requests.size, match_count, 'Unexpected number of requests matched the received payloads')
 end
+
+# Verifies that a request was sent via a given method.
+# Currently only supported with the reflective servlet.
+#
+# @step_input request_type [String] The type of request (error, session, build, etc)
+# @step_input method [String] The request method expected (GET, POST, etc)
+Then('the {request_type} request method equals {string}') do |request_type, method|
+  list = Maze::Server.list_for(request_type)
+  payload = list.current
+  if payload[:method].nil?
+    raise Test::Unit::AssertionFailedError.new("#{request_type} request had no receipt method listed")
+  end
+  Maze.check.equal(method, payload[:method], "Expected #{request_type} request method to be #{method}")
+end

--- a/lib/features/support/cucumber_types.rb
+++ b/lib/features/support/cucumber_types.rb
@@ -1,6 +1,6 @@
 ParameterType(
   name:        'request_type',
-  regexp:      /errors?|sessions?|builds?|logs?|metrics?|sampling requests?|traces?|uploads?|sourcemaps?|invalid requests?/,
+  regexp:      /errors?|sessions?|builds?|logs?|metrics?|sampling requests?|traces?|uploads?|sourcemaps?|reflects?|reflections?|invalid requests?/,
   type:        String,
   transformer: ->(s) { s }
 )

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.4.0'
+  VERSION = '9.5.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/maze_output.rb
+++ b/lib/maze/maze_output.rb
@@ -13,7 +13,7 @@ module Maze
       path = output_folder
       FileUtils.makedirs(path)
 
-      request_types = %w[errors sessions builds uploads logs sourcemaps traces invalid]
+      request_types = %w[errors sessions builds uploads logs sourcemaps traces invalid reflections]
       request_types << 'sampling requests'
 
       request_types.each do |request_type|
@@ -50,6 +50,11 @@ module Maze
               file.puts "  #{key}: #{values.map {|v| "'#{v}'"}.join(' ')}"
             end
             file.puts
+
+            if request.include?(:query)
+              file.puts "Query:"
+              file.puts JSON.pretty_generate(request[:query])
+            end
 
             file.puts "Request body:"
             if !invalid_request && headers["content-type"].first == 'application/json'

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -93,7 +93,7 @@ module Maze
           uploads
         when 'sourcemap', 'sourcemaps'
           sourcemaps
-        when 'reflection', 'reflections'
+        when 'reflect', 'reflects', 'reflection', 'reflections'
           reflections
         when 'invalid', 'invalid requests'
           invalid_requests

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -93,6 +93,8 @@ module Maze
           uploads
         when 'sourcemap', 'sourcemaps'
           sourcemaps
+        when 'reflection', 'reflections'
+          reflections
         when 'invalid', 'invalid requests'
           invalid_requests
         else
@@ -161,6 +163,13 @@ module Maze
       # @return [RequestList] Received metric requests
       def metrics
         @metrics ||= RequestList.new
+      end
+
+      # A list of reflection requests received
+      #
+      # @return [RequestList] Received reflection requests
+      def reflections
+        @reflections ||= RequestList.new
       end
 
       # A list of commands for a test fixture to perform.  Strictly speaking these are responses to HTTP
@@ -272,6 +281,7 @@ module Maze
         traces.clear
         logs.clear
         invalid_requests.clear
+        reflections.clear
       end
     end
   end

--- a/lib/maze/servlets/reflective_servlet.rb
+++ b/lib/maze/servlets/reflective_servlet.rb
@@ -20,6 +20,16 @@ module Maze
       def do_GET(request, response)
         delay_ms = request.query['delay_ms']
         status = request.query['status']
+
+        logged_request = {
+          body: {},
+          query: Rack::Utils.parse_nested_query(request.query_string),
+          request: request,
+          response: response,
+          method: 'GET'
+        }
+        Server.list_for(REFLECTION_REQUEST_TYPE).add(logged_request)
+
         reflect response, delay_ms, status
       end
 
@@ -46,7 +56,8 @@ module Maze
         logged_request = {
           body: body,
           request: request,
-          response: response
+          response: response,
+          method: 'POST'
         }
         logged_request[:query] = query if query
         Server.list_for(REFLECTION_REQUEST_TYPE).add(logged_request)

--- a/lib/maze/servlets/reflective_servlet.rb
+++ b/lib/maze/servlets/reflective_servlet.rb
@@ -11,6 +11,8 @@ module Maze
     # for POST requests they are expected to be given as JSON fields.
     class ReflectiveServlet < BaseServlet
 
+      REFLECTION_REQUEST_TYPE = 'reflection'
+
       # Accepts a GET request to provide a reflective response to.
       #
       # @param request [HTTPRequest] The incoming GET request
@@ -36,9 +38,18 @@ module Maze
           status = body['status']
         else
           query = Rack::Utils.parse_nested_query(request.query_string)
+          body = {}
           delay_ms = query['delay_ms']
           status = query['status']
         end
+
+        logged_request = {
+          body: body,
+          request: request,
+          response: response
+        }
+        logged_request[:query] = query if query
+        Server.list_for(REFLECTION_REQUEST_TYPE).add(logged_request)
 
         reflect response, delay_ms, status
       rescue JSON::ParserError => e

--- a/test/fixtures/payload-helpers/features/reflect_requests.feature
+++ b/test/fixtures/payload-helpers/features/reflect_requests.feature
@@ -1,0 +1,15 @@
+Feature: Reflect payloads are captured
+
+    Scenario: Verify reflect payload bodies can be interrogated
+        When I send a "reflect"-type request
+        And I wait to receive a reflection
+        Then the reflection request method equals "POST"
+        And the reflection "some-header" header equals "is-here"
+        And the reflection payload field "foo" equals "bar"
+
+    Scenario: Verify reflect queries can be interrogated
+        When I send a reflect query request
+        And I wait to receive a reflect
+        Then the reflect request method equals "GET"
+        And the reflect "foo" query parameter equals "1"
+        And the reflect "bar" query parameter equals "b"

--- a/test/fixtures/payload-helpers/features/scripts/send_query.sh
+++ b/test/fixtures/payload-helpers/features/scripts/send_query.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require 'net/http'
+require 'uri'
+
+http = Net::HTTP.new('localhost', ENV['MOCK_API_PORT'])
+request = Net::HTTP::Get.new('/reflect?foo=1&bar=b')
+
+request['some-header'] = 'some-value'
+
+http.request(request)

--- a/test/fixtures/payload-helpers/features/steps/scripting_steps.rb
+++ b/test/fixtures/payload-helpers/features/steps/scripting_steps.rb
@@ -34,6 +34,13 @@ When('I send a span request with {int} span(s)') do |span_count|
   }
 end
 
+When('I send a reflect query request') do
+  steps %Q{
+    And I set environment variable "MOCK_API_PORT" to "9339"
+    And I run the script "features/scripts/send_query.sh" synchronously
+  }
+end
+
 When('The HTTP response header {string} equals {string}') do |header, value|
   Maze.check.equal value, $http_response[header]
 end

--- a/test/fixtures/payload-helpers/features/support/send_request.rb
+++ b/test/fixtures/payload-helpers/features/support/send_request.rb
@@ -14,6 +14,8 @@ def send_request(request_type, mock_api_port = 9339)
                '/metrics'
              elsif request_type == 'trace' || request_type == 'browser-trace' || request_type == 'sampling-trace'
                '/traces'
+             elsif request_type == 'reflect'
+               '/reflect'
              else
                '/notify'
              end
@@ -24,6 +26,14 @@ def send_request(request_type, mock_api_port = 9339)
   end_time = start_time + (2 * 1000 * 1000 * 1000)
 
   templates = {
+    'reflect' => {
+      'headers' => {
+        'some-header' => 'is-here'
+      },
+      'body' => {
+        'foo' => 'bar'
+      }
+    },
     'metric-age' => {
       'headers' => {},
       'body' => {


### PR DESCRIPTION
## Tests

I've tested locally, but have some ideas about a maze_output test fixture which could be added to verify this and all other post-test outputs if we think it's necessary.
