### PR TITLE
Add outline of steps to get events from data-access-api

### DIFF
--- a/lib/features/steps/pipeline_event_steps.rb
+++ b/lib/features/steps/pipeline_event_steps.rb
@@ -1,0 +1,60 @@
+# @!group Pipeline_event steps
+
+# Checks to see if an event is available in the pipeline
+Then('the event is available via the data access api') do
+  # Get event_id from... somewhere
+  # Check if the event exists in the pipeline_events list already
+  return if Maze::Server.pipeline_events.any? { |event| event[:event_id].eql?(event_id) }
+
+  # if not, attempt to get the event via the data access api
+  event = get_event_from_api(event_id)
+
+  unless event
+    raise Test::Unit::AssertionFailedError.new <<-MESSAGE
+    Could not find event with id #{event_id} via the data access api
+    MESSAGE
+  end
+end
+
+Then('the event is not available via the data access api') do
+  if Maze::Server.pipeline_events.any? { |event| event[:event_id].eql?(event_id) }
+    raise Test::Unit::AssertionFailedError.new <<-MESSAGE
+    Event with id #{event_id} already exists in the events pulled via data access api
+    MESSAGE
+  end
+
+  # if not, attempt to get the event via the data access api
+  event = get_event_from_api(event_id)
+
+  if event
+    raise Test::Unit::AssertionFailedError.new <<-MESSAGE
+    Found event with id #{event_id} via the data access api
+    MESSAGE
+  end
+end
+
+def get_event_from_api(event_id)
+  wait = Maze::Wait.new(interval: 3, timeout: 15)
+  received_event = wait.until do
+    event = data_access_api.get_event(event_id)
+    # Probably needs some error handling somewhere
+    if event.has_key?('errors')
+      false
+    else
+      event
+    end
+  end
+  if received_event
+    Maze::Server.pipeline_events.add({
+      body: JSON.parse(received_event),
+      request: received_event,
+      event_id: event_id
+    })
+  end
+
+  received_event
+end
+
+def data_access_api
+  @data_access_api ||= Maze::Client::Bugsnag::DataAccessApi.new
+end

--- a/lib/features/support/cucumber_types.rb
+++ b/lib/features/support/cucumber_types.rb
@@ -1,6 +1,6 @@
 ParameterType(
   name:        'request_type',
-  regexp:      /errors?|sessions?|builds?|logs?|metrics?|sampling requests?|traces?|uploads?|sourcemaps?|reflects?|reflections?|invalid requests?/,
+  regexp:      /errors?|sessions?|builds?|logs?|metrics?|sampling requests?|traces?|uploads?|sourcemaps?|reflects?|reflections?|invalid requests?|pipeline events?/,
   type:        String,
   transformer: ->(s) { s }
 )

--- a/lib/maze/maze_output.rb
+++ b/lib/maze/maze_output.rb
@@ -13,7 +13,7 @@ module Maze
       path = output_folder
       FileUtils.makedirs(path)
 
-      request_types = %w[errors sessions builds uploads logs sourcemaps traces invalid reflections]
+      request_types = %w[errors sessions builds uploads logs sourcemaps traces invalid reflections pipeline_events]
       request_types << 'sampling requests'
 
       request_types.each do |request_type|

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -101,6 +101,8 @@ module Maze
           sourcemaps
         when 'reflect', 'reflects', 'reflection', 'reflections'
           reflections
+        when 'pipeline event', 'pipeline events, pipeline_events'
+          pipeline_events
         when 'invalid', 'invalid requests'
           invalid_requests
         else
@@ -184,6 +186,10 @@ module Maze
       # @return [RequestList] Commands to be performed
       def commands
         @commands ||= RequestList.new
+      end
+
+      def pipeline_events
+        @pipeline_events ||= RequestList.new
       end
 
       # Whether the server thread is running
@@ -289,6 +295,7 @@ module Maze
         logs.clear
         invalid_requests.clear
         reflections.clear
+        pipeline_events.clear
       end
     end
   end


### PR DESCRIPTION
## Goal
Adds a couple of steps to wrap getting the last sent event from the pipeline via data-access-api.

Note: NON-FUNCTIONAL, DO NOT MERGE until error ID acquisition is implemented
