### PR TITLE
Add failed driver guard to FileManager Appium API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Enhancements
+
+- Failed driver guards added to File Manager API [709](https://github.com/bugsnag/maze-runner/pull/709)
+
 # 9.22.0 - 2025/01/08
 
 ## Enhancements

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -11,6 +11,7 @@ require_relative '../lib/utils/deep_merge'
 require_relative '../lib/maze'
 
 require_relative '../lib/maze/appium_server'
+require_relative '../lib/maze/api/appium/manager'
 require_relative '../lib/maze/api/appium/file_manager'
 require_relative '../lib/maze/api/cucumber/scenario'
 require_relative '../lib/maze/api/exit_code'

--- a/lib/maze/api/appium/file_manager.rb
+++ b/lib/maze/api/appium/file_manager.rb
@@ -31,6 +31,10 @@ module Maze
         rescue Selenium::WebDriver::Error::UnknownError => e
           $logger.error "Error writing file to device: #{e.message}"
           false
+        rescue Selenium::WebDriver::Error::ServerError => e
+          # Assume the remote appium session has stopped, so crash out of the session
+          fail_driver
+          raise e
         end
 
         # Attempts to retrieve a given file from the device (using Appium).  The default location for the file will be
@@ -62,6 +66,10 @@ module Maze
         rescue Selenium::WebDriver::Error::UnknownError => e
           $logger.error "Error reading file from device: #{e.message}"
           false
+        rescue Selenium::WebDriver::Error::ServerError => e
+          # Assume the remote appium session has stopped, so crash out of the session
+          fail_driver
+          raise e
         end
       end
     end

--- a/lib/maze/api/appium/file_manager.rb
+++ b/lib/maze/api/appium/file_manager.rb
@@ -11,10 +11,11 @@ module Maze
         # Maze.config.android_app_files_directory has been set.
         # @param contents [String] Content of the file to be written
         # @param filename [String] Name (with no path) of the file to be written on the device
+        # @return [Boolean] Whether the file was successfully written to the device
         def write_app_file(contents, filename)
           if failed_driver?
             $logger.error 'Cannot write file to device - Appium driver failed.'
-            return
+            return false
           end
 
           path = case Maze::Helper.get_current_platform
@@ -23,6 +24,8 @@ module Maze
                  when 'android'
                    directory = Maze.config.android_app_files_directory || "/sdcard/Android/data/#{@driver.app_id}/files"
                    "#{directory}/#{filename}"
+                 else
+                   raise 'write_app_file is not supported on this platform'
                  end
 
           $logger.trace "Pushing file to '#{path}' with contents: #{contents}"
@@ -42,10 +45,11 @@ module Maze
         # Maze.config.android_app_files_directory has been set.
         # @param filename [String] Name (with no path) of the file to be retrieved from the device
         # @param directory [String] Directory on the device where the file is located (optional)
+        # @return [String, nil] The content of the file read, or nil
         def read_app_file(filename, directory = nil)
           if failed_driver?
             $logger.error 'Cannot read file from device - Appium driver failed.'
-            return
+            return nil
           end
 
           if directory
@@ -57,15 +61,16 @@ module Maze
                   when 'android'
                     dir = Maze.config.android_app_files_directory || "/sdcard/Android/data/#{@driver.app_id}/files"
                     "#{dir}/#{filename}"
+                  else
+                    raise 'read_app_file is not supported on this platform'
                   end
           end
 
           $logger.trace "Attempting to read file from '#{path}'"
           @driver.pull_file(path)
-          true
         rescue Selenium::WebDriver::Error::UnknownError => e
           $logger.error "Error reading file from device: #{e.message}"
-          false
+          nil
         rescue Selenium::WebDriver::Error::ServerError => e
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver

--- a/lib/maze/api/appium/file_manager.rb
+++ b/lib/maze/api/appium/file_manager.rb
@@ -27,6 +27,10 @@ module Maze
 
           $logger.trace "Pushing file to '#{path}' with contents: #{contents}"
           @driver.push_file(path, contents)
+          true
+        rescue Selenium::WebDriver::Error::UnknownError => e
+          $logger.error "Error writing file to device: #{e.message}"
+          false
         end
 
         # Attempts to retrieve a given file from the device (using Appium).  The default location for the file will be
@@ -54,6 +58,10 @@ module Maze
 
           $logger.trace "Attempting to read file from '#{path}'"
           @driver.pull_file(path)
+          true
+        rescue Selenium::WebDriver::Error::UnknownError => e
+          $logger.error "Error reading file from device: #{e.message}"
+          false
         end
       end
     end

--- a/lib/maze/api/appium/file_manager.rb
+++ b/lib/maze/api/appium/file_manager.rb
@@ -2,18 +2,18 @@ module Maze
   module Api
     module Appium
       # Provides operations for working with files during Appium runs.
-      class FileManager
-        # param driver
-        def initialize
-          @driver = Maze.driver
-        end
-
+      class FileManager < Maze::Api::Appium::Manager
         # Creates a file with the given contents on the device (using Appium).  The file will be located in the app's
         # documents directory for iOS. On Android, it will be /sdcard/Android/data/<app-id>/files unless
         # Maze.config.android_app_files_directory has been set.
         # @param contents [String] Content of the file to be written
         # @param filename [String] Name (with no path) of the file to be written on the device
         def write_app_file(contents, filename)
+          if failed_driver?
+            $logger.error 'Cannot write file to device - Appium driver failed.'
+            return
+          end
+
           path = case Maze::Helper.get_current_platform
                  when 'ios'
                    "@#{@driver.app_id}/Documents/#{filename}"
@@ -32,6 +32,11 @@ module Maze
         # @param filename [String] Name (with no path) of the file to be retrieved from the device
         # @param directory [String] Directory on the device where the file is located (optional)
         def read_app_file(filename, directory = nil)
+          if failed_driver?
+            $logger.error 'Cannot read file from device - Appium driver failed.'
+            return
+          end
+
           if directory
             path = directory
           else

--- a/lib/maze/api/appium/file_manager.rb
+++ b/lib/maze/api/appium/file_manager.rb
@@ -1,3 +1,6 @@
+require_relative '../../helper'
+require_relative './manager'
+
 module Maze
   module Api
     module Appium
@@ -38,7 +41,7 @@ module Maze
           end
 
           if directory
-            path = directory
+            path = "#{directory}/#{filename}"
           else
             path = case Maze::Helper.get_current_platform
                   when 'ios'
@@ -50,7 +53,7 @@ module Maze
           end
 
           $logger.trace "Attempting to read file from '#{path}'"
-          file = @driver.pull_file(path)
+          @driver.pull_file(path)
         end
       end
     end

--- a/lib/maze/api/appium/manager.rb
+++ b/lib/maze/api/appium/manager.rb
@@ -10,6 +10,10 @@ module Maze
         def failed_driver?
           @driver.failed?
         end
+
+        def fail_driver
+          @driver.fail_driver
+        end
       end
     end
   end

--- a/lib/maze/api/appium/manager.rb
+++ b/lib/maze/api/appium/manager.rb
@@ -1,0 +1,16 @@
+module Maze
+  module Api
+    module Appium
+      # Base class for all Appium managers.
+      class Manager
+        def initialize
+          @driver = Maze.driver
+        end
+
+        def failed_driver?
+          @driver.failed?
+        end
+      end
+    end
+  end
+end

--- a/test/api/appium/file_manager_test.rb
+++ b/test/api/appium/file_manager_test.rb
@@ -1,0 +1,78 @@
+require 'selenium-webdriver'
+
+require_relative '../../test_helper'
+require_relative '../../../lib/maze'
+require_relative '../../../lib/maze/api/appium/file_manager'
+
+module Maze
+  module Api
+    module Appium
+      class FileManagerTest < Test::Unit::TestCase
+
+        def setup()
+          $logger = mock('logger')
+          @mock_driver = mock('driver')
+          Maze.driver = @mock_driver
+          @manager = Maze::Api::Appium::FileManager.new
+        end
+
+        def test_write_app_file_failed_driver
+          @mock_driver.expects(:failed?).returns(true)
+          $logger.expects(:error).with("Cannot write file to device - Appium driver failed.")
+
+          @manager.write_app_file('contents', 'filename.json')
+        end
+
+        def test_write_app_file_success
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:app_id).returns('app1')
+          Maze::Helper.expects(:get_current_platform).returns('ios')
+          $logger.expects(:trace).with("Pushing file to '@app1/Documents/filename.json' with contents: contents")
+          @mock_driver.expects(:push_file).with('@app1/Documents/filename.json', 'contents')
+
+          assert_true(@manager.write_app_file('contents', 'filename.json'))
+        end
+
+        def test_write_app_file_failure
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:app_id).returns('app1')
+          Maze::Helper.expects(:get_current_platform).returns('ios')
+          $logger.expects(:trace).with("Pushing file to '@app1/Documents/filename.json' with contents: contents")
+          @mock_driver.expects(:push_file).with('@app1/Documents/filename.json', 'contents').raises(Selenium::WebDriver::Error::UnknownError, 'error')
+          $logger.expects(:error).with("Error writing file to device: error")
+
+          assert_false(@manager.write_app_file('contents', 'filename.json'))
+        end
+
+        def test_read_app_file_failed_driver
+          @mock_driver.expects(:failed?).returns(true)
+          $logger.expects(:error).with("Cannot read file from device - Appium driver failed.")
+
+          @manager.read_app_file('filename.json')
+        end
+
+        def test_read_app_file_success
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:app_id).returns('app1')
+          Maze::Helper.expects(:get_current_platform).returns('ios')
+          $logger.expects(:trace).with("Attempting to read file from '@app1/Documents/filename.json'")
+          @mock_driver.expects(:pull_file).with('@app1/Documents/filename.json')
+
+          assert_true(@manager.read_app_file('filename.json'))
+        end
+
+        def test_read_app_file_failure
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:app_id).returns('app1')
+          Maze::Helper.expects(:get_current_platform).returns('ios')
+          $logger.expects(:trace).with("Attempting to read file from '@app1/Documents/filename.json'")
+          @mock_driver.expects(:pull_file).with('@app1/Documents/filename.json').raises(Selenium::WebDriver::Error::UnknownError, 'error')
+
+          $logger.expects(:error).with("Error reading file from device: error")
+
+          assert_false(@manager.read_app_file('filename.json'))
+        end
+      end
+    end
+  end
+end

--- a/test/api/appium/file_manager_test.rb
+++ b/test/api/appium/file_manager_test.rb
@@ -56,9 +56,9 @@ module Maze
           @mock_driver.expects(:app_id).returns('app1')
           Maze::Helper.expects(:get_current_platform).returns('ios')
           $logger.expects(:trace).with("Attempting to read file from '@app1/Documents/filename.json'")
-          @mock_driver.expects(:pull_file).with('@app1/Documents/filename.json')
+          @mock_driver.expects(:pull_file).with('@app1/Documents/filename.json').returns('contents')
 
-          assert_true(@manager.read_app_file('filename.json'))
+          assert_equal('contents', @manager.read_app_file('filename.json'))
         end
 
         def test_read_app_file_failure
@@ -70,7 +70,7 @@ module Maze
 
           $logger.expects(:error).with("Error reading file from device: error")
 
-          assert_false(@manager.read_app_file('filename.json'))
+          assert_nil(@manager.read_app_file('filename.json'))
         end
       end
     end


### PR DESCRIPTION
## Goal

Add failed driver guard to FileManager Appium API.

## Design

First of a number of PRs to shift logic away from `Maze::Appium::Driver` and protect clients from noise caused by a failed underlying Appium driver.

## Tests

Unit test added and some local testing performed, but further testing will be performed on the integration branch prior to release.