### PR TITLE
Add simple retry system for invalid aws public port response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.20.0 - TBD
+
+## Enhancements
+
+- Catch AWS IP invalid response error and attempt to retry [704](https://github.com/bugsnag/maze-runner/pull/704)
+
 # 9.19.1 - 2024/11/19
 
 ## Fixes

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -7,7 +7,7 @@ require_relative 'maze/timers'
 # Glues the various parts of MazeRunner together that need to be accessed globally,
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
-  VERSION = '9.19.1'
+  VERSION = '9.20.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/aws_public_ip.rb
+++ b/lib/maze/aws_public_ip.rb
@@ -43,6 +43,8 @@ module Maze
       port = 0
       count = 0
       max_attempts = 30
+      invalid_response_retries = 0
+      max_invalid_retries = 2
 
       # Give up after 30 seconds
       while port == 0 && count < max_attempts do
@@ -54,6 +56,17 @@ module Maze
             json_string = result[0][0].strip
             json_result = JSON.parse(json_string)
             port = json_result['NetworkSettings']['Ports']["#{local_port}/tcp"][0]['HostPort']
+          rescue NoMethodError => error
+            if invalid_response_retries >= max_invalid_retries
+              Bugsnag.notify error
+              $logger.error "Public port response was invalid or incomplete: #{json_string}"
+              $logger.error "This has occurred more than once, exiting port process"
+              return 0
+            else
+              invalid_response_retries += 1
+              $logger.warn "Public port response was invalid or incomplete: #{json_string}"
+              $logger.warn "Attempting to determine public port again"
+            end
           rescue StandardError => error
             Bugsnag.notify error
             $logger.error "Unable to parse public port from: #{json_string}"

--- a/lib/maze/aws_public_ip.rb
+++ b/lib/maze/aws_public_ip.rb
@@ -60,12 +60,12 @@ module Maze
             if invalid_response_retries >= max_invalid_retries
               Bugsnag.notify error
               $logger.error "Public port response was invalid or incomplete: #{json_string}"
-              $logger.error "This has occurred more than once, exiting port process"
+              $logger.error "This has occurred more than maximum allowed #{max_invalid_retries}, exiting port process"
               return 0
             else
               invalid_response_retries += 1
               $logger.warn "Public port response was invalid or incomplete: #{json_string}"
-              $logger.warn "Attempting to determine public port again"
+              $logger.warn "Attempting to acquire public port again, retry attempt: #{invalid_response_retries}"
             end
           rescue StandardError => error
             Bugsnag.notify error


### PR DESCRIPTION
## Goal

It seems like the curl command to get the public port sometimes returns successfully, but with an invalid response.

This change captures the subsequent error, allowing us to retry the command a number of times (currently 2, for 3 runs total).  After that it can be assumed we aren't going to receive a usable response and we should exit the test run.

## Tests

Difficult to test currently, but non-invasive and we should be able to see any generated errors in the dashboard.
