### PR TITLE
[PLAT-12770] Override `--fail-fast` via an environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Enhancements
 
 - Add support for defining custom validation blocks in configuration [672](https://github.com/bugsnag/maze-runner/pull/672)
-- Add the ability to override the `--fail-fast` option via an environment variable 
+- Add the ability to override the `--fail-fast` option via an environment variable [674](https://github.com/bugsnag/maze-runner/pull/674)
 
 # 9.13.1 - 2024-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Add support for defining custom validation blocks in configuration [672](https://github.com/bugsnag/maze-runner/pull/672)
+- Add the ability to override the `--fail-fast` option via an environment variable 
 
 # 9.13.1 - 2024-08-30
 

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -188,6 +188,12 @@ class MazeRunnerEntry
     remove_maze_runner_args
     add_cucumber_args
 
+    # Check if we've set ENV['MAZE_NO_FAIL_FAST'] to override the fail fast behaviour
+    # And remove the --fail-fast option if it's set
+    if ENV['MAZE_NO_FAIL_FAST'] && @args.include?('--fail-fast')
+      @args = @args - ['--fail-fast']
+    end
+
     Cucumber::Cli::Main.new(@args).execute!
   end
 end

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -136,6 +136,7 @@ class MazeRunnerEntry
     # And remove the --fail-fast option if it's set
     if ENV['MAZE_NO_FAIL_FAST'] && @args.include?('--fail-fast')
       @args = @args - ['--fail-fast']
+      $logger.info 'Suppressing --fail-fast option as MAZE_NO_FAIL_FAST is set.'
     end
 
     # Load internal steps and helper functions

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -132,6 +132,12 @@ class MazeRunnerEntry
       @args << "--expand"
     end
 
+    # Check if we've set ENV['MAZE_NO_FAIL_FAST'] to override the fail fast behaviour
+    # And remove the --fail-fast option if it's set
+    if ENV['MAZE_NO_FAIL_FAST'] && @args.include?('--fail-fast')
+      @args = @args - ['--fail-fast']
+    end
+
     # Load internal steps and helper functions
     load_dir = File.expand_path(File.dirname(File.dirname(__FILE__))).freeze
     paths = Dir.glob("#{load_dir}/lib/features/**/*.rb")
@@ -187,12 +193,6 @@ class MazeRunnerEntry
     # Adjust CL options before calling down to Cucumber
     remove_maze_runner_args
     add_cucumber_args
-
-    # Check if we've set ENV['MAZE_NO_FAIL_FAST'] to override the fail fast behaviour
-    # And remove the --fail-fast option if it's set
-    if ENV['MAZE_NO_FAIL_FAST'] && @args.include?('--fail-fast')
-      @args = @args - ['--fail-fast']
-    end
 
     Cucumber::Cli::Main.new(@args).execute!
   end

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -84,12 +84,9 @@ InstallPlugin do |config|
   Maze::BugsnagConfig.start_bugsnag(config)
 
   if config.fail_fast?
-    # Check if we want to override the fail fast behaviour
-    unless ENV['MAZE_NO_FAIL_FAST']
-      # Register exit code handler
-      Maze::Hooks::ErrorCodeHook.register_exit_code_hook
-      config.filters << Maze::Plugins::ErrorCodePlugin.new(config)
-    end
+    # Register exit code handler
+    Maze::Hooks::ErrorCodeHook.register_exit_code_hook
+    config.filters << Maze::Plugins::ErrorCodePlugin.new(config)
   end
 
   # Only add the retry plugin if --retry is not used on the command line

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -84,9 +84,12 @@ InstallPlugin do |config|
   Maze::BugsnagConfig.start_bugsnag(config)
 
   if config.fail_fast?
-    # Register exit code handler
-    Maze::Hooks::ErrorCodeHook.register_exit_code_hook
-    config.filters << Maze::Plugins::ErrorCodePlugin.new(config)
+    # Check if we want to override the fail fast behaviour
+    unless ENV['MAZE_NO_FAIL_FAST']
+      # Register exit code handler
+      Maze::Hooks::ErrorCodeHook.register_exit_code_hook
+      config.filters << Maze::Plugins::ErrorCodePlugin.new(config)
+    end
   end
 
   # Only add the retry plugin if --retry is not used on the command line


### PR DESCRIPTION
## Goal

Add the ability to override the `--fail-fast` option via an environment variable `MAZE_NO_FAIL_FAST`

## Changeset

Check if we're passing the `--fail-fast` option and that we've set the environment variable `MAZE_NO_FAIL_FAST` and remove the `--fail-fast` option before we pass it to cucumber.

## Tests

Covered by CI