### PR TITLE
Modify default setup for how validation works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 9.14.0 - TBD
+# 9.14.0 - 2024-09-23
 
 ## Enhancements
 
@@ -6,6 +6,8 @@
 - Add support for defining custom validation blocks in configuration
   - [672](https://github.com/bugsnag/maze-runner/pull/672)
   - [675](https://github.com/bugsnag/maze-runner/pull/675)
+  - [677](https://github.com/bugsnag/maze-runner/pull/677)
+- Add client mode configuration option [677](https://github.com/bugsnag/maze-runner/pull/677)
 - Add support for command line options files [676](https://github.com/bugsnag/maze-runner/pull/676)
 
 # 9.13.1 - 2024-08-30

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.13.1'
+  VERSION = '9.14.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -96,6 +96,20 @@ module Maze
       @custom_validators[endpoint] = validator
     end
 
+    # Whether default validation should be skipped for a given endpoint
+    attr_reader :skipped_validators
+
+    # Sets whether to skip default validation for a given endpoint
+    #
+    # @param endpoint [String] The endpoint to skip default validation for
+    def skip_default_validation(endpoint)
+      @skipped_validators ||= {}
+      @skipped_validators[endpoint] = true
+    end
+
+    # Sets whether validation should be run in client mode
+    attr_accessor :client_mode_validation
+
     #
     # General appium configuration
     #

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -14,6 +14,7 @@ module Maze
       self.android_app_files_directory = nil
       self.span_timestamp_validation = true
       self.unmanaged_traces_mode = false
+      self.client_mode_validation = true
       @legacy_driver = false
     end
 

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -34,7 +34,7 @@ module Maze
           'resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano'
         )
 
-        unless Maze.config.client_mode_validation
+        if Maze.config.client_mode_validation
           span_element_contains('resourceSpans.0.resource.attributes', 'device.id')
         end
       end

--- a/lib/maze/schemas/trace_validator.rb
+++ b/lib/maze/schemas/trace_validator.rb
@@ -23,7 +23,6 @@ module Maze
         element_int_in_range('resourceSpans.0.scopeSpans.0.spans.0.kind', 0..5)
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano', '^[0-9]+$')
         regex_comparison('resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano', '^[0-9]+$')
-        span_element_contains('resourceSpans.0.resource.attributes', 'device.id')
         each_span_element_contains('resourceSpans.0.scopeSpans.0.spans', 'attributes', 'bugsnag.sampling.p')
         span_element_contains('resourceSpans.0.resource.attributes', 'deployment.environment')
         span_element_contains('resourceSpans.0.resource.attributes', 'telemetry.sdk.name')
@@ -34,6 +33,10 @@ module Maze
           'resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano',
           'resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano'
         )
+
+        unless Maze.config.client_mode_validation
+          span_element_contains('resourceSpans.0.resource.attributes', 'device.id')
+        end
       end
 
       def verify_against_schema

--- a/lib/maze/schemas/validator.rb
+++ b/lib/maze/schemas/validator.rb
@@ -18,36 +18,30 @@ module Maze
         # @param list_name [String] The name of the payload list for received requests
         def validate_payload_elements(list, list_name)
           # Test to see if a custom validator exists for the list
-          if Maze.config.custom_validators&.key?(list_name)
-            custom_validator = true
-            validator_class = Maze::Schemas::ConfigValidator
+          custom_validator = Maze.config.custom_validators&.key?(list_name)
+          validator_class = case list_name
+          when 'trace', 'traces'
+            Maze::Schemas::TraceValidator
+          when 'error', 'errors'
+            Maze::Schemas::ErrorValidator
           else
-            custom_validator = false
-            validator_class = case list_name
-            when 'trace', 'traces'
-              Maze::Schemas::TraceValidator
-            when 'error', 'errors'
-              Maze::Schemas::ErrorValidator
-            else
-              nil
-            end
+            nil
           end
 
-          if validator_class
-            validators = list.all.map do |request|
-              # TODO: Implement generically in class and handle there?
-              if custom_validator
-                validator = validator_class.new(request, Maze.config.custom_validators[list_name])
-              else
-                validator = validator_class.new(request)
-              end
-              validator.validate
-              validator
-            end
+          list_validators = list.all.map do |request|
+            payload_validators = []
+            payload_validators << Maze::Schemas::ConfigValidator.new(request, Maze.config.custom_validators[list_name]) if custom_validator
+            payload_validators << validator_class.new(request) if validator_class
 
-            return if validators.all? { |validator| validator.success }
-            validators.each.with_index(1) do |validator, index|
+            payload_validators.each { |validator| validator.validate }
+            payload_validators
+          end
+
+          failing = false
+          list_validators.each.with_index(1) do |validators, index|
+            validators.each do |validator|
               unless validator.success
+                failing = true
                 $stdout.puts "\n"
                 $stdout.puts "\e[31m--- #{list_name} #{index} failed validation with the following errors:\e[0m"
                 validator.errors.each do |error|
@@ -56,8 +50,8 @@ module Maze
                 $stdout.puts "\n"
               end
             end
-            raise Test::Unit::AssertionFailedError.new("One or more #{list_name} payloads failed validation.  A full list of the errors can be found above")
           end
+          raise Test::Unit::AssertionFailedError.new("One or more #{list_name} payloads failed validation.  A full list of the errors can be found above") if failing
         end
       end
     end

--- a/lib/maze/schemas/validator.rb
+++ b/lib/maze/schemas/validator.rb
@@ -19,13 +19,18 @@ module Maze
         def validate_payload_elements(list, list_name)
           # Test to see if a custom validator exists for the list
           custom_validator = Maze.config.custom_validators&.key?(list_name)
-          validator_class = case list_name
-          when 'trace', 'traces'
-            Maze::Schemas::TraceValidator
-          when 'error', 'errors'
-            Maze::Schemas::ErrorValidator
+
+          if Maze.config.skipped_validators && Maze.config.skipped_validators[list_name]
+            validator_class = false
           else
-            nil
+            validator_class = case list_name
+            when 'trace', 'traces'
+              Maze::Schemas::TraceValidator
+            when 'error', 'errors'
+              Maze::Schemas::ErrorValidator
+            else
+              nil
+            end
           end
 
           list_validators = list.all.map do |request|


### PR DESCRIPTION
## Goal

Accomplishes 3 things:
- Changes how validation will be run by default, ensuring a given config block won't prevent the default validators being run
- Adds a new configuration option that will disable the default validation if called, but won't disable any custom configured validators:
```
Maze.config.skip_default_validation('errors')
```
- Adds a new configuration option that denotes that the test is in client mode, and indicates different kinds of verification could be used.  This is intended to be used to modify the internal validators in the case where certain attributes are not present in different notifier circumstances.

## Tests

Not implemented yet...
