### PR TITLE
Serve documents on primary port

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -348,6 +348,7 @@ steps:
         service-ports: true
         command:
           - "--app=build/test-fixture.apk"
+          - "--appium-version=1.22"
           - "--farm=bb"
           - "--device=ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
           - "--fail-fast"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Adds further retries for 'unknown errors' received by appium attempting to start a test session.[645](https://github.com/bugsnag/maze-runner/pull/645)
 - Use deviceGroupId capability to acquire device in BitBar tests where appropriate [646](https://github.com/bugsnag/maze-runner/pull/646)
-- Serve documents from `/docs` on primary port [648](https://github.com/bugsnag/maze-runner/pull/648)
+- Serve documents from `/docs` on primary port [650](https://github.com/bugsnag/maze-runner/pull/650)
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-# 9.8.0 - TBD
+# 9.8.0 - 2024/05/02 
 
 ## Enhancements
 
 - Adds further retries for 'unknown errors' received by appium attempting to start a test session.[645](https://github.com/bugsnag/maze-runner/pull/645)
 - Use deviceGroupId capability to acquire device in BitBar tests where appropriate [646](https://github.com/bugsnag/maze-runner/pull/646)
+- Serve documents from `/docs` on primary port [648](https://github.com/bugsnag/maze-runner/pull/648)
 
 ## Fixes
 

--- a/docs/Mock_Server.md
+++ b/docs/Mock_Server.md
@@ -40,3 +40,4 @@ The mock server provides a number of endpoints for test fixture to use:
 - `/logs` - provides a mechanism for recording and checking log messages
 - `/command` and `/commands` - provides a mechanism for feeding instructions and any other information to the test fixture using only HTTP requests instigated by the test fixture.  Essential for platforms that either do not support Appium, or render in such a way that elements are not accessible.  See [Mock Server](./Commands.md) for more information,
 - `/metrics` - provides a mechanism for collecting arbitrary metrics from a test fixture, collating and writing them to a CSV file at the end of a run.
+- `/docs' - a document server, just set Maze.config.document_server_root to the file location you want to server documents from. 

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -242,6 +242,7 @@ module Maze
             server.mount '/logs', Servlets::LogServlet
             server.mount '/metrics', Servlets::Servlet, :metrics
             server.mount '/reflect', Servlets::ReflectiveServlet
+            server.mount '/docs', WEBrick::HTTPServlet::FileHandler, Maze.config.document_server_root unless Maze.config.document_server_root.nil?
             server.start
           rescue StandardError => e
             Bugsnag.notify e


### PR DESCRIPTION
## Goal

Serve documents on primary port, under `/docs`.

## Design

A source of repeated annoyance are CORS errors stemming form the document server running on a separate port to the mock server that captures errors, traces, etc.  This change adds a document serving capability beneath `/docs`, avoiding that complication.

## Tests

I've tested this using the Unity Performance tests that highlighted a new CORS issue when setting an addition header.