### PR TITLE
Fix uri version to avoid command servlet errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.18.1 - 2024/11/13
+
+## Fixes
+
+- Pin "uri" dependency to avoid v1.0.0 release bug [700](https://github.com/bugsnag/maze-runner/pull/700)
+
 # 9.18.0 - 2024/11/07
 
 ## Enhancements

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'test-unit', '~> 3.5.2'
   spec.add_dependency 'rack', '~> 2.2'
   spec.add_dependency 'webrick', '~> 1.7.0'
+  spec.add_dependency 'uri', '~> 0.13.0'
 
   # Appium 12/Selenium 4 enforce the use of W3C
   if ENV['USE_LEGACY_DRIVER']

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.18.0'
+  VERSION = '9.18.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

We've experienced errors for fixtures attempting to access the command servlet, which appear to be linked to the v1.0.0 release of the ruby `uri` module.

This pins the version to `~> 0.13.0` to avoid the issue.

## Tests

A full test run [here](https://buildkite.com/bugsnag/maze-runner/builds/4278) confirmed the issue.
The test run of this PR proves the fix works.
