### PR TITLE
Bump Curb to 1.0.5

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
   - label: 'AWS - SAM tests'
     timeout_in_minutes: 30
     agents:
-      queue: "macos-14-5"
+      queue: "macos-14"
     env:
       NODE_VERSION: "18"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.11.2 - 2024/07/18
+
+## Fixes
+
+- Bump `curb` dependency to 1.0.5 [664](https://github.com/bugsnag/maze-runner/pull/664)
+
 # 9.11.1 - 2024/07/15
 
 ## Fixes

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bugsnag', '~> 6.24'
   spec.add_dependency 'cucumber-expressions', '~> 6.0.0'
-  spec.add_dependency 'curb', '~> 0.9.6'
+  spec.add_dependency 'curb', '~> 1.0.5'
   spec.add_dependency 'dogstatsd-ruby', '~> 5.5.0'
   spec.add_dependency 'optimist', '~> 3.0.1'
   spec.add_dependency 'rake', '~> 12.3.3'

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.11.1'
+  VERSION = '9.11.2'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

Fix bundle install (building native extensions) on newer ARM macs.

## Tests

Tested locally and covered by CI.