### PR TITLE
Read command line options from files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for defining custom validation blocks in configuration
   - [672](https://github.com/bugsnag/maze-runner/pull/672)
   - [675](https://github.com/bugsnag/maze-runner/pull/675)
+- Add support for command line options files [674](https://github.com/bugsnag/maze-runner/pull/674)
 
 # 9.13.1 - 2024-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add support for defining custom validation blocks in configuration
   - [672](https://github.com/bugsnag/maze-runner/pull/672)
   - [675](https://github.com/bugsnag/maze-runner/pull/675)
-- Add support for command line options files [674](https://github.com/bugsnag/maze-runner/pull/674)
+- Add support for command line options files [676](https://github.com/bugsnag/maze-runner/pull/676)
 
 # 9.13.1 - 2024-08-30
 

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -104,6 +104,7 @@ class MazeRunnerEntry
   def read_options_file(filename)
     return unless File.exist?(filename)
 
+    $logger.info "Reading command line options from #{filename}"
     File.readlines(filename).each do |line|
       line.strip!
       next if line.empty? || line.start_with?('#')

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -101,6 +101,24 @@ require_relative '../lib/utils/selenium_money_patch'
 # Encapsulates the MazeRunner entry point
 class MazeRunnerEntry
 
+  def read_options_file(filename)
+    return unless File.exist?(filename)
+
+    File.readlines(filename).each do |line|
+      line.strip!
+      next if line.empty? || line.start_with?('#')
+      @args << line
+    end
+  end
+
+  # Loads options from config files
+  def load_options_from_files
+    all_file = File.join('features', 'support', 'maze.all.cfg')
+    buildkite_file = File.join('features', 'support', 'maze.buildkite.cfg')
+    read_options_file(all_file)
+    read_options_file(buildkite_file) if ENV['BUILDKITE']
+  end
+
   # Removes Maze Runner specific args from the array, as these will cause Cucumber to error.
   def remove_maze_runner_args
     Maze::Option.constants.each do |opt|
@@ -192,6 +210,7 @@ class MazeRunnerEntry
     Maze::Option::Processor.populate Maze.config, options
 
     # Adjust CL options before calling down to Cucumber
+    load_options_from_files
     remove_maze_runner_args
     add_cucumber_args
 

--- a/docs/Test_Inputs.md
+++ b/docs/Test_Inputs.md
@@ -1,21 +1,31 @@
-# Environment Variables
+# Test Inputs
+
+## Command line options
+
+All command line options for Cucumber Ruby are supported by Maze Runner.  To see the full list of options, run `bundle exec maze-runner --help`.
+
+Command line options can also be listed in the following files:
+- features/support/maze.all.cfg - included for all test runs.
+- features/support/maze.buildkite.cfg - included if the BUILDKITE environment variable is set.
+
+## Environment variables
 
 Maze Runner recognises various environment variables, as follows:
 
-## Bugsnag reporting
+### Bugsnag reporting
 
 `MAZE_BUGSNAG_API_KEY` - the API key for the Bugsnag project to which errors that occur during the test run should be reported.
 `MAZE_SCENARIO_BUGSNAG_API_KEY` - the API key for the Bugsnag project to which test failures should be reported as errors.
 
-## Device farms
+### Device farms
 
-### Configuration
+#### Configuration
 
 `MAZE_APPIUM_SERVER` - the Appium server URL (if different to the default).
 `MAZE_SELENIUM_SERVER` - the Selenium server URL (if different to the default).
 `USE_LEGACY_DRIVER` - whether the legacy (JSON-WP) driver should be used.
 
-### BitBar
+#### BitBar
 
 `MAZE_SB_LOCAL` - location of the SmartBear secure tunnel binary.
 `BITBAR_USERNAME`/`BITBAR_ACCESS_KEY` - BitBar account credentials.
@@ -23,7 +33,7 @@ Maze Runner recognises various environment variables, as follows:
 `MAZE_ASPECTO_REPEATER_API_KEY` - Enables forwarding of all received POST trace requests to Aspecto, using the API key provided.
 `MAZE_REPEATER_API_KEY` - Enables forwarding of all received session, error and trace requests to Bugsnag, using the API key provided.
 
-### BrowserStack
+#### BrowserStack
 
 `MAZE_BS_LOCAL` - location of the BrowserStack secure tunnel binary.
 
@@ -32,7 +42,7 @@ Maze Runner recognises various environment variables, as follows:
 `BROWSER_STACK_BROWSERS_USERNAME`/`BROWSER_STACK_BROWSERS_ACCESS_KEY` - BrowserStack account credentials for browser tests, used instead of `BROWSER_STACK_USERNAME`/`BROWSER_STACK_ACCESS_KEY` if both are provided.
 `BROWSER_STACK_DEVICES_USERNAME`/`BROWSER_STACK_DEVICES_ACCESS_KEY` - BrowserStack account credentials for device tests, used instead of `BROWSER_STACK_USERNAME`/`BROWSER_STACK_ACCESS_KEY` if both are provided.
 
-### Local devices
+#### Local devices
 
 `MAZE_APPLE_TEAM_ID` - the Apple Developer Team ID, required for testing on physical iOS devices.
 `MAZE_UDID` - the UDID of the physical iOS device to be used for test.


### PR DESCRIPTION
## Goal

Support reading command line options from files, reducing repetition in Buildkite pipeline files.

## Documentation

Docs updated.

## Tests

Basic testing performed locally and by prototyping the change to the Android pipeline.