### PR TITLE
Add extra guard when terminating appium session app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Removed deprecated safari 15 & 16 from BitBar configuration, added safari 17 & 18 [701](https://github.com/bugsnag/maze-runner/pull/701)
 
+## Fixes
+
+- Add extra guard for stopping running apps in case of remote server error [694](https://github.com/bugsnag/maze-runner/pull/694)
+
 # 9.18.1 - 2024/11/13
 
 ## Fixes

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -34,7 +34,7 @@ module Maze
           # commands from the previous scenario (in idempotent mode).
           begin
             Maze.driver.terminate_app Maze.driver.app_id
-          rescue Selenium::WebDriver::Error::UnknownError
+          rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::InvalidSessionIdError
             if Maze.config.appium_version && Maze.config.appium_version.to_f < 2.0
               $logger.warn 'terminate_app failed, using the slower but more forceful close_app instead'
               Maze.driver.close_app


### PR DESCRIPTION
## Goal

When calling terminate_app we sometimes get the sessionId error.  We can safely ignore it, and prevent it calling into our testing dashboard.

## Tests

Should be covered by existing tests
