### PR TITLE
Do not set unrecognised capability with IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-# 9.17.0 - 2024/11/05
+# 9.17.0 - 2024/11/06
 
 ## Enhancements
 
 - Add Android 15 to the available BrowserStack devices [697](https://github.com/bugsnag/maze-runner/pull/697)
+
+## Fixes
+
+- Do not set `acceptInsecureCerts` capability with IE [698](https://github.com/bugsnag/maze-runner/pull/698)
 
 # 9.16.0 - 2024-11-01
 

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -12,7 +12,7 @@ module Maze
           capabilities.merge! browsers[config.browser]
           capabilities.merge! JSON.parse(config.capabilities_option)
           capabilities['bitbar:options']['testTimeout'] = 900
-          capabilities['acceptInsecureCerts'] = true
+          capabilities['acceptInsecureCerts'] = true unless Maze.config.browser.include? 'ie_'
           config.capabilities = capabilities
 
           if Maze::Client::BitBarClientUtils.use_local_tunnel?

--- a/test/fixtures/browser/features/steps/browser_steps.rb
+++ b/test/fixtures/browser/features/steps/browser_steps.rb
@@ -1,10 +1,11 @@
 require 'socket'
 
 def get_maze_runner_url
+  protocol = Maze.config.https ? 'https' : 'http'
   if Maze.config.aws_public_ip
-      "https://#{Maze.public_address}"
+      "#{protocol}://#{Maze.public_address}"
   else
-    "https://#{get_private_hostname}:#{Maze.config.port}"
+    "#{protocol}://#{get_private_hostname}:#{Maze.config.port}"
   end
 end
 


### PR DESCRIPTION
## Goal

Resolves a bug where we were setting a capability that's not recognised by the IE driver, causing tests to fail.

## Design

Used a fairly crude approach of a string comparison on the browser name provided.

## Tests

Tested locally against BitBar with `ie_11`.