### PR TITLE
Captures server-side error and removes appium driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Add tool to find failed BitBar sessions and save them to a CSV file [665](https://github.com/bugsnag/maze-runner/pull/665)
 - Add regex-based variants of steps for checking platform-dependent values [665](https://github.com/bugsnag/maze-runner/pull/667)
 
+## Fixes
+
+- Add better appium driver exits on server error [666](https://github.com/bugsnag/maze-runner/pull/666)
+
 # 9.11.2 - 2024/07/18
 
 ## Fixes

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -81,8 +81,30 @@ module Maze
           $logger.warn "StaleElementReferenceError occurred: #{e}"
           false
         end
+      rescue Selenium::WebDriver::Error::ServerError => e
+        # Assume the remote appium session has stopped, so crash out of the session
+        Maze.driver = nil
+        raise e
       else
         true
+      end
+
+      # A wrapper around launch_app adding extra error handling
+      def launch_app
+        super
+      rescue Selenium::WebDriver::Error::ServerError => e
+        # Assume the remote appium session has stopped, so crash out of the session
+        Maze.driver = nil
+        raise e
+      end
+
+      # A wrapper around close_app adding extra error handling
+      def close_app
+        super
+      rescue Selenium::WebDriver::Error::ServerError => e
+        # Assume the remote appium session has stopped, so crash out of the session
+        Maze.driver = nil
+        raise e
       end
 
       # A wrapper around find_element adding timer functionality
@@ -90,6 +112,10 @@ module Maze
         @find_element_timer.time do
           find_element(@element_locator, element_id)
         end
+      rescue Selenium::WebDriver::Error::ServerError => e
+        # Assume the remote appium session has stopped, so crash out of the session
+        Maze.driver = nil
+        raise e
       end
 
       # Clicks a given element
@@ -100,6 +126,10 @@ module Maze
         @click_element_timer.time do
           element.click
         end
+      rescue Selenium::WebDriver::Error::ServerError => e
+        # Assume the remote appium session has stopped, so crash out of the session
+        Maze.driver = nil
+        raise e
       end
 
       # Clicks a given element, ignoring any NoSuchElementError
@@ -114,6 +144,10 @@ module Maze
         true
       rescue Selenium::WebDriver::Error::NoSuchElementError
         false
+      rescue Selenium::WebDriver::Error::ServerError => e
+        # Assume the remote appium session has stopped, so crash out of the session
+        Maze.driver = nil
+        raise e
       end
 
       # Clears a given element
@@ -124,6 +158,10 @@ module Maze
         @clear_element_timer.time do
           element.clear
         end
+      rescue Selenium::WebDriver::Error::ServerError => e
+        # Assume the remote appium session has stopped, so crash out of the session
+        Maze.driver = nil
+        raise e
       end
 
       # Gets the application hierarchy XML
@@ -145,6 +183,10 @@ module Maze
         @send_keys_timer.time do
           element.send_keys(text)
         end
+      rescue Selenium::WebDriver::Error::ServerError => e
+        # Assume the remote appium session has stopped, so crash out of the session
+        Maze.driver = nil
+        raise e
       end
 
       # Sets the rotation of the device
@@ -178,6 +220,10 @@ module Maze
         @send_keys_timer.time do
           element.send_keys(text)
         end
+      rescue Selenium::WebDriver::Error::ServerError => e
+        # Assume the remote appium session has stopped, so crash out of the session
+        Maze.driver = nil
+        raise e
       end
 
       # Reset the currently running application after a given timeout


### PR DESCRIPTION
This should prevent multiple instances of server side errors appearing in the dashboard.  Afterwards any attempt to access the appium driver should fail without delivering a report, and the session will close.