### PR TITLE
Resolve error parsing port information

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
     env_file: $DOCKER_ENV_FILE
     ports:
       - "9000-9499:9339"
+      - "9000-9499:9340"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 


### PR DESCRIPTION
## Goal

Resolve error parsing port information in the BitBar iOS test, which has come about at Cocoa has started to use the document server on port 9040.

## Tests

Covered by inspecting the log out in the CI run.