### PR TITLE
Only zip maze_output if file_log is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Fixes
+
+- Only zip maze_output if file_log is on [#644](https://github.com/bugsnag/maze-runner/pull/644)
+
 # 9.6.0 - 2024/04/03
 
 ## Enhancements

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -238,17 +238,21 @@ AfterAll do
   # Ensure the logger output is in the correct location
   Maze::Hooks::LoggerHooks.after_all
 
-  maze_output = File.join(Dir.pwd, 'maze_output')
-  maze_output_zip = File.join(Dir.pwd, 'maze_output.zip')
-  # zip a folder with files and subfolders
-  Zip::File.open(maze_output_zip, Zip::File::CREATE) do |zipfile|
-    Dir["#{maze_output}/**/**"].each do |file|
-      zipfile.add(file.sub(Dir.pwd + '/', ''), file)
+  if Maze.config.file_log
+    # create a zip file from the maze_output directory
+    maze_output = File.join(Dir.pwd, 'maze_output')
+    maze_output_zip = File.join(Dir.pwd, 'maze_output.zip')
+    
+    # zip a folder with files and subfolders
+    Zip::File.open(maze_output_zip, Zip::File::CREATE) do |zipfile|
+      Dir["#{maze_output}/**/**"].each do |file|
+        zipfile.add(file.sub(Dir.pwd + '/', ''), file)
+      end
     end
-  end
 
-  # Move the zip file to the maze_output folder
-  FileUtils.mv(maze_output_zip, maze_output)
+    # Move the zip file to the maze_output folder
+    FileUtils.mv(maze_output_zip, maze_output)
+  end
 
   metrics = Maze::MetricsProcessor.new(Maze::Server.metrics)
   metrics.process


### PR DESCRIPTION
## Goal

Currently Maze Runner unconditionally creates a zip file from the `maze_output` directory even if `file_log` is disabled and therefore `maze_output` will be empty

This PR gates this behind the `Maze.config.file_log` flag so that an empty `maze_output` zip file isn't created every time Maze Runner runs