### PR TITLE
Revert "[PLAT-12352] Remove Ruby 2 tests"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,6 +44,22 @@ steps:
       artifacts#v1.9.0:
         upload: "bugsnag-cocoa/features/fixtures/ios/output/iOSTestApp.ipa"
 
+  - label: ':docker: Build CI image for Ruby 2'
+    timeout_in_minutes: 30
+    key: "ci-image-ruby-2"
+    plugins:
+      - docker-compose#v4.14.0:
+          build:
+            - ci-ruby-2
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+          cache-from:
+            - ci-ruby-2:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2
+      - docker-compose#v4.14.0:
+          push:
+            - ci-ruby-2:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2
+    env:
+      RUBY_VERSION: "2"
+
   - label: ':docker: Build CI image for Ruby 3'
     timeout_in_minutes: 30
     key: "ci-image-ruby-3"
@@ -60,6 +76,17 @@ steps:
     env:
       RUBY_VERSION: "3"
 
+  - label: 'Unit tests with Ruby 2'
+    timeout_in_minutes: 30
+    depends_on: 'ci-image-ruby-2'
+    plugins:
+      docker-compose#v4.14.0:
+        run: unit-test-ruby-2
+        image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+        cache-from:
+          - ci-ruby-2:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-2
+    command: 'bundle exec rake'
+
   - label: 'Unit tests with Ruby 3'
     timeout_in_minutes: 30
     depends_on: 'ci-image-ruby-3'
@@ -74,7 +101,7 @@ steps:
   - label: ':docker: Push W3C CLI image for branch'
     key: push-branch-cli
     timeout_in_minutes: 30
-    depends_on: "ci-image-ruby-3"
+    depends_on: "ci-image-ruby-2"
     plugins:
       - docker-compose#v4.14.0:
           build: cli
@@ -84,6 +111,62 @@ steps:
       - docker-compose#v4.14.0:
           push:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
+
+  - label: ':docker: Push Legacy CLI image for branch'
+    key: push-branch-cli-legacy
+    timeout_in_minutes: 30
+    depends_on: "ci-image-ruby-2"
+    plugins:
+      - docker-compose#v4.14.0:
+          build: cli-legacy
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
+          cache-from:
+            - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli-legacy
+      - docker-compose#v4.14.0:
+          push:
+            - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli-legacy
+
+  - label: 'No-device tests with Ruby 2 - batch 1'
+    timeout_in_minutes: 30
+    depends_on: "ci-image-ruby-2"
+    plugins:
+      - docker-compose#v4.14.0:
+          run: framework-tests
+      - docker-compose#v4.14.0:
+          run: comparison-tests
+      - docker-compose#v4.14.0:
+          run: proxy-tests
+      - docker-compose#v4.14.0:
+          run: cli-tests
+      - docker-compose#v4.14.0:
+          run: http-response-tests
+    env:
+      RUBY_VERSION: "2"
+      USE_LEGACY_DRIVER: "1"
+    command: 'bundle exec maze-runner -e features/fixtures'
+
+  - label: 'No-device tests with Ruby 2 - batch 2'
+    timeout_in_minutes: 30
+    depends_on: "ci-image-ruby-2"
+    plugins:
+      - docker-compose#v4.14.0:
+          run: payload-helper-tests
+      - docker-compose#v4.14.0:
+          run: docker-tests
+      - docker-compose#v4.14.0:
+          run: doc-server-tests
+      - docker-compose#v4.14.0:
+          run: exit-codes-tests
+      - docker-compose#v4.14.0:
+          run: command-workflow-tests
+      - artifacts#v1.9.0:
+          upload:
+            - test/fixtures/payload-helpers/maze_output/**/*
+            - test/fixtures/payload-helpers/maze_output/*
+    env:
+      RUBY_VERSION: "2"
+      USE_LEGACY_DRIVER: "1"
+    command: 'bundle exec maze-runner -e features/fixtures'
 
   - label: 'No-device tests with Ruby 3 - batch 1'
     timeout_in_minutes: 30
@@ -129,15 +212,15 @@ steps:
     timeout_in_minutes: 20
     depends_on:
       - "android-test-fixture"
-      - "push-branch-cli"
+      - "push-branch-cli-legacy"
     plugins:
       artifacts#v1.9.0:
         download: "bugsnag-android-performance/build/test-fixture.apk"
         upload:
           - "bugsnag-android-performance/maze_output/**/*"
       docker-compose#v4.14.0:
-        pull: appium-test-bs
-        run: appium-test-bs
+        pull: appium-test-bs-legacy
+        run: appium-test-bs-legacy
         volumes:
           - "./bugsnag-android-performance/build:/app/build"
           - "./bugsnag-android-performance/features:/app/features"
@@ -150,9 +233,9 @@ steps:
           - "features/manual_spans.feature"
         image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner
         cache-from:
-          - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli
+          - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-cli-legacy
     env:
-      RUBY_VERSION: "3"
+      RUBY_VERSION: "2"
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -189,11 +272,11 @@ steps:
     concurrency_method: eager
 
   - label: ':browserstack: Firefox - JWP'
-    depends_on: "push-branch-cli"
+    depends_on: "push-branch-cli-legacy"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v4.14.0:
-        run: browser-tests
+        run: browser-tests-legacy
         use-aliases: true
         verbose: true
         command:
@@ -244,7 +327,7 @@ steps:
           - "--fail-fast"
           - "--no-tunnel"
     env:
-      RUBY_VERSION: "3"
+      RUBY_VERSION: "2"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
@@ -334,6 +417,9 @@ steps:
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:${BUILDKITE_TAG}-cli
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v9-cli
             - cli:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-cli
+            - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:${BUILDKITE_TAG}-cli-legacy
+            - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v9-cli-legacy
+            - cli-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-cli-legacy
 
   - label: 'Push to RubyGems.org'
     if: build.tag =~ /^v[0-9]{1,2}\.[0-9]+\.[0-9]+\$/


### PR DESCRIPTION
Reverts bugsnag/maze-runner#657.

Unfortunately Ruby 2 is needed to run the legacy Appium and Selenium drivers.