### PR TITLE
Improve maze feedback in bugsnag dashboard 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Enhancements
+
+- Add bugsnag middleware to group ambiguous errors differently [640](https://github.com/bugsnag/maze-runner/pull/640)
+
 # 9.5.0 - 2024/03/12
 
 ## Enhancements


### PR DESCRIPTION
## Goal

In effort to slightly improve how errors are presented on our bugsnag dashboard, this PR adds a middleware to our bugsnag config that applies a different grouping hash based on the error message in the event a specific error type occurs.

Note: While this is a general structure that I think should do what we want, we can adjust and add new error classes that we believe to be ambiguous as and when we need to.