### PR TITLE
Add extra dependencies no longer part of the standard library to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.14.1 - TBD
+
+## Fixes
+
+- Add dependencies for modules no longer present in Ruby standard lib for v3.3+ [678](https://github.com/bugsnag/maze-runner/pull/678)
+
 # 9.14.0 - 2024-09-23
 
 ## Enhancements

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -52,6 +52,12 @@ Gem::Specification.new do |spec|
   # Pin indirect dependencies
   spec.add_runtime_dependency 'rubyzip', '~> 2.3.2'
 
+  # Dependencies no longer part of the standard library
+  spec.add_runtime_dependency 'ostruct', '~>0.6.0'
+  spec.add_runtime_dependency 'logger', '~>1.6'
+  spec.add_runtime_dependency 'base64', '~>0.2.0'
+  spec.add_runtime_dependency 'bigdecimal', '~>3.1'
+
   spec.add_development_dependency 'license_finder', '~> 7.0'
   spec.add_development_dependency 'markdown', '~> 1.2'
   spec.add_development_dependency 'mocha', '~> 1.13.0'

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.14.0'
+  VERSION = '9.14.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
Namely:
- `ostruct`
- `bigdecimal`
- `base64`
- `logger`