### PR TITLE
Add guard for close_app usage in appium v2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add dependencies for modules no longer present in Ruby standard lib for v3.3+ [678](https://github.com/bugsnag/maze-runner/pull/678)
 - Fix issues with loading maze-runner commands from file [679](https://github.com/bugsnag/maze-runner/pull/679)
+- Remove deprecated close_app usage [681](https://github.com/bugsnag/maze-runner/pull/681)
 
 # 9.14.0 - 2024-09-23
 

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -35,8 +35,12 @@ module Maze
           begin
             Maze.driver.terminate_app Maze.driver.app_id
           rescue Selenium::WebDriver::Error::UnknownError
-            $logger.warn 'terminate_app failed, using the slower but more forceful close_app instead'
-            Maze.driver.close_app
+            if Maze.config.appium_version && Maze.config.appium_version.to_f < 2.0
+              $logger.warn 'terminate_app failed, using the slower but more forceful close_app instead'
+              Maze.driver.close_app
+            else
+              $logger.warn 'terminate_app failed, future errors may occur if the application did not close remotely'
+            end
           end
           Maze::Server.reset!
           Maze.driver.activate_app Maze.driver.app_id


### PR DESCRIPTION
## Goal

close_app has been deprecated, so this avoids calling it when an appium version of >2 is expected on the server

## Tests

It's been run through the android tests here: https://buildkite.com/bugsnag/bugsnag-android/builds/11999
