### PR TITLE
Update IOS_15 BrowserStack tests to iPhone 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Fixes
+
+- Move iOS 15 BrowserStack tests from iPhone 11 Pro to iPhone 13 [662](https://github.com/bugsnag/maze-runner/pull/662)
+
 # 9.11.0 - 2024/07/05
 
 ## Enhancements

--- a/lib/maze/client/appium/bs_devices.rb
+++ b/lib/maze/client/appium/bs_devices.rb
@@ -83,7 +83,7 @@ module Maze
               # iOS devices
               'IOS_17' => make_ios_hash('iPhone 15', '17'),
               'IOS_16' => make_ios_hash('iPhone 14', '16'),
-              'IOS_15' => make_ios_hash('iPhone 11 Pro', '15'),
+              'IOS_15' => make_ios_hash('iPhone 13', '15'),
               'IOS_14' => make_ios_hash('iPhone 11', '14'),
               'IOS_13' => make_ios_hash('iPhone 11', '13'),
               'IOS_12' => make_ios_hash('iPhone 8', '12'),


### PR DESCRIPTION
## Goal

Required as the iPhone 11 Pro will no longer be supported by BrowserStack shortly.

Looking through our test setups I can't find anywhere this is actually in use, as we run all of our IOS_15 tests against BitBar, but it'll protect us against some weird nonsense in the future.

The other removed devices have no effect on our existing setup.
