### PR TITLE
Add support for Android 15 on BrowserStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.17.0 - 2024/11/05
+
+## Enhancements
+
+- Add Android 15 to the available BrowserStack devices [697](https://github.com/bugsnag/maze-runner/pull/697)
+
 # 9.16.0 - 2024-11-01
 
 ## Enhancements

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.16.0'
+  VERSION = '9.17.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/bs_devices.rb
+++ b/lib/maze/client/appium/bs_devices.rb
@@ -71,6 +71,7 @@ module Maze
           def create_hash
             hash = {
               # Classic, non-specific devices for each Android version
+              'ANDROID_15' => make_android_hash('Google Pixel 9', '15.0'),
               'ANDROID_14' => make_android_hash('Google Pixel 8', '14.0'),
               'ANDROID_13' => make_android_hash('Google Pixel 6 Pro', '13.0'),
               'ANDROID_12' => make_android_hash('Google Pixel 5', '12.0'),


### PR DESCRIPTION
## Goal

Add support for Android 15 on BrowserStack.

## Tests

Tested locally using bugsnag-android.