### PR TITLE
Skip remaining scenarios if the Appium session fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.22.0 - 2024/12/13
+
+## Enhancements
+
+- Skip remaining tests after Appium session failure [7xx](https://github.com/bugsnag/maze-runner/pull/7xx)
+
 # 9.21.0 - 2024/11/28
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 9.22.0 - 2024/12/13
+# 9.22.0 - 2024/12/xx
 
 ## Enhancements
 
-- Skip remaining tests after Appium session failure [7xx](https://github.com/bugsnag/maze-runner/pull/7xx)
+- Skip remaining tests after Appium session failure [708](https://github.com/bugsnag/maze-runner/pull/708)
 
 # 9.21.0 - 2024/11/28
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -104,7 +104,7 @@ Before do |scenario|
   Maze.scenario = Maze::Api::Cucumber::Scenario.new(scenario)
 
   # Skip scenario if the driver it needs has failed
-  if Maze.driver.failed? && (Maze.mode == :appium || Maze.mode == :browser)
+  if (Maze.mode == :appium || Maze.mode == :browser) && Maze.driver.failed?
     skip_this_scenario
   end
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -103,7 +103,12 @@ end
 Before do |scenario|
   Maze.scenario = Maze::Api::Cucumber::Scenario.new(scenario)
 
-  # Default to no dynamic try
+  # Skip scenario if the driver it needs has failed
+  if Maze.driver.failed? && (Maze.mode == :appium || Maze.mode == :browser)
+    skip_this_scenario
+  end
+
+  # Default to no dynamic retry
   Maze.dynamic_retry = false
 
   if ENV['BUILDKITE']

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -11,20 +11,11 @@ module Maze
   VERSION = '9.22.0'
 
   class << self
-    attr_accessor :check, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,
+    attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,
                   :public_document_server_address, :run_uuid, :scenario
 
     def config
       @config ||= Maze::Configuration.new
-    end
-
-    def driver
-      raise 'Cannot use a failed driver' if @driver&.failed?
-      @driver
-    end
-
-    def driver=(driver)
-      @driver = driver
     end
 
     def hooks

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.21.0'
+  VERSION = '9.22.0'
 
   class << self
     attr_accessor :check, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -11,11 +11,20 @@ module Maze
   VERSION = '9.21.0'
 
   class << self
-    attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,
+    attr_accessor :check, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,
                   :public_document_server_address, :run_uuid, :scenario
 
     def config
       @config ||= Maze::Configuration.new
+    end
+
+    def driver
+      raise 'Cannot use a failed driver' if @driver&.failed?
+      @driver
+    end
+
+    def driver=(driver)
+      @driver = driver
     end
 
     def hooks

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -134,7 +134,7 @@ module Maze
         end
 
         def stop_session
-          Maze.driver&.driver_quit
+          Maze.driver.driver_quit unless Maze.driver.failed?
           Maze::AppiumServer.stop if Maze::AppiumServer.running
         end
       end

--- a/lib/maze/client/selenium/base_client.rb
+++ b/lib/maze/client/selenium/base_client.rb
@@ -11,7 +11,7 @@ module Maze
         end
 
         def stop_session
-          Maze.driver&.driver_quit
+          Maze.driver.driver_quit unless Maze.driver.failed?
         end
       end
     end

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -20,7 +20,7 @@ module Maze
       attr_reader :device_type
 
       # @!attribute [r] capabilities
-      #   @return [Hash] The capabilities used to launch the BrowserStack instance
+      #   @return [Hash] The capabilities used to launch the Appium session
       attr_reader :capabilities
 
       # Creates the Appium driver

--- a/lib/maze/driver/appium.rb
+++ b/lib/maze/driver/appium.rb
@@ -32,6 +32,7 @@ module Maze
         # Sets up identifiers for ease of connecting jobs
         capabilities ||= {}
 
+        @failed = false
         @element_locator = locator
         @capabilities = capabilities
 
@@ -64,6 +65,17 @@ module Maze
         end
       end
 
+      # Whether the driver has known to have failed (it may still have failed and us not know yet)
+      def failed?
+        @failed
+      end
+
+      # Marks the driver as failed
+      def fail_driver
+        $logger.error 'Appium driver failed, remaining scenarios will be skipped'
+        @failed = true
+      end
+
       # Checks for an element, waiting until it is present or the method times out
       #
       # @param element_id [String] the element to search for
@@ -83,7 +95,7 @@ module Maze
         end
       rescue Selenium::WebDriver::Error::ServerError => e
         # Assume the remote appium session has stopped, so crash out of the session
-        Maze.driver = nil
+        fail_driver
         raise e
       else
         true
@@ -94,7 +106,7 @@ module Maze
         super
       rescue Selenium::WebDriver::Error::ServerError => e
         # Assume the remote appium session has stopped, so crash out of the session
-        Maze.driver = nil
+        fail_driver
         raise e
       end
 
@@ -103,7 +115,7 @@ module Maze
         super
       rescue Selenium::WebDriver::Error::ServerError => e
         # Assume the remote appium session has stopped, so crash out of the session
-        Maze.driver = nil
+        fail_driver
         raise e
       end
 
@@ -114,7 +126,7 @@ module Maze
         end
       rescue Selenium::WebDriver::Error::ServerError => e
         # Assume the remote appium session has stopped, so crash out of the session
-        Maze.driver = nil
+        fail_driver
         raise e
       end
 
@@ -128,7 +140,7 @@ module Maze
         end
       rescue Selenium::WebDriver::Error::ServerError => e
         # Assume the remote appium session has stopped, so crash out of the session
-        Maze.driver = nil
+        fail_driver
         raise e
       end
 
@@ -146,7 +158,7 @@ module Maze
         false
       rescue Selenium::WebDriver::Error::ServerError => e
         # Assume the remote appium session has stopped, so crash out of the session
-        Maze.driver = nil
+        fail_driver
         raise e
       end
 
@@ -160,7 +172,7 @@ module Maze
         end
       rescue Selenium::WebDriver::Error::ServerError => e
         # Assume the remote appium session has stopped, so crash out of the session
-        Maze.driver = nil
+        fail_driver
         raise e
       end
 
@@ -185,7 +197,7 @@ module Maze
         end
       rescue Selenium::WebDriver::Error::ServerError => e
         # Assume the remote appium session has stopped, so crash out of the session
-        Maze.driver = nil
+        fail_driver
         raise e
       end
 
@@ -222,7 +234,7 @@ module Maze
         end
       rescue Selenium::WebDriver::Error::ServerError => e
         # Assume the remote appium session has stopped, so crash out of the session
-        Maze.driver = nil
+        fail_driver
         raise e
       end
 

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -13,9 +13,21 @@ module Maze
 
       def initialize(driver_for, selenium_url=nil, capabilities=nil)
         capabilities ||= {}
+        @failed = false
         @capabilities = capabilities
         @driver_for = driver_for
         @selenium_url = selenium_url
+      end
+
+      # Whether the driver has known to have failed (it may still have failed and us not know yet)
+      def failed?
+        @failed
+      end
+
+      # Marks the driver as failed
+      def fail_driver
+        $logger.error 'Selenium driver failed, remaining scenarios will be skipped'
+        @failed = true
       end
 
       def find_element(*args)
@@ -128,6 +140,7 @@ module Maze
           end
           $logger.info "Selenium driver started in #{(Time.now - time).to_i}s"
           @driver = driver
+          @failed = false
         rescue => error
           Bugsnag.notify error
           $logger.warn "Selenium driver failed to start in #{(Time.now - time).to_i}s"

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -42,11 +42,11 @@ module Maze
           # Reset the server to ensure that test fixtures cannot fetch
           # commands from the previous scenario (in idempotent mode).
           begin
-            Maze.driver.terminate_app Maze.driver&.app_id
+            Maze.driver.terminate_app Maze.driver.app_id
           rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::InvalidSessionIdError
             if Maze.config.appium_version && Maze.config.appium_version.to_f < 2.0
               $logger.warn 'terminate_app failed, using the slower but more forceful close_app instead'
-              Maze.driver&.close_app
+              Maze.driver.close_app
             else
               $logger.warn 'terminate_app failed, future errors may occur if the application did not close remotely'
             end

--- a/test/client/appium/bb_client_test.rb
+++ b/test/client/appium/bb_client_test.rb
@@ -74,7 +74,6 @@ module Maze
 
           # Logging
           @mock_driver.expects(:start_driver).returns true
-          @mock_driver.expects(:failed?).twice.returns false
           $logger.expects(:info).with('Created Appium session: session_id')
 
           # Successful starting of the driver
@@ -95,7 +94,6 @@ module Maze
           #
           message = 'no sessionId in returned payload'
           @mock_driver.expects(:start_driver).twice.raises(message).then.returns(true)
-          @mock_driver.expects(:failed?).twice.returns false
           $logger.expects(:error).with("Session creation failed: #{message}")
           interval = 60
           $logger.expects(:warn).with("Failed to create Appium driver, retrying in #{interval} seconds")

--- a/test/client/appium/bb_client_test.rb
+++ b/test/client/appium/bb_client_test.rb
@@ -74,6 +74,7 @@ module Maze
 
           # Logging
           @mock_driver.expects(:start_driver).returns true
+          @mock_driver.expects(:failed?).twice.returns false
           $logger.expects(:info).with('Created Appium session: session_id')
 
           # Successful starting of the driver
@@ -94,6 +95,7 @@ module Maze
           #
           message = 'no sessionId in returned payload'
           @mock_driver.expects(:start_driver).twice.raises(message).then.returns(true)
+          @mock_driver.expects(:failed?).twice.returns false
           $logger.expects(:error).with("Session creation failed: #{message}")
           interval = 60
           $logger.expects(:warn).with("Failed to create Appium driver, retrying in #{interval} seconds")


### PR DESCRIPTION
## Goal

Skip remaining scenarios if the Appium session fails.

## Design

Previously we were nilling out `Maze.driver` when it failed and guarding any uses of it with the `&.`.  That was generally ok, but the problem with `&.` is that operations essentially fail silently.  This change introduces an explicit failed state, which we can build more rigour on top of.

## Changeset

<!-- What changed? -->

## Tests

This change can be seen in action on this trial build:
https://buildkite.com/bugsnag/bugsnag-unity/builds/5355#0193cf49-9bcd-4d1a-adad-2d719f96ea89

Although there are many errors in amongst the skipped scenarios, they are due to the failed driver still attempting to be used.  I've raised PLAT-13337 to introduce a formal API for accessing driver methods instead of calling it directly.
