### PR TITLE
Fix loading maze options from config files

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -143,7 +143,7 @@ steps:
     env:
       RUBY_VERSION: "2"
       USE_LEGACY_DRIVER: "1"
-    command: 'bundle exec maze-runner -e features/fixtures'
+    command: 'bundle exec maze-runner'
 
   - label: 'No-device tests with Ruby 2 - batch 2'
     timeout_in_minutes: 30
@@ -166,7 +166,7 @@ steps:
     env:
       RUBY_VERSION: "2"
       USE_LEGACY_DRIVER: "1"
-    command: 'bundle exec maze-runner -e features/fixtures'
+    command: 'bundle exec maze-runner'
 
   - label: 'No-device tests with Ruby 3 - batch 1'
     timeout_in_minutes: 30
@@ -184,7 +184,7 @@ steps:
           run: http-response-tests
     env:
       RUBY_VERSION: "3"
-    command: 'bundle exec maze-runner -e features/fixtures'
+    command: 'bundle exec maze-runner'
 
   - label: 'No-device tests with Ruby 3 - batch 2'
     timeout_in_minutes: 30
@@ -202,7 +202,7 @@ steps:
           run: command-workflow-tests
     env:
       RUBY_VERSION: "3"
-    command: 'bundle exec maze-runner -e features/fixtures'
+    command: 'bundle exec maze-runner'
 
   #
   # BrowserStack tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Add dependencies for modules no longer present in Ruby standard lib for v3.3+ [678](https://github.com/bugsnag/maze-runner/pull/678)
+- Fix issues with loading maze-runner commands from file [679](https://github.com/bugsnag/maze-runner/pull/679)
 
 # 9.14.0 - 2024-09-23
 

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -174,7 +174,8 @@ class MazeRunnerEntry
 
     # Parse args, processing any Maze Runner specific options
     @args = args.dup
-    options = Maze::Option::Parser.parse args
+    load_options_from_files
+    options = Maze::Option::Parser.parse @args
 
     if options[Maze::Option::LIST_DEVICES]
       case options[Maze::Option::FARM].to_sym
@@ -211,7 +212,6 @@ class MazeRunnerEntry
     Maze::Option::Processor.populate Maze.config, options
 
     # Adjust CL options before calling down to Cucumber
-    load_options_from_files
     remove_maze_runner_args
     add_cucumber_args
 

--- a/test/fixtures/cli/features/support/maze.all.cfg
+++ b/test/fixtures/cli/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--exclude=features/fixtures

--- a/test/fixtures/command-workflow/features/support/maze.all.cfg
+++ b/test/fixtures/command-workflow/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--exclude=features/fixtures

--- a/test/fixtures/comparison/features/support/maze.all.cfg
+++ b/test/fixtures/comparison/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--exclude=features/fixtures

--- a/test/fixtures/doc-server/features/support/maze.all.cfg
+++ b/test/fixtures/doc-server/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--exclude=features/fixtures

--- a/test/fixtures/docker-app/features/support/maze.all.cfg
+++ b/test/fixtures/docker-app/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--exclude=features/fixtures

--- a/test/fixtures/exit-codes/features/support/maze.all.cfg
+++ b/test/fixtures/exit-codes/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--exclude=features/fixtures

--- a/test/fixtures/framework/features/support/maze.all.cfg
+++ b/test/fixtures/framework/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--exclude=features/fixtures

--- a/test/fixtures/http-response/features/support/maze.all.cfg
+++ b/test/fixtures/http-response/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--exclude=features/fixtures

--- a/test/fixtures/payload-helpers/features/support/maze.all.cfg
+++ b/test/fixtures/payload-helpers/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--exclude=features/fixtures

--- a/test/fixtures/proxy/features/support/maze.all.cfg
+++ b/test/fixtures/proxy/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--exclude=features/fixtures

--- a/test/fixtures/validation/features/support/maze.all.cfg
+++ b/test/fixtures/validation/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--exclude=features/fixtures


### PR DESCRIPTION
## Goal

Moves some method calls around to allow options in config files to be passed into the options parser.

## Tests

I've removed the exclusion of the purposefully failing features from the buildkite file calling those tests, and moved that option into the config files in each test fixture.   This should act as a trip, as if these excluded tests start failing the CI runs we'll know the options aren't being picked up from the config files.

