### PR TITLE
Remove safari 15 & 16, add 17 & 18

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -309,7 +309,7 @@ steps:
   # BitBar tests
   #
 
-  - label: ':bitbar: Safari 16'
+  - label: ':bitbar: Safari 18'
     depends_on: "push-branch-cli"
     timeout_in_minutes: 10
     plugins:
@@ -323,7 +323,7 @@ steps:
         verbose: true
         command:
           - "--farm=bb"
-          - "--browser=safari_16"
+          - "--browser=safari_18"
           - "--aws-public-ip"
           - "--fail-fast"
           - "--no-tunnel"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.19.0 - TBD
+
+## Enhancements
+
+- Removed deprecated safari 15 & 16 from BitBar configuration, added safari 17 & 18 [701](https://github.com/bugsnag/maze-runner/pull/701)
+
 # 9.18.1 - 2024/11/13
 
 ## Fixes

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.18.1'
+  VERSION = '9.19.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/selenium/bb_browsers.yml
+++ b/lib/maze/client/selenium/bb_browsers.yml
@@ -65,16 +65,16 @@ edge_latest:
   version: 'latest'
   resolution: '1920x1080'
 
-safari_16:
-  platform: 'macOS'
+safari_18:
+  platforms: 'macOS'
   osVersion: '13'
   browserName: 'safari'
-  version: '16'
+  version: '18'
   resolution: '2560x1920'
 
-safari_15:
+safari_17:
   platform: 'macOS'
   osVersion: '12'
   browserName: 'safari'
-  version: '15'
+  version: '17'
   resolution: '2560x1920'

--- a/lib/maze/client/selenium/bb_browsers.yml
+++ b/lib/maze/client/selenium/bb_browsers.yml
@@ -66,7 +66,7 @@ edge_latest:
   resolution: '1920x1080'
 
 safari_18:
-  platforms: 'macOS'
+  platform: 'macOS'
   osVersion: '13'
   browserName: 'safari'
   version: '18'


### PR DESCRIPTION
## Goal

Removes the deprecated safari 15 and 16 from our bitbar config, replacing them with 17 & 18

## Tests

I've updated our safari 16 test to safari 18 in repo.