### PR TITLE
Enable general validation through configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.14.0 - TBD
+
+## Enhancements
+
+- Add support for defining custom validation blocks in configuration [671](https://github.com/bugsnag/maze-runner/pull/671) & [672](https://github.com/bugsnag/maze-runner/pull/672)
+
 # 9.13.1 - 2024-08-30
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Add support for defining custom validation blocks in configuration [671](https://github.com/bugsnag/maze-runner/pull/671) & [672](https://github.com/bugsnag/maze-runner/pull/672)
+- Add support for defining custom validation blocks in configuration [672](https://github.com/bugsnag/maze-runner/pull/672)
 
 # 9.13.1 - 2024-08-30
 

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -66,9 +66,6 @@ require_relative '../lib/maze/server'
 require_relative '../lib/maze/assertions/request_set_assertions'
 
 require_relative '../lib/maze/schemas/validator'
-require_relative '../lib/maze/schemas/error_validator'
-require_relative '../lib/maze/schemas/trace_schema'
-require_relative '../lib/maze/schemas/trace_validator'
 
 require_relative '../lib/maze/store'
 require_relative '../lib/maze/timers'

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -66,8 +66,6 @@ require_relative '../lib/maze/server'
 require_relative '../lib/maze/assertions/request_set_assertions'
 
 require_relative '../lib/maze/schemas/validator'
-require_relative '../lib/maze/schemas/validator_base'
-
 require_relative '../lib/maze/schemas/error_validator'
 require_relative '../lib/maze/schemas/trace_schema'
 require_relative '../lib/maze/schemas/trace_validator'

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -65,9 +65,12 @@ require_relative '../lib/maze/server'
 
 require_relative '../lib/maze/assertions/request_set_assertions'
 
+require_relative '../lib/maze/schemas/validator'
+require_relative '../lib/maze/schemas/validator_base'
+
+require_relative '../lib/maze/schemas/error_validator'
 require_relative '../lib/maze/schemas/trace_schema'
 require_relative '../lib/maze/schemas/trace_validator'
-require_relative '../lib/maze/schemas/validator'
 
 require_relative '../lib/maze/store'
 require_relative '../lib/maze/timers'

--- a/lib/features/steps/trace_steps.rb
+++ b/lib/features/steps/trace_steps.rb
@@ -317,7 +317,6 @@ def assert_received_spans(list, min_received, max_received = nil)
 
   Maze.check.operator(max_received, :>=, received_count, "#{received_count} spans received") if max_received
 
-  Maze::Schemas::Validator.verify_against_schema(list, 'trace')
   Maze::Schemas::Validator.validate_payload_elements(list, 'trace')
 end
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -233,7 +233,6 @@ end
 # specified for the specific endpoint
 After do |scenario|
   ['error', 'session', 'build', 'trace'].each do |endpoint|
-    Maze::Schemas::Validator.verify_against_schema(Maze::Server.list_for(endpoint), endpoint)
     Maze::Schemas::Validator.validate_payload_elements(Maze::Server.list_for(endpoint), endpoint)
   end
 end

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -83,6 +83,19 @@ module Maze
     # Enables unmanaged trace mode.
     attr_accessor :unmanaged_traces_mode
 
+    # Custom validators to use for a given endpoint
+    attr_reader :custom_validators
+
+    # Consumes a block that will be triggered when a request is received for a specific endpoint
+    # This will prevent any existing default validation from triggering.
+    #
+    # @param endpoint [String] The endpoint to validate
+    # @param validator [Proc] The block to run when a request is received
+    def add_validator(endpoint, &validator)
+      @custom_validators ||= {}
+      @custom_validators[endpoint] = validator
+    end
+
     #
     # General appium configuration
     #

--- a/lib/maze/schemas/config_validator.rb
+++ b/lib/maze/schemas/config_validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../helper'
+require_relative 'validator_base'
+
+module Maze
+  module Schemas
+    class ConfigValidator < ValidatorBase
+      def initialize(request, validation_block)
+        super(request)
+        @validation_block = validation_block
+      end
+
+      def validate
+        @success = true
+        @validation_block.call(self)
+      end
+    end
+  end
+end

--- a/lib/maze/schemas/config_validator.rb
+++ b/lib/maze/schemas/config_validator.rb
@@ -6,6 +6,12 @@ require_relative 'validator_base'
 module Maze
   module Schemas
     class ConfigValidator < ValidatorBase
+
+      attr_accessor :success
+      attr_accessor :errors
+      attr_reader :headers
+      attr_reader :body
+
       def initialize(request, validation_block)
         super(request)
         @validation_block = validation_block

--- a/lib/maze/schemas/config_validator.rb
+++ b/lib/maze/schemas/config_validator.rb
@@ -22,7 +22,8 @@ module Maze
         @validation_block.call(self)
       rescue => exception
         @success = false
-        @errors << "A #{exception.class} occurred while running validation: #{exception.message}"
+        @errors << "A #{exception.class} occurred while running validation: #{exception.message}, \n #{exception.backtrace.join("\n")}" 
+
       end
     end
   end

--- a/lib/maze/schemas/config_validator.rb
+++ b/lib/maze/schemas/config_validator.rb
@@ -20,6 +20,9 @@ module Maze
       def validate
         @success = true
         @validation_block.call(self)
+      rescue => exception
+        @success = false
+        @errors << "A #{exception.class} occurred while running validation: #{exception.message}"
       end
     end
   end

--- a/lib/maze/schemas/error_validator.rb
+++ b/lib/maze/schemas/error_validator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../helper'
+require_relative 'validator_base'
 
 module Maze
   module Schemas

--- a/lib/maze/schemas/error_validator.rb
+++ b/lib/maze/schemas/error_validator.rb
@@ -7,7 +7,7 @@ module Maze
   module Schemas
 
     # Contains a set of pre-defined validations for ensuring errors are correct
-    class ErrorValidator
+    class ErrorValidator < ValidatorBase
     end
   end
 end

--- a/lib/maze/schemas/error_validator.rb
+++ b/lib/maze/schemas/error_validator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../helper'
+
+module Maze
+  module Schemas
+
+    # Contains a set of pre-defined validations for ensuring errors are correct
+    class ErrorValidator
+
+      # Runs the validation against the trace given
+      def validate
+        @success = true
+      end
+    end
+  end
+end

--- a/lib/maze/schemas/error_validator.rb
+++ b/lib/maze/schemas/error_validator.rb
@@ -8,11 +8,6 @@ module Maze
 
     # Contains a set of pre-defined validations for ensuring errors are correct
     class ErrorValidator
-
-      # Runs the validation against the trace given
-      def validate
-        @success = true
-      end
     end
   end
 end

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../helper'
+require_relative 'validator_base'
 
 module Maze
   module Schemas

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -37,7 +37,7 @@ module Maze
       end
 
       def verify_against_schema
-        if !@schema_errors.nil? || @schema_errors.size > 0
+        if !@schema_errors.nil? && @schema_errors.size > 0
           @success = false
           @schema_errors.each do |error|
             @errors << "#{JSONSchemer::Errors.pretty(error)}"

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -11,16 +11,10 @@ module Maze
 
     # Contains a set of pre-defined validations for ensuring traces are correct
     class TraceValidator < ValidatorBase
-
-      # Whether the trace passed the validation, one of true, false, or nil (not run)
-      #   @returns [Boolean|nil] Whether the validation was successful
-      attr_reader :success
-      attr_reader :errors
-
       # Runs the validation against the trace given
       def validate
+        # The tests are being run
         @success = true
-
         validate_headers
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.spanId', HEX_STRING_16)
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.traceId', HEX_STRING_32)

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -5,29 +5,16 @@ require_relative '../helper'
 module Maze
   module Schemas
 
-    HEX_STRING_16 = '^[A-Fa-f0-9]{16}$'
-    HEX_STRING_32 = '^[A-Fa-f0-9]{32}$'
     SAMPLING_HEADER_ENTRY = '((1(.0)?|0(\.[0-9]+)?):[0-9]+)'
     SAMPLING_HEADER = "^#{SAMPLING_HEADER_ENTRY}(;#{SAMPLING_HEADER_ENTRY})*$"
-    HOUR_TOLERANCE = 60 * 60 * 1000 * 1000 * 1000 # 1 hour in nanoseconds
 
     # Contains a set of pre-defined validations for ensuring traces are correct
-    class TraceValidator
+    class TraceValidator < ValidatorBase
 
       # Whether the trace passed the validation, one of true, false, or nil (not run)
       #   @returns [Boolean|nil] Whether the validation was successful
       attr_reader :success
       attr_reader :errors
-
-      # Creates the validator
-      #
-      #   @param request [Hash] The trace request to validate
-      def initialize(request)
-        @headers = request[:request].header
-        @body = request[:body]
-        @success = nil
-        @errors = []
-      end
 
       # Runs the validation against the trace given
       def validate
@@ -50,36 +37,6 @@ module Maze
           'resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano',
           'resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano'
         )
-      end
-
-      def validate_timestamp(path, tolerance)
-        return unless Maze.config.span_timestamp_validation
-        timestamp = Maze::Helper.read_key_path(@body, path)
-        unless timestamp.kind_of?(String)
-          @success = false
-          @errors << "Timestamp was expected to be a string, was '#{timestamp.class.name}'"
-          return
-        end
-        parsed_timestamp = timestamp.to_i
-        unless parsed_timestamp > 0
-          @success = false
-          @errors << "Timestamp was expected to be a positive integer, was '#{parsed_timestamp}'"
-          return
-        end
-        time_in_nanos = Time.now.to_i * 1000000000
-        unless (time_in_nanos - parsed_timestamp).abs < tolerance
-          @success = false
-          @errors << "Timestamp was expected to be within #{tolerance} nanoseconds of the current time (#{time_in_nanos}), was '#{parsed_timestamp}'"
-        end
-      end
-
-      def validate_header(name)
-        value = @headers[name]
-        if value.nil? || value.size > 1
-          @errors << "Expected exactly one value for header #{name}, received #{value || 'nil'}"
-        else
-          yield value[0]
-        end
       end
 
       # Checks that the required headers are present and correct
@@ -115,70 +72,6 @@ module Maze
               end
             end
           end
-        end
-      end
-
-      def regex_comparison(path, regex)
-        element_value = Maze::Helper.read_key_path(@body, path)
-        expected = Regexp.new(regex)
-        unless expected.match(element_value)
-          @success = false
-          @errors << "Element '#{path}' was expected to match the regex '#{regex}', but was '#{element_value}'"
-        end
-      end
-
-      def element_int_in_range(path, range)
-        element_value = Maze::Helper.read_key_path(@body, path)
-        if element_value.nil? || !element_value.kind_of?(Integer)
-          @success = false
-          @errors << "Element '#{path}' was expected to be an integer, was '#{element_value}'"
-          return
-        end
-        unless range.include?(element_value)
-          @success = false
-          @errors << "Element '#{path}':'#{element_value}' was expected to be in the range '#{range}'"
-        end
-      end
-
-      def element_contains(path, key_value, value_type=nil, possible_values=nil)
-        container = Maze::Helper.read_key_path(@body, path)
-        if container.nil? || !container.kind_of?(Array)
-          @success = false
-          @errors << "Element '#{path}' was expected to be an array, was '#{container}'"
-          return
-        end
-        element = container.find { |value| value['key'].eql?(key_value) }
-        unless element
-          @success = false
-          @errors << "Element '#{path}' did not contain a value with the key '#{key_value}'"
-          return
-        end
-        if value_type && possible_values
-          unless element['value'] && element['value'][value_type] && possible_values.include?(element['value'][value_type])
-            @success = false
-            @errors << "Element '#{path}':'#{element}' did not contain a value of '#{value_type}' from '#{possible_values}'"
-          end
-        end
-      end
-
-      def each_element_contains(container_path, attribute_path, key_value)
-        container = Maze::Helper.read_key_path(@body, container_path)
-        if container.nil? || !container.kind_of?(Array)
-          @success = false
-          @errors << "Element '#{container_path}' was expected to be an array, was '#{container}'"
-          return
-        end
-        container.each_with_index do |_item, index|
-          element_contains("#{container_path}.#{index}.#{attribute_path}", key_value)
-        end
-      end
-
-      def element_a_greater_or_equal_element_b(path_a, path_b)
-        element_a = Maze::Helper.read_key_path(@body, path_a)
-        element_b = Maze::Helper.read_key_path(@body, path_b)
-        unless element_a && element_b && element_a >= element_b
-          @success = false
-          @errors << "Element '#{path_a}':'#{element_a}' was expected to be greater than or equal to '#{path_b}':'#{element_b}'"
         end
       end
     end

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../helper'
+require_relative 'trace_schema'
 require_relative 'validator_base'
 
 module Maze
@@ -15,6 +16,7 @@ module Maze
       def validate
         # The tests are being run
         @success = true
+        verify_against_schema
         validate_headers
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.spanId', HEX_STRING_16)
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.traceId', HEX_STRING_32)
@@ -32,6 +34,15 @@ module Maze
           'resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano',
           'resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano'
         )
+      end
+
+      def verify_against_schema
+        if !@schema_errors.nil? || @schema_errors.size > 0
+          @success = false
+          @schema_errors.each do |error|
+            @errors << "#{JSONSchemer::Errors.pretty(error)}"
+          end
+        end
       end
 
       # Checks that the required headers are present and correct

--- a/lib/maze/schemas/validator.rb
+++ b/lib/maze/schemas/validator.rb
@@ -2,7 +2,6 @@
 
 require_relative 'config_validator'
 require_relative 'error_validator'
-require_relative 'trace_schema'
 require_relative 'trace_validator'
 
 module Maze
@@ -12,32 +11,6 @@ module Maze
     class Validator
 
       class << self
-        # Tests that payloads for a specific path have passed any schema checks implemented on receipt
-        # Throws an AssertionFailedError with a list of issues on failure
-        #
-        # @param list [Array] An array of received requests
-        # @param list_name [String] The name of the payload list for received requests
-        def verify_against_schema(list, list_name)
-          request_schema_results = list.all.map { |request| request[:schema_errors] }
-          passed = true
-          request_schema_results.each.with_index(1) do |schema_errors, index|
-            next if schema_errors.nil?
-            if schema_errors.size > 0
-              passed = false
-              $stdout.puts "\n"
-              $stdout.puts "\e[31m--- #{list_name} #{index} failed validation:\e[0m"
-              schema_errors.each do |error|
-                $stdout.puts "\e[31m#{JSONSchemer::Errors.pretty(error)}\e[0m"
-              end
-              $stdout.puts "\n"
-            end
-          end
-
-          unless passed
-            raise Test::Unit::AssertionFailedError.new 'The received payloads did not match the endpoint schema.  A full list of the errors can be found above'
-          end
-        end
-
         # Tests that payloads for a specific path pass any additional validation checks
         # Throws an AssertionFailedError with a list of issues on failure
         #

--- a/lib/maze/schemas/validator.rb
+++ b/lib/maze/schemas/validator.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require_relative '../config_validator'
-require_relative '../error_validator'
-require_relative '../trace_schema'
-require_relative '../trace_validator'
+require_relative 'config_validator'
+require_relative 'error_validator'
+require_relative 'trace_schema'
+require_relative 'trace_validator'
 
 module Maze
   module Schemas

--- a/lib/maze/schemas/validator_base.rb
+++ b/lib/maze/schemas/validator_base.rb
@@ -53,39 +53,6 @@ module Maze
         end
       end
 
-      def element_contains(path, key_value, value_type=nil, possible_values=nil)
-        container = Maze::Helper.read_key_path(@body, path)
-        if container.nil? || !container.kind_of?(Array)
-          @success = false
-          @errors << "Element '#{path}' was expected to be an array, was '#{container}'"
-          return
-        end
-        element = container.find { |value| value['key'].eql?(key_value) }
-        unless element
-          @success = false
-          @errors << "Element '#{path}' did not contain a value with the key '#{key_value}'"
-          return
-        end
-        if value_type && possible_values
-          unless element['value'] && element['value'][value_type] && possible_values.include?(element['value'][value_type])
-            @success = false
-            @errors << "Element '#{path}':'#{element}' did not contain a value of '#{value_type}' from '#{possible_values}'"
-          end
-        end
-      end
-
-      def each_element_contains(container_path, attribute_path, key_value)
-        container = Maze::Helper.read_key_path(@body, container_path)
-        if container.nil? || !container.kind_of?(Array)
-          @success = false
-          @errors << "Element '#{container_path}' was expected to be an array, was '#{container}'"
-          return
-        end
-        container.each_with_index do |_item, index|
-          element_contains("#{container_path}.#{index}.#{attribute_path}", key_value)
-        end
-      end
-
       def element_a_greater_or_equal_element_b(path_a, path_b)
         element_a = Maze::Helper.read_key_path(@body, path_a)
         element_b = Maze::Helper.read_key_path(@body, path_b)

--- a/lib/maze/schemas/validator_base.rb
+++ b/lib/maze/schemas/validator_base.rb
@@ -8,9 +8,12 @@ module Maze
       HEX_STRING_32 = '^[A-Fa-f0-9]{32}$'
       HOUR_TOLERANCE = 60 * 60 * 1000 * 1000 * 1000 # 1 hour in nanoseconds
 
-      # Whether the trace passed the validation, one of true, false, or nil (not run)
+      # Whether the payloads passed the validation, one of true, false, or nil (not run)
       #   @returns [Boolean|nil] Whether the validation was successful
       attr_reader :success
+
+      # An array of error messages if the validation failed
+      #  @returns [Array] The error messages
       attr_reader :errors
 
       # Creates the validator
@@ -23,10 +26,9 @@ module Maze
         @errors = []
       end
 
-      # Fill in method, needs to be overwritten by inheriting class
       def validate
-        @success = false
-        raise "Method 'validate' needs to be overwritten by inheriting class"
+        # By default the validation will pass
+        @success = true
       end
 
       def regex_comparison(path, regex)

--- a/lib/maze/schemas/validator_base.rb
+++ b/lib/maze/schemas/validator_base.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module Maze
+  module Schemas
+    class ValidatorBase
+
+      HEX_STRING_16 = '^[A-Fa-f0-9]{16}$'
+      HEX_STRING_32 = '^[A-Fa-f0-9]{32}$'
+      HOUR_TOLERANCE = 60 * 60 * 1000 * 1000 * 1000 # 1 hour in nanoseconds
+
+      # Whether the trace passed the validation, one of true, false, or nil (not run)
+      #   @returns [Boolean|nil] Whether the validation was successful
+      attr_reader :success
+      attr_reader :errors
+
+      # Creates the validator
+      #
+      #   @param request [Hash] The trace request to validate
+      def initialize(request)
+        @headers = request[:request].header
+        @body = request[:body]
+        @success = nil
+        @errors = []
+      end
+
+      # Fill in method, needs to be overwritten by inheriting class
+      def validate
+        @success = false
+        raise "Method 'validate' needs to be overwritten by inheriting class"
+      end
+
+      def regex_comparison(path, regex)
+        element_value = Maze::Helper.read_key_path(@body, path)
+        expected = Regexp.new(regex)
+        unless expected.match(element_value)
+          @success = false
+          @errors << "Element '#{path}' was expected to match the regex '#{regex}', but was '#{element_value}'"
+        end
+      end
+
+      def element_int_in_range(path, range)
+        element_value = Maze::Helper.read_key_path(@body, path)
+        if element_value.nil? || !element_value.kind_of?(Integer)
+          @success = false
+          @errors << "Element '#{path}' was expected to be an integer, was '#{element_value}'"
+          return
+        end
+        unless range.include?(element_value)
+          @success = false
+          @errors << "Element '#{path}':'#{element_value}' was expected to be in the range '#{range}'"
+        end
+      end
+
+      def element_contains(path, key_value, value_type=nil, possible_values=nil)
+        container = Maze::Helper.read_key_path(@body, path)
+        if container.nil? || !container.kind_of?(Array)
+          @success = false
+          @errors << "Element '#{path}' was expected to be an array, was '#{container}'"
+          return
+        end
+        element = container.find { |value| value['key'].eql?(key_value) }
+        unless element
+          @success = false
+          @errors << "Element '#{path}' did not contain a value with the key '#{key_value}'"
+          return
+        end
+        if value_type && possible_values
+          unless element['value'] && element['value'][value_type] && possible_values.include?(element['value'][value_type])
+            @success = false
+            @errors << "Element '#{path}':'#{element}' did not contain a value of '#{value_type}' from '#{possible_values}'"
+          end
+        end
+      end
+
+      def each_element_contains(container_path, attribute_path, key_value)
+        container = Maze::Helper.read_key_path(@body, container_path)
+        if container.nil? || !container.kind_of?(Array)
+          @success = false
+          @errors << "Element '#{container_path}' was expected to be an array, was '#{container}'"
+          return
+        end
+        container.each_with_index do |_item, index|
+          element_contains("#{container_path}.#{index}.#{attribute_path}", key_value)
+        end
+      end
+
+      def element_a_greater_or_equal_element_b(path_a, path_b)
+        element_a = Maze::Helper.read_key_path(@body, path_a)
+        element_b = Maze::Helper.read_key_path(@body, path_b)
+        unless element_a && element_b && element_a >= element_b
+          @success = false
+          @errors << "Element '#{path_a}':'#{element_a}' was expected to be greater than or equal to '#{path_b}':'#{element_b}'"
+        end
+      end
+
+      def validate_timestamp(path, tolerance)
+        return unless Maze.config.span_timestamp_validation
+        timestamp = Maze::Helper.read_key_path(@body, path)
+        unless timestamp.kind_of?(String)
+          @success = false
+          @errors << "Timestamp was expected to be a string, was '#{timestamp.class.name}'"
+          return
+        end
+        parsed_timestamp = timestamp.to_i
+        unless parsed_timestamp > 0
+          @success = false
+          @errors << "Timestamp was expected to be a positive integer, was '#{parsed_timestamp}'"
+          return
+        end
+        time_in_nanos = Time.now.to_i * 1000000000
+        unless (time_in_nanos - parsed_timestamp).abs < tolerance
+          @success = false
+          @errors << "Timestamp was expected to be within #{tolerance} nanoseconds of the current time (#{time_in_nanos}), was '#{parsed_timestamp}'"
+        end
+      end
+
+      def validate_header(name)
+        value = @headers[name]
+        if value.nil? || value.size > 1
+          @errors << "Expected exactly one value for header #{name}, received #{value || 'nil'}"
+        else
+          yield value[0]
+        end
+      end
+    end
+  end
+end

--- a/lib/maze/schemas/validator_base.rb
+++ b/lib/maze/schemas/validator_base.rb
@@ -22,6 +22,7 @@ module Maze
       def initialize(request)
         @headers = request[:request].header
         @body = request[:body]
+        @schema_errors = request[:schema_errors]
         @success = nil
         @errors = []
       end

--- a/test/fixtures/validation/Dockerfile
+++ b/test/fixtures/validation/Dockerfile
@@ -1,0 +1,6 @@
+ARG BRANCH_NAME
+ARG RUBY_VERSION
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:${BRANCH_NAME}-ci-ruby-${RUBY_VERSION}
+
+COPY . /app
+WORKDIR /app

--- a/test/fixtures/validation/Gemfile
+++ b/test/fixtures/validation/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'bugsnag-maze-runner', path: '../../..'

--- a/test/fixtures/validation/features/config_validation.feature
+++ b/test/fixtures/validation/features/config_validation.feature
@@ -1,0 +1,41 @@
+Feature: Tests that validation blocks can be provided to the configuration
+
+    Scenario: A scenario passes with no configured validation
+        Given I set up the maze-harness console
+        And I input "bundle exec maze-runner --port=9349 features/error_payload.feature" interactively
+        Then the last interactive command exit code is 0
+
+    Scenario: A scenario passes with pre-configured validation
+        Given I set up the maze-harness console
+        When I input "VALIDATOR_SCENARIO=pass bundle exec maze-runner --port=9349 features/error_payload.feature" interactively
+        Then the last interactive command exit code is 0
+
+    Scenario: A scenario fails with pre-configured validation
+        Given I set up the maze-harness console
+        When I input "VALIDATOR_SCENARIO=fail bundle exec maze-runner --port=9349 features/error_payload.feature" interactively
+        Then the last interactive command exit code is 1
+
+    Scenario: A scenario passes if the validation block is empty
+        Given I set up the maze-harness console
+        When I input "VALIDATOR_SCENARIO=empty bundle exec maze-runner --port=9349 features/error_payload.feature" interactively
+        Then the last interactive command exit code is 0
+
+    Scenario: A scenario fails if the block makes it fail
+        Given I set up the maze-harness console
+        When I input "VALIDATOR_SCENARIO=custom_fail bundle exec maze-runner --port=9349 features/error_payload.feature" interactively
+        Then the last interactive command exit code is 1
+
+    Scenario: A scenario fails if an error occurs in the block
+        Given I set up the maze-harness console
+        When I input "VALIDATOR_SCENARIO=error bundle exec maze-runner --port=9349 features/error_payload.feature" interactively
+        Then the last interactive command exit code is 1
+
+    Scenario: The default validation runs if not overwritten
+        Given I set up the maze-harness console
+        When I input "bundle exec maze-runner --port=9349 features/trace_payload.features" interactively
+        Then the last interactive command exit code is 1
+
+    Scenario: Configured validation overrides default validation
+        Given I set up the maze-harness console
+        When I input "VALIDATOR_SCENARIO=trace bundle exec maze-runner --port=9349 features/trace_payload.features" interactively
+        Then the last interactive command exit code is 0

--- a/test/fixtures/validation/features/fixtures/maze-harness/Gemfile
+++ b/test/fixtures/validation/features/fixtures/maze-harness/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'bugsnag-maze-runner', path: '../../../../../..'

--- a/test/fixtures/validation/features/fixtures/maze-harness/features/error_payload.feature
+++ b/test/fixtures/validation/features/fixtures/maze-harness/features/error_payload.feature
@@ -1,0 +1,5 @@
+Feature: Sends a payload to the error endpoint
+
+    Scenario: An error payload is sent
+        When I send a request to the "notify" endpoint
+        Then I wait to receive an error

--- a/test/fixtures/validation/features/fixtures/maze-harness/features/steps/maze_harness_steps.rb
+++ b/test/fixtures/validation/features/fixtures/maze-harness/features/steps/maze_harness_steps.rb
@@ -1,0 +1,33 @@
+require 'net/http'
+require 'json'
+require 'time'
+
+When('I send a request to the {string} endpoint') do |endpoint|
+  http = Net::HTTP.new('localhost', 9349)
+  request = Net::HTTP::Post.new("/#{endpoint}")
+  request['Content-Type'] = 'application/json'
+
+  payload = {
+    'headers' => {
+      'Bugsnag-Api-Key' => ENV['TEST_API_KEY'],
+      'Bugsnag-Payload-Version' => '1.0'
+    },
+    'body' => {
+      'number' => 120,
+      'string' => 'foobar',
+      'array' => [1, 2, 3],
+      'hash' => {
+        'val1' => 1,
+        'val2' => 2
+      }
+    }
+  }
+
+  payload['headers'].each do |header, value|
+    request[header] = value
+  end
+
+  request.body = JSON.dump(payload['body'])
+
+  http.request(request)
+end

--- a/test/fixtures/validation/features/fixtures/maze-harness/features/support/env.rb
+++ b/test/fixtures/validation/features/fixtures/maze-harness/features/support/env.rb
@@ -1,0 +1,38 @@
+Maze.config.enforce_bugsnag_integrity = false
+
+pp "Current validator scenario is: #{ENV['VALIDATOR_SCENARIO']}"
+
+case ENV['VALIDATOR_SCENARIO']
+when 'pass'
+  Maze.config.add_validator('error') do |validator|
+    validator.regex_comparison('string', /[fobar]{6}/)
+    validator.element_int_in_range('number', 100..200)
+    validator.element_a_greater_or_equal_element_b('hash.val2', 'hash.val1')
+  end
+when 'fail'
+  Maze.config.add_validator('error') do |validator|
+    validator.regex_comparison('string', /[fobr]{6}/)
+    validator.element_int_in_range('number', 100..110)
+    validator.element_a_greater_or_equal_element_b('hash.val1', 'hash.val2')
+  end
+when 'empty'
+  Maze.config.add_validator('error') do |validator|
+  end
+when 'error'
+  Maze.config.add_validator('error') do |validator|
+    raise 'An error occurred in the validator'
+  end
+when 'custom_fail'
+  Maze.config.add_validator('error') do |validator|
+    if Maze::Helper.read_key_path(validator.body, 'string') == 'foobar'
+      validator.success = false
+      validator.errors << 'The string should not be "foobar"'
+    end
+  end
+when 'trace'
+  Maze.config.add_validator('trace') do |validator|
+    validator.regex_comparison('string', /[fobar]{6}/)
+    validator.element_int_in_range('number', 100..200)
+    validator.element_a_greater_or_equal_element_b('hash.val2', 'hash.val1')
+  end
+end

--- a/test/fixtures/validation/features/fixtures/maze-harness/features/trace_payload.feature
+++ b/test/fixtures/validation/features/fixtures/maze-harness/features/trace_payload.feature
@@ -1,0 +1,5 @@
+Feature: Sends a payload to the trace endpoint
+
+    Scenario: An trace payload is sent
+        When I send a request to the "traces" endpoint
+        Then I wait to receive a trace

--- a/test/fixtures/validation/features/steps/scripting_steps.rb
+++ b/test/fixtures/validation/features/steps/scripting_steps.rb
@@ -1,0 +1,8 @@
+When('I set up the maze-harness console') do
+  steps %{
+    Given I start a new shell
+    And I input "cd features/fixtures/maze-harness" interactively
+    And I input "bundle install" interactively
+    And I wait for the shell to output a match for the regex "Bundle complete!" to stdout
+  }
+end

--- a/test/fixtures/validation/features/support/env.rb
+++ b/test/fixtures/validation/features/support/env.rb
@@ -1,0 +1,11 @@
+BeforeAll do
+  ENV['BUGSNAG_API_KEY'] = $api_key
+end
+
+Before do
+  Maze.config.enforce_bugsnag_integrity = false
+end
+
+When('I enforce checking of the Bugsnag-Integrity header') do
+  Maze.config.enforce_bugsnag_integrity = true
+end

--- a/test/schemas/config_validation_test.rb
+++ b/test/schemas/config_validation_test.rb
@@ -1,0 +1,88 @@
+require 'test_helper'
+require_relative '../../lib/maze/schemas/config_validator'
+
+class MockRequest
+  attr_accessor :header
+end
+
+class ConfigValidationTest < Test::Unit::TestCase
+
+  def setup
+    Maze.config.span_timestamp_validation = true
+  end
+
+  def create_basic_request(body)
+    request = MockRequest.new
+    request.header = {
+      'bugsnag-api-key' => ['12345678901234567890123456789012'],
+      'bugsnag-sent-at' => ['2023-06-12T14:24:48.755Z']
+    }
+    {
+      :request => request,
+      :body => body
+    }
+  end
+
+  def test_passing_block
+    request = create_basic_request({'foo' => 'bar'})
+
+    block_run = false
+
+    test_block = Proc.new do |validator|
+      block_run = true
+      assert_equal(validator.headers, request[:request].header)
+      assert_equal(validator.body, request[:body])
+      assert(validator.success)
+      assert(validator.errors.empty?)
+    end
+
+    validator = Maze::Schemas::ConfigValidator.new(request, test_block)
+    validator.validate
+
+    assert(block_run)
+  end
+
+  def test_basic_failing_block
+    request = create_basic_request({ 'value' => 'abc' })
+
+    block_run = false
+
+    test_block = Proc.new do |validator|
+      block_run = true
+      validator.element_int_in_range('value', 1..3)
+    end
+
+    validator = Maze::Schemas::ConfigValidator.new(request, test_block)
+    validator.validate
+
+    assert(block_run)
+
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size)
+    assert_equal(validator.errors.first, "Element 'value' was expected to be an integer, was 'abc'")
+  end
+
+  def test_custom_failing_block
+    request = create_basic_request({ 'value' => 'abc' })
+
+    block_run = false
+
+    test_block = Proc.new do |validator|
+      block_run = true
+      test_val = Maze::Helper.read_key_path(validator.body, 'value')
+      if test_val != 'abcd'
+        validator.success = false
+        validator.errors << "Element 'value' was expected to be 'abcd', was '#{test_val}'"
+      end
+    end
+
+    validator = Maze::Schemas::ConfigValidator.new(request, test_block)
+    validator.validate
+
+    assert(block_run)
+
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size)
+    assert_equal(validator.errors.first, "Element 'value' was expected to be 'abcd', was 'abc'")
+  end
+end

--- a/test/schemas/trace_validation_test.rb
+++ b/test/schemas/trace_validation_test.rb
@@ -145,7 +145,7 @@ class TraceValidationTest < Test::Unit::TestCase
         }
       ]
     }))
-    validator.element_contains('value', 'correct')
+    validator.span_element_contains('value', 'correct')
     assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
@@ -167,7 +167,7 @@ class TraceValidationTest < Test::Unit::TestCase
         }
       ]
     }))
-    validator.element_contains('value', 'incorrect')
+    validator.span_element_contains('value', 'incorrect')
     assert_false(validator.success)
     assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'value' did not contain a value with the key 'incorrect'")
@@ -175,7 +175,7 @@ class TraceValidationTest < Test::Unit::TestCase
 
   def test_contains_not_array
     validator = Maze::Schemas::TraceValidator.new(create_basic_request({ 'value' => '1234' }))
-    validator.element_contains('value', 'incorrect')
+    validator.span_element_contains('value', 'incorrect')
     assert_false(validator.success)
     assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'value' was expected to be an array, was '1234'")
@@ -198,7 +198,7 @@ class TraceValidationTest < Test::Unit::TestCase
         }
       ]
     }))
-    validator.element_contains('value', 'correct', 'stringValue', ['good', 'done'])
+    validator.span_element_contains('value', 'correct', 'stringValue', ['good', 'done'])
     assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
@@ -220,7 +220,7 @@ class TraceValidationTest < Test::Unit::TestCase
         }
       ]
     }))
-    validator.element_contains('value', 'correct', 'stringValue', ['good', 'one'])
+    validator.span_element_contains('value', 'correct', 'stringValue', ['good', 'one'])
     assert_false(validator.success)
     assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'value':'{\"key\"=>\"correct\", \"value\"=>{\"stringValue\"=>\"done\"}}' did not contain a value of 'stringValue' from '[\"good\", \"one\"]'")
@@ -243,7 +243,7 @@ class TraceValidationTest < Test::Unit::TestCase
         }
       ]
     }))
-    validator.element_contains('value', 'correct', 'intValue', ['good', 'one'])
+    validator.span_element_contains('value', 'correct', 'intValue', ['good', 'one'])
     assert_false(validator.success)
     assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'value':'{\"key\"=>\"correct\", \"value\"=>{\"stringValue\"=>\"done\"}}' did not contain a value of 'intValue' from '[\"good\", \"one\"]'")
@@ -371,12 +371,12 @@ class TraceValidationTest < Test::Unit::TestCase
       ]
     }))
     # Calls to test each of the container elements
-    validator.expects(:element_contains).with('container.0.attributes', 'test_value')
-    validator.expects(:element_contains).with('container.1.attributes', 'test_value')
-    validator.expects(:element_contains).with('container.2.attributes', 'test_value')
-    validator.expects(:element_contains).with('container.3.attributes', 'test_value')
+    validator.expects(:span_element_contains).with('container.0.attributes', 'test_value')
+    validator.expects(:span_element_contains).with('container.1.attributes', 'test_value')
+    validator.expects(:span_element_contains).with('container.2.attributes', 'test_value')
+    validator.expects(:span_element_contains).with('container.3.attributes', 'test_value')
 
-    validator.each_element_contains('container', 'attributes', 'test_value')
+    validator.each_span_element_contains('container', 'attributes', 'test_value')
     assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
@@ -386,7 +386,7 @@ class TraceValidationTest < Test::Unit::TestCase
       'container' => 'foobar'
     }))
 
-    validator.each_element_contains('container', 'attributes', 'test_value')
+    validator.each_span_element_contains('container', 'attributes', 'test_value')
     assert_false(validator.success)
     assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Element 'container' was expected to be an array, was 'foobar'")

--- a/test/schemas/trace_validation_test.rb
+++ b/test/schemas/trace_validation_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 require_relative '../../lib/maze/schemas/trace_validator'
-require_relative '../../lib/maze/schemas/validator_base'
 
 class MockRequest
   attr_accessor :header
@@ -23,6 +22,11 @@ class TraceValidationTest < Test::Unit::TestCase
       :request => request,
       :body => body
     }
+  end
+
+  def format_errors(errors)
+    list = errors.join("\n")
+    "Errors given:\n#{list}"
   end
 
   def test_sampling_span_regex
@@ -79,53 +83,6 @@ class TraceValidationTest < Test::Unit::TestCase
     assert_false(validator.success)
     assert_equal(1, validator.errors.size, format_errors(validator.errors))
     assert_equal("bugsnag-span-sampling header was expected to match the regex '^((1(.0)?|0(\\.[0-9]+)?):[0-9]+)(;((1(.0)?|0(\\.[0-9]+)?):[0-9]+))*$', but was '2:2'", validator.errors.first)
-  end
-
-  def test_regex_success
-    validator = Maze::Schemas::TraceValidator.new(create_basic_request({ 'value' => 'abc123' }))
-    validator.regex_comparison('value', '[abc123]{6}')
-    assert_nil(validator.success)
-    assert(validator.errors.empty?)
-  end
-
-  def format_errors(errors)
-    list = errors.join("\n")
-    "Errors given:\n#{list}"
-  end
-
-  def test_regex_failure
-    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
-      'value' => 'abc123'
-    }))
-    validator.regex_comparison('value', '[ab12]{6}')
-    assert_false(validator.success)
-    assert_equal(1, validator.errors.size)
-    assert_equal(validator.errors.first, "Element 'value' was expected to match the regex '[ab12]{6}', but was 'abc123'")
-  end
-
-  def test_element_int_in_range_success
-    validator = Maze::Schemas::TraceValidator.new(create_basic_request({
-      'value' => 2
-    }))
-    validator.element_int_in_range('value', 1..3)
-    assert_nil(validator.success)
-    assert(validator.errors.empty?)
-  end
-
-  def test_element_int_in_range_failure
-    validator = Maze::Schemas::TraceValidator.new(create_basic_request({ 'value' => 4 }))
-    validator.element_int_in_range('value', 1..3)
-    assert_false(validator.success)
-    assert_equal(1, validator.errors.size)
-    assert_equal(validator.errors.first, "Element 'value':'4' was expected to be in the range '1..3'")
-  end
-
-  def test_element_int_in_range_no_int_failure
-    validator = Maze::Schemas::TraceValidator.new(create_basic_request({ 'value' => 'abc' }))
-    validator.element_int_in_range('value', 1..3)
-    assert_false(validator.success)
-    assert_equal(1, validator.errors.size)
-    assert_equal(validator.errors.first, "Element 'value' was expected to be an integer, was 'abc'")
   end
 
   def test_contains_key_success

--- a/test/schemas/trace_validation_test.rb
+++ b/test/schemas/trace_validation_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require_relative '../../lib/maze/schemas/trace_validator'
+require_relative '../../lib/maze/schemas/validator_base'
 
 class MockRequest
   attr_accessor :header
@@ -288,7 +289,7 @@ class TraceValidationTest < Test::Unit::TestCase
       'timestamp' => '12345000000000'
     }))
     Time.expects(:now).never
-    validator.validate_timestamp('timestamp', Maze::Schemas::HOUR_TOLERANCE)
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
     assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
@@ -298,7 +299,7 @@ class TraceValidationTest < Test::Unit::TestCase
       'timestamp' => '12345000000000'
     }))
     Time.expects(:now).returns(12345)
-    validator.validate_timestamp('timestamp', Maze::Schemas::HOUR_TOLERANCE)
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
     assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
@@ -308,7 +309,7 @@ class TraceValidationTest < Test::Unit::TestCase
       'timestamp' => "#{30 * 60 * 1000 * 1000 * 1000}"
     }))
     Time.expects(:now).returns(0)
-    validator.validate_timestamp('timestamp', Maze::Schemas::HOUR_TOLERANCE)
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
     assert_nil(validator.success)
     assert(validator.errors.empty?)
   end
@@ -317,7 +318,7 @@ class TraceValidationTest < Test::Unit::TestCase
     validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'timestamp' => 12345
     }))
-    validator.validate_timestamp('timestamp', Maze::Schemas::HOUR_TOLERANCE)
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
     assert_false(validator.success)
     assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Timestamp was expected to be a string, was 'Integer'")
@@ -327,7 +328,7 @@ class TraceValidationTest < Test::Unit::TestCase
     validator = Maze::Schemas::TraceValidator.new(create_basic_request({
       'timestamp' => '-1'
     }))
-    validator.validate_timestamp('timestamp', Maze::Schemas::HOUR_TOLERANCE)
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
     assert_false(validator.success)
     assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Timestamp was expected to be a positive integer, was '-1'")
@@ -338,7 +339,7 @@ class TraceValidationTest < Test::Unit::TestCase
       'timestamp' => '12345000000000'
     }))
     Time.expects(:now).returns(12345 + 3601)
-    validator.validate_timestamp('timestamp', Maze::Schemas::HOUR_TOLERANCE)
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
     assert_false(validator.success)
     assert_equal(1, validator.errors.size)
     assert_equal(validator.errors.first, "Timestamp was expected to be within 3600000000000 nanoseconds of the current time (15946000000000), was '12345000000000'")

--- a/test/schemas/validator_base_test.rb
+++ b/test/schemas/validator_base_test.rb
@@ -1,0 +1,163 @@
+require 'test_helper'
+require_relative '../../lib/maze/schemas/validator_base'
+
+class MockRequest
+  attr_accessor :header
+end
+
+class ValidatorBaseTest < Test::Unit::TestCase
+
+  def setup
+    Maze.config.span_timestamp_validation = true
+  end
+
+  def create_basic_request(body)
+    request = MockRequest.new
+    request.header = {
+      'bugsnag-api-key' => ['12345678901234567890123456789012'],
+      'bugsnag-sent-at' => ['2023-06-12T14:24:48.755Z']
+    }
+    {
+      :request => request,
+      :body => body
+    }
+  end
+
+  def test_regex_success
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({ 'value' => 'abc123' }))
+    validator.regex_comparison('value', '[abc123]{6}')
+    assert_nil(validator.success)
+    assert(validator.errors.empty?)
+  end
+
+  def test_regex_failure
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({
+      'value' => 'abc123'
+    }))
+    validator.regex_comparison('value', '[ab12]{6}')
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size)
+    assert_equal(validator.errors.first, "Element 'value' was expected to match the regex '[ab12]{6}', but was 'abc123'")
+  end
+
+  def test_element_int_in_range_success
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({
+      'value' => 2
+    }))
+    validator.element_int_in_range('value', 1..3)
+    assert_nil(validator.success)
+    assert(validator.errors.empty?)
+  end
+
+  def test_element_int_in_range_failure
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({ 'value' => 4 }))
+    validator.element_int_in_range('value', 1..3)
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size)
+    assert_equal(validator.errors.first, "Element 'value':'4' was expected to be in the range '1..3'")
+  end
+
+  def test_element_int_in_range_no_int_failure
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({ 'value' => 'abc' }))
+    validator.element_int_in_range('value', 1..3)
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size)
+    assert_equal(validator.errors.first, "Element 'value' was expected to be an integer, was 'abc'")
+  end
+
+  def test_greater_than_success
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({
+      'smaller' => 1,
+      'unit' => 1,
+      'larger' => 5
+    }))
+    validator.element_a_greater_or_equal_element_b('larger', 'smaller')
+    assert_nil(validator.success)
+    assert(validator.errors.empty?)
+  end
+
+  def test_greater_than_success_equals
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({
+      'smaller' => 1,
+      'unit' => 1,
+      'larger' => 5
+    }))
+    validator.element_a_greater_or_equal_element_b('smaller', 'unit')
+    assert_nil(validator.success)
+    assert(validator.errors.empty?)
+  end
+
+  def test_greater_than_failure_lesser
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({
+      'smaller' => 1,
+      'unit' => 1,
+      'larger' => 5
+    }))
+    validator.element_a_greater_or_equal_element_b('smaller', 'larger')
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size)
+    assert_equal(validator.errors.first, "Element 'smaller':'1' was expected to be greater than or equal to 'larger':'5'")
+  end
+
+  def test_not_validate_timestamp
+    Maze.config.span_timestamp_validation = false
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({
+      'timestamp' => '12345000000000'
+    }))
+    Time.expects(:now).never
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
+    assert_nil(validator.success)
+    assert(validator.errors.empty?)
+  end
+
+  def test_validate_timestamp_success_exact
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({
+      'timestamp' => '12345000000000'
+    }))
+    Time.expects(:now).returns(12345)
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
+    assert_nil(validator.success)
+    assert(validator.errors.empty?)
+  end
+
+  def test_validate_timestamp_success_within_tolerance
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({
+      'timestamp' => "#{30 * 60 * 1000 * 1000 * 1000}"
+    }))
+    Time.expects(:now).returns(0)
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
+    assert_nil(validator.success)
+    assert(validator.errors.empty?)
+  end
+
+  def test_validate_timestamp_failure_invalid_type
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({
+      'timestamp' => 12345
+    }))
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size)
+    assert_equal(validator.errors.first, "Timestamp was expected to be a string, was 'Integer'")
+  end
+
+  def test_validate_timestamp_failure_negative
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({
+      'timestamp' => '-1'
+    }))
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size)
+    assert_equal(validator.errors.first, "Timestamp was expected to be a positive integer, was '-1'")
+  end
+
+  def test_validate_timestamp_failure_outside_tolerance
+    validator = Maze::Schemas::ValidatorBase.new(create_basic_request({
+      'timestamp' => '12345000000000'
+    }))
+    Time.expects(:now).returns(12345 + 3601)
+    validator.validate_timestamp('timestamp', Maze::Schemas::ValidatorBase::HOUR_TOLERANCE)
+    assert_false(validator.success)
+    assert_equal(1, validator.errors.size)
+    assert_equal(validator.errors.first, "Timestamp was expected to be within 3600000000000 nanoseconds of the current time (15946000000000), was '12345000000000'")
+  end
+end


### PR DESCRIPTION
# Goal

The main functional change, this should allow us to write a custom validator in a block, which will automatically get run, replacing any existing validation.

## Changes

This accomplishes a few things:
- Moves file loading from maze-runner to the main validator class
- Adjusts where the schema validation is called from, moving it into the validator itself.  This should allow us to add more complex logic to when and how it's called without cluttering our hooks
- Adds a config option to add validators for specific endpoints, a form of which will be demonstrated below
- Adds a config validator, a ValidatorBase subclass that wraps the blocks given above, allowing them to access the validator base functionality

## Example

I've semi-implemented validation in go, [which can be viewed here](https://github.com/bugsnag/bugsnag-go/compare/master...tests/builtin-error-validation).  I'm not entirely happy with the setup - I think some of the methods can be added at the validator base level, abstracting some of the logic I've added there, but it serves as an example.

## Tests

I've updated the existing unit tests, and added several new e2e tests in a new test fixture.  These should demonstrate how maze-runner will respond to validation passes/failures.

## Future work

My main concern would be expanding the base class, ensuring a suite of basic tools to verify payloads exist within the validator context, keeping any validation blocks concise and easily readable.

I would also like to document these methods and instructions for adding custom validation thoroughly to make writing and adjusting any and all validators as painless as possible. 
