### PR TITLE
Add span step for checking properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Pods
 *.gem
 coverage/
 maze_output/
+maze-runner.log
 Gemfile.lock
 package-lock.json
 test/fixtures/init-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 9.8.0 - 2024/05/02 
+# 9.9.0 - TBD
+
+## Enhancements
+
+- Adds step to allow testing of a set of properties in a named span [651](https://github.com/bugsnag/maze-runner/pull/651)
+
+# 9.8.0 - 2024/05/02
 
 ## Enhancements
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bugsnag-maze-runner (9.8.0)
+    bugsnag-maze-runner (9.9.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -179,6 +179,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   bugsnag-maze-runner!

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.8.0'
+  VERSION = '9.9.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/test/fixtures/payload-helpers/features/span_support.feature
+++ b/test/fixtures/payload-helpers/features/span_support.feature
@@ -53,3 +53,13 @@ Feature: Testing support for span receipt and interrogation
        Given I set up the maze-harness console
        And I input "bundle exec maze-runner --port=9349 features/span_maximum.feature" interactively
        Then the last interactive command exit code is 1
+
+    Scenario: Spans can be tested for specific properties
+        When I send a span request with 1 spans
+        Then I wait to receive 1 span
+        Then a span named "AppStart\134/Cold" has the following properties:
+            | property                       | value              |
+            | kind                           | 1                  |
+            | spanId                         | 7af51275a21aa300   |
+            | attributes.0.key               | bugsnag.sampling.p |
+            | attributes.3.value.stringValue | wifi               |


### PR DESCRIPTION
## Goal

Allows us to create a table of properties to be verified in a specifically named span, in the form:

```
Then a span named {name} has the following properties:
            | property                       | value                          |
            | path.to.property          | here i am                   |
            | spanId                          | 7af51275a21aa300   |
            | attributes.0.key           | bugsnag.sampling.p |
```

Note, it verifies these by converting the properties into strings, as the table values will also be strings.  If this is a potential issue (i.e. numbers need to be within a tolerance) we can look at changing the behaviour.