### PR TITLE
Only update documentation if the release is the most recent

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ def run_command(command)
 end
 
 def parse_release_tag(tag)
-  regex = /^v?(\d+)\.(\d+)\.(\d+).*$/
+  regex = /^[vV]?(\d+)\.(\d+)\.(\d+).*$/
   parsed = regex.match(tag)
   {
     major: parsed[1].to_i,


### PR DESCRIPTION
## Goal

Adds an in-process check to see if a given release matches (or exceeds) the release marked as 'latest' on github.  We'll only attempt to build and update the docs if that's the case.