### PR TITLE
Add wait for element and click element patches from js-perf into browser driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Skip remaining tests after Appium session failure [708](https://github.com/bugsnag/maze-runner/pull/708)
+- Add wait_for_element and click_element methods to browser driver [710](https://github.com/bugsnag/maze-runner/pull/710)
 
 # 9.21.0 - 2024/11/28
 

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -34,6 +34,20 @@ module Maze
         @driver.find_element(*args)
       end
 
+      def wait_for_element(id)
+        @driver.find_element(id: id)
+      end
+
+      def click_element(id)
+        element = @driver.find_element(id: id)
+
+        if $browser.mobile?
+          element.click
+        else
+          @driver.action.move_to(element).click.perform
+        end
+      end
+
       def navigate
         @driver.navigate
       end


### PR DESCRIPTION
## Goal

This will include them being removed from the js-perf repo.  There was an additional change added to the trace servlet which has already been implemented in maze-runner, so that isn't being removed in this PR.
