### PR TITLE
Allow the command server to provide the next ID when given the last from the previous scenario

### DIFF
--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -15,6 +15,12 @@ module Maze
     DEFAULT_STATUS_CODE = 200
 
     class << self
+
+      # Records the previous command UUID sent to the test fixture
+      #
+      # @return [String] The UUID of the last command sent
+      attr_accessor :last_command_uuid
+
       # Sets the response delay generator.
       #
       # @param generator [Maze::Generator] The new generator

--- a/lib/maze/servlets/command_servlet.rb
+++ b/lib/maze/servlets/command_servlet.rb
@@ -11,8 +11,6 @@ module Maze
 
       NOOP_COMMAND = '{"action": "noop", "message": "No commands queued"}'
 
-      attr_reader :last_uuid
-
       # Serves the next command, if these is one.
       #
       # @param request [HTTPRequest] The incoming GET request
@@ -45,8 +43,8 @@ module Maze
           response.status = 200
         else
           command = commands.current
-          @last_uuid = command[:uuid]
-          pp "LAST UUID: #{@last_uuid}"
+          Server.last_command_uuid = command[:uuid]
+          pp "LAST UUID: #{Server.last_command_uuid}"
           response.body = JSON.pretty_generate(command)
           response.status = 200
           commands.next
@@ -63,9 +61,9 @@ module Maze
         end
         if index.nil?
           # If the UUID given matches the last UUID sent by the server, we can assume the fixture has failed to reset
-          pp "Current UUID: #{@last_uuid}"
+          pp "Current UUID: #{Server.last_command_uuid}"
           pp "Given UUID: #{uuid}"
-          if uuid.eql?(@last_uuid)
+          if uuid.eql?(Server.last_command_uuid)
 
             pp "SENDING CURRENT UUID DUE TO MATCH"
 
@@ -81,8 +79,8 @@ module Maze
             pp "SENDING NEXT COMMAND IDEMPOTENT STYLE"
             # Respond with the next command in the queue
             command = commands.get(index + 1)
-            @last_uuid = command[:uuid]
-            pp "LAST UUID: #{@last_uuid}"
+            Server.last_command_uuid = command[:uuid]
+            pp "LAST UUID: #{Server.last_command_uuid}"
             command_json = JSON.pretty_generate(command)
             response.body = command_json
             response.status = 200

--- a/lib/maze/servlets/command_servlet.rb
+++ b/lib/maze/servlets/command_servlet.rb
@@ -37,6 +37,7 @@ module Maze
       end
 
       def send_current_command(response)
+        pp "SENDING CURRENT COMMAND"
         commands = Maze::Server.commands
 
         if commands.size_remaining == 0
@@ -45,6 +46,7 @@ module Maze
         else
           command = commands.current
           @last_uuid = command[:uuid]
+          pp "LAST UUID: #{@last_uuid}"
           response.body = JSON.pretty_generate(command)
           response.status = 200
           commands.next
@@ -52,6 +54,7 @@ module Maze
       end
 
       def command_after(uuid, response)
+        pp "GIVEN UUID: #{uuid}"
         commands = Maze::Server.commands
         if uuid.empty?
           index = -1
@@ -61,6 +64,9 @@ module Maze
         if index.nil?
           # If the UUID given matches the last UUID sent by the server, we can assume the fixture has failed to reset
           if uuid.eql?(@last_uuid)
+
+            pp "SENDING CURRENT UUID DUE TO MATCH"
+
             send_current_command(response)
           else
             msg = "Request invalid - there is no command with a UUID of #{uuid} to follow on from"

--- a/lib/maze/servlets/command_servlet.rb
+++ b/lib/maze/servlets/command_servlet.rb
@@ -35,7 +35,6 @@ module Maze
       end
 
       def send_current_command(response)
-        pp "SENDING CURRENT COMMAND"
         commands = Maze::Server.commands
 
         if commands.size_remaining == 0
@@ -44,7 +43,6 @@ module Maze
         else
           command = commands.current
           Server.last_command_uuid = command[:uuid]
-          pp "LAST UUID: #{Server.last_command_uuid}"
           response.body = JSON.pretty_generate(command)
           response.status = 200
           commands.next
@@ -52,7 +50,6 @@ module Maze
       end
 
       def command_after(uuid, response)
-        pp "GIVEN UUID: #{uuid}"
         commands = Maze::Server.commands
         if uuid.empty?
           index = -1
@@ -61,12 +58,7 @@ module Maze
         end
         if index.nil?
           # If the UUID given matches the last UUID sent by the server, we can assume the fixture has failed to reset
-          pp "Current UUID: #{Server.last_command_uuid}"
-          pp "Given UUID: #{uuid}"
           if uuid.eql?(Server.last_command_uuid)
-
-            pp "SENDING CURRENT UUID DUE TO MATCH"
-
             send_current_command(response)
           else
             msg = "Request invalid - there is no command with a UUID of #{uuid} to follow on from"
@@ -76,11 +68,9 @@ module Maze
           end
         else
           if index + 1 < commands.size_all
-            pp "SENDING NEXT COMMAND IDEMPOTENT STYLE"
             # Respond with the next command in the queue
             command = commands.get(index + 1)
             Server.last_command_uuid = command[:uuid]
-            pp "LAST UUID: #{Server.last_command_uuid}"
             command_json = JSON.pretty_generate(command)
             response.body = command_json
             response.status = 200

--- a/lib/maze/servlets/command_servlet.rb
+++ b/lib/maze/servlets/command_servlet.rb
@@ -76,9 +76,11 @@ module Maze
           end
         else
           if index + 1 < commands.size_all
+            pp "SENDING NEXT COMMAND IDEMPOTENT STYLE"
             # Respond with the next command in the queue
             command = commands.get(index + 1)
             @last_uuid = command[:uuid]
+            pp "LAST UUID: #{@last_uuid}"
             command_json = JSON.pretty_generate(command)
             response.body = command_json
             response.status = 200

--- a/lib/maze/servlets/command_servlet.rb
+++ b/lib/maze/servlets/command_servlet.rb
@@ -11,6 +11,8 @@ module Maze
 
       NOOP_COMMAND = '{"action": "noop", "message": "No commands queued"}'
 
+      attr_reader :last_uuid
+
       # Serves the next command, if these is one.
       #
       # @param request [HTTPRequest] The incoming GET request
@@ -19,17 +21,7 @@ module Maze
 
         if request.query.empty?
           # Non-idempotent mode - return the "current" command
-          commands = Maze::Server.commands
-
-          if commands.size_remaining == 0
-            response.body = NOOP_COMMAND
-            response.status = 200
-          else
-            command = commands.current
-            response.body = JSON.pretty_generate(command)
-            response.status = 200
-            commands.next
-          end
+          send_current_command(response)
         else
           # Idempotent mode
           after_uuid = request.query['after']
@@ -44,6 +36,21 @@ module Maze
         response.header['Access-Control-Allow-Origin'] = '*'
       end
 
+      def send_current_command(response)
+        commands = Maze::Server.commands
+
+        if commands.size_remaining == 0
+          response.body = NOOP_COMMAND
+          response.status = 200
+        else
+          command = commands.current
+          @last_uuid = command[:uuid]
+          response.body = JSON.pretty_generate(command)
+          response.status = 200
+          commands.next
+        end
+      end
+
       def command_after(uuid, response)
         commands = Maze::Server.commands
         if uuid.empty?
@@ -52,14 +59,20 @@ module Maze
           index = commands.all.find_index {|command| command[:uuid] == uuid }
         end
         if index.nil?
-          msg = "Request invalid - there is no command with a UUID of #{uuid} to follow on from"
-          $logger.error msg
-          response.body = msg
-          response.status = 400
+          # If the UUID given matches the last UUID sent by the server, we can assume the fixture has failed to reset
+          if uuid.eql?(@last_uuid)
+            send_current_command(response)
+          else
+            msg = "Request invalid - there is no command with a UUID of #{uuid} to follow on from"
+            $logger.error msg
+            response.body = msg
+            response.status = 400
+          end
         else
           if index + 1 < commands.size_all
             # Respond with the next command in the queue
             command = commands.get(index + 1)
+            @last_uuid = command[:uuid]
             command_json = JSON.pretty_generate(command)
             response.body = command_json
             response.status = 200

--- a/lib/maze/servlets/command_servlet.rb
+++ b/lib/maze/servlets/command_servlet.rb
@@ -63,6 +63,8 @@ module Maze
         end
         if index.nil?
           # If the UUID given matches the last UUID sent by the server, we can assume the fixture has failed to reset
+          pp "Current UUID: #{@last_uuid}"
+          pp "Given UUID: #{uuid}"
           if uuid.eql?(@last_uuid)
 
             pp "SENDING CURRENT UUID DUE TO MATCH"


### PR DESCRIPTION
## Goal

Enables the command servlet to respond with the next command in the list when an idempotent request for a command contains the previously sent commands UUID.  This indicates that the app may not have cleared the cache properly, for a number of reasons, mainly because the test fixture was closed suddenly as part of the previous test.

The command servlet will always check to see if there's a matching command for the UUID given _before_ checking against the previously given UUID, so we shouldn't run into any scenario where an incorrect command is given by mistake.

In addition, the previous UUID is stored on the server class as the servlet resets in some way between scenarios.

## Tests

Additional tests will be added before merging (as well as changelog and version updates)