### PR TITLE
Add additional retry circumstances during bitbar appium driver start

### DIFF
--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -34,6 +34,10 @@ module Maze
             interval = 10
           elsif error.message.include? 'Could not proxy command to the remote server'
             interval = 10
+          elsif error.message.include? 'Could not find a connected Android device'
+            interval = 10
+          elsif error.message.include? '\'platformVersion\' must be a valid version number.'
+            interval = 10
           else
             # Do not retry in any other case
           end


### PR DESCRIPTION
## Goal
Adds retries for another two specific 'unknown errors' that can be received by appium when attempting to start a test session.