### PR TITLE
Fix incorrect way to access error captor class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.19.1 - 2024/11/19
+
+## Fixes
+
+- Fix incorrect access of error captor class [703](https://github.com/bugsnag/maze-runner/pull/703)
+
 # 9.19.0 - 2024/11/18
 
 ## Enhancements

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.19.0'
+  VERSION = '9.19.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/bugsnag_config.rb
+++ b/lib/maze/bugsnag_config.rb
@@ -97,7 +97,7 @@ module Maze
       end
 
       def call(report)
-        Maze::ErrorCaptor.instance.add_captured_error(report.dup)
+        Maze::ErrorCaptor.add(report.dup)
 
         @middleware.call(report)
       end


### PR DESCRIPTION
## Goal

The singleton pattern is not longer being used, and it should be addressed as a static class.

## Tests

To be tested in the next run.