### PR TITLE
Allow multiple browsers to be specified

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -283,6 +283,7 @@ steps:
         command:
           - "--farm=bs"
           - "--browser=firefox_latest"
+          - "--browser=chrome_latest"
           - "--fail-fast"
     concurrency: 2
     concurrency_group: 'browserstack'
@@ -324,6 +325,7 @@ steps:
         command:
           - "--farm=bb"
           - "--browser=safari_18"
+          - "--browser=chrome_latest"
           - "--aws-public-ip"
           - "--fail-fast"
           - "--no-tunnel"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.23.0 - 2025/01/XX
+
+## Enhancements
+
+- Allow multiple browser options to be presented to BitBar and BrowserStack test runs [712](https://github.com/bugsnag/maze-runner/pull/712)
+
 # 9.22.0 - 2025/01/08
 
 ## Enhancements

--- a/dockerfiles/Dockerfile.ci-ruby-3
+++ b/dockerfiles/Dockerfile.ci-ruby-3
@@ -1,5 +1,5 @@
 # Ruby image are based on Debian
-FROM ruby:3.3.3-bullseye as ci-ruby-3
+FROM ruby:3.3-bullseye as ci-ruby-3
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     apt-get install -y apt-utils wget unzip bash bundler \

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.22.0'
+  VERSION = '9.23.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/selenium/base_client.rb
+++ b/lib/maze/client/selenium/base_client.rb
@@ -19,6 +19,7 @@ module Maze
               Maze.driver = Maze::Driver::Browser.new(:remote, selenium_url, config.capabilities)
               Maze.driver.start_driver
             rescue => error
+              Maze.driver = nil
               $logger.error "Session creation failed: #{error}"
               start_error = error
             end

--- a/lib/maze/client/selenium/base_client.rb
+++ b/lib/maze/client/selenium/base_client.rb
@@ -6,6 +6,61 @@ module Maze
           raise 'Method not implemented by this class'
         end
 
+        def start_driver(config, selenium_url, max_attempts = 5)
+          attempts = 0
+
+          while attempts < max_attempts && Maze.driver.nil?
+            attempts += 1
+            start_error = nil
+
+            $logger.trace "Attempting to start Selenium driver with capabilities: #{config.capabilities.to_json}"
+            $logger.trace "Attempt #{attempts}"
+            begin
+              Maze.driver = Maze::Driver::Browser.new(:remote, selenium_url, config.capabilities)
+              Maze.driver.start_driver
+            rescue => error
+              $logger.error "Session creation failed: #{error}"
+              start_error = error
+            end
+
+            unless Maze.driver
+              interval = handle_start_error(config, start_error)
+              if interval.nil? || attempts >= max_attempts
+                $logger.error 'Failed to create Selenium driver, exiting'
+                Kernel.exit(::Maze::Api::ExitCode::SESSION_CREATION_FAILURE)
+              else
+                $logger.warn "Failed to create Selenium driver, retrying in #{interval} seconds"
+                $logger.info "Error: #{start_error.message}" if start_error
+                Kernel.sleep(interval)
+              end
+            end
+          end
+        end
+
+        def handle_start_error(config, error)
+          notify = true
+          interval = nil
+
+          # Used if we have a want to determine fatal errors later
+          case error.class.to_s
+          when 'Selenium::WebDriver::Error::WebDriverError'
+            interval = 5
+            notify = false
+          else
+            interval = 10
+          end
+
+          Bugsnag.notify error if notify
+
+          unless config.browser_list.empty?
+            # If the list is empty we have only one browser to continue with
+            config.browser = config.browser_list.shift
+            config.capabilities = create_capabilities(config)
+          end
+
+          interval
+        end
+
         def log_run_outro
           raise 'Method not implemented by this class'
         end

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -5,7 +5,6 @@ module Maze
         def start_session
           config = Maze.config
           if Maze::Client::BitBarClientUtils.use_local_tunnel?
-            capabilities['bitbar_apiKey'] = config.access_key
             Maze::Client::BitBarClientUtils.start_local_tunnel config.sb_local,
                                                                config.username,
                                                                config.access_key
@@ -27,6 +26,7 @@ module Maze
           capabilities.merge! JSON.parse(config.capabilities_option)
           capabilities['bitbar:options']['testTimeout'] = 900
           capabilities['acceptInsecureCerts'] = true unless Maze.config.browser.include? 'ie_'
+          capabilities['bitbar_apiKey'] = config.access_key if Maze::Client::BitBarClientUtils.use_local_tunnel?
           config.capabilities = capabilities
         end
 

--- a/lib/maze/client/selenium/bs_client.rb
+++ b/lib/maze/client/selenium/bs_client.rb
@@ -5,55 +5,63 @@ module Maze
     module Selenium
       class BrowserStackClient < BaseClient
         def start_session
-          # Set up the capabilities
-          browsers = YAML.safe_load(File.read("#{__dir__}/bs_browsers.yml"))
-
           config = Maze.config
-          browser = browsers[config.browser]
-
-          if config.legacy_driver?
-            capabilities = ::Selenium::WebDriver::Remote::Capabilities.new
-            capabilities['browserstack.local'] = 'true'
-            capabilities['browserstack.localIdentifier'] = Maze.run_uuid
-            capabilities['browserstack.console'] = 'errors'
-            capabilities['acceptInsecureCerts'] = 'true'
-
-            # Convert W3S capabilities to JSON-WP
-            capabilities['browser'] = browser['browserName']
-            capabilities['browser_version'] = browser['browserVersion']
-            capabilities['device'] = browser['device']
-            capabilities['os'] = browser['os']
-            capabilities['os_version'] = browser['osVersion']
-
-            capabilities.merge! JSON.parse(config.capabilities_option)
-            capabilities.merge! project_name_capabilities
-            config.capabilities = capabilities
-          else
-            capabilities = {
-              'acceptInsecureCerts' => true,
-              'bstack:options' => {
-                'local' => 'true',
-                'localIdentifier' => Maze.run_uuid
-              }
-            }
-            capabilities.deep_merge! browser
-            capabilities.deep_merge! JSON.parse(config.capabilities_option)
-            capabilities.merge! project_name_capabilities
-            config.capabilities = ::Selenium::WebDriver::Remote::Capabilities.new capabilities
-          end
 
           # Start the tunnel
           Maze::Client::BrowserStackClientUtils.start_local_tunnel config.bs_local,
                                                                    Maze.run_uuid,
                                                                    config.access_key
 
+          create_capabilities(config)
+
           # Start the driver
           selenium_url = "https://#{config.username}:#{config.access_key}@hub.browserstack.com/wd/hub"
-          Maze.driver = Maze::Driver::Browser.new :remote, selenium_url, config.capabilities
-          Maze.driver.start_driver
+          start_driver(config, selenium_url)
 
           # Log details for the session
           log_session_info
+        end
+
+        def create_capabilities(config)
+          if config.legacy_driver?
+            capabilities = ::Selenium::WebDriver::Remote::Capabilities.new
+            capabilities['browserstack.local'] = 'true'
+            capabilities['browserstack.localIdentifier'] = Maze.run_uuid
+            capabilities['browserstack.console'] = 'errors'
+            capabilities['acceptInsecureCerts'] = 'true'
+            capabilities.merge! JSON.parse(config.capabilities_option)
+            capabilities.merge! project_name_capabilities
+            add_browser_capabilities(config, capabilities)
+          else
+            raw_capabilities = {
+              'acceptInsecureCerts' => true,
+              'bstack:options' => {
+                'local' => 'true',
+                'localIdentifier' => Maze.run_uuid
+              }
+            }
+            raw_capabilities.deep_merge! JSON.parse(config.capabilities_option)
+            raw_capabilities.merge! project_name_capabilities
+            add_browser_capabilities(config, raw_capabilities)
+            capabilities = ::Selenium::WebDriver::Remote::Capabilities.new raw_capabilities
+          end
+          config.capabilities = capabilities
+        end
+
+        def add_browser_capabilities(config, capabilities)
+          browsers = YAML.safe_load(File.read("#{__dir__}/bs_browsers.yml"))
+          browser = browsers[config.browser]
+
+          if config.legacy_driver?
+            # Convert W3S capabilities to JSON-WP
+            capabilities['browser'] = browser['browserName']
+            capabilities['browser_version'] = browser['browserVersion']
+            capabilities['device'] = browser['device']
+            capabilities['os'] = browser['os']
+            capabilities['os_version'] = browser['osVersion']
+          else
+            capabilities.deep_merge! browser
+          end
         end
 
         def stop_session

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -173,6 +173,9 @@ module Maze
     # Test browser type
     attr_accessor :browser
 
+    # A list of browsers to attempt to connect to, in order
+    attr_accessor :browser_list
+
     # Test browser version
     attr_accessor :browser_version
 

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -124,9 +124,10 @@ module Maze
                 type: :string,
                 multi: true
             opt Option::BROWSER,
-                'Browser to use (an entry in <farm>_browsers.yml)',
+                'Browser to use (an entry in <farm>_browsers.yml). Can be listed multiple times to have a prioritised list of browsers',
                 short: :none,
-                type: :string
+                type: :string,
+                multi: true
             opt Option::BROWSER_VERSION,
                 'Browser version to use (applies to entries in <farm>_browsers.yml that do not include a version)',
                 short: :none,

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -57,7 +57,7 @@ module Maze
           case config.farm
           when :bs
             device_option = options[Maze::Option::DEVICE]
-            browser_option = options[Maze::Options::BROWSER]
+            browser_option = options[Maze::Option::BROWSER]
             if !device_option.empty?
               config.device = device_option.first
               config.device_list = device_option.drop(1)

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -57,21 +57,18 @@ module Maze
           case config.farm
           when :bs
             device_option = options[Maze::Option::DEVICE]
-            if device_option.nil? || device_option.empty?
-              config.browser = options[Maze::Option::BROWSER]
-            else
-              if device_option.is_a?(Array)
-                config.device = device_option.first
-                config.device_list = device_option.drop(1)
-              else
-                config.device = device_option
-                config.device_list = []
-              end
+            browser_option = options[Maze::Options::BROWSER]
+            if !device_option.empty?
+              config.device = device_option.first
+              config.device_list = device_option.drop(1)
               if config.legacy_driver?
                 config.os_version = Maze::Client::Appium::BrowserStackDevices::DEVICE_HASH[config.device]['os_version'].to_f
               else
                 config.os_version = Maze::Client::Appium::BrowserStackDevices::DEVICE_HASH[config.device]['platformVersion'].to_f
               end
+            elsif !browser_option.empty?
+              config.browser = browser_option.first
+              config.browser_list = browser_option.drop(1)
             end
             config.bs_local = Maze::Helper.expand_path(options[Maze::Option::BS_LOCAL])
             config.appium_version = options[Maze::Option::APPIUM_VERSION]
@@ -83,18 +80,20 @@ module Maze
             config.access_key = options[Maze::Option::ACCESS_KEY]
             config.appium_version = options[Maze::Option::APPIUM_VERSION]
             device_option = options[Maze::Option::DEVICE]
-            if device_option.nil? || device_option.empty?
-              # BitBar Web
-              config.browser = options[Maze::Option::BROWSER]
-              config.browser_version = options[Maze::Option::BROWSER_VERSION]
-            else
-              # BitBar Devices
-              if device_option.is_a?(Array)
-                config.device = device_option.first
-                config.device_list = device_option.drop(1)
+            browser_option = options[Maze::Option::BROWSER]
+            browser_version = options[Maze::Option::BROWSER_VERSION]
+            if !device_option.empty?
+              config.device = device_option.first
+              config.device_list = device_option.drop(1)
+            elsif !browser_option.empty?
+              if browser_version.nil?
+                config.browser = browser_option.first
+                config.browser_list = browser_option.drop(1)
               else
-                config.device = device_option
-                config.device_list = []
+                # Dropping all but the first browser as the version is specified
+                config.browser = browser_option.first
+                config.browser_list = []
+                config.browser_version = browser_version
               end
             end
             config.os = options[Maze::Option::OS]

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -103,9 +103,7 @@ module Maze
             config.selenium_server_url = options[Maze::Option::SELENIUM_SERVER]
             config.app_bundle_id = options[Maze::Option::APP_BUNDLE_ID]
           when :local then
-            if options[Maze::Option::BROWSER]
-              config.browser = options[Maze::Option::BROWSER]
-            else
+            if options[Maze::Option::BROWSER].empty?
               os = config.os = options[Maze::Option::OS].downcase
               config.os_version = options[Maze::Option::OS_VERSION].to_f unless options[Maze::Option::OS_VERSION].nil?
               config.appium_server_url = options[Maze::Option::APPIUM_SERVER]
@@ -115,6 +113,8 @@ module Maze
                 config.apple_team_id = options[Maze::Option::APPLE_TEAM_ID]
                 config.device_id = options[Maze::Option::UDID]
               end
+            else
+              config.browser = options[Maze::Option::BROWSER].first
             end
           when :none
             if options[Maze::Option::OS]

--- a/lib/maze/option/validator.rb
+++ b/lib/maze/option/validator.rb
@@ -100,17 +100,18 @@ module Maze
           browsers = YAML.safe_load(File.read("#{__dir__}/../client/selenium/bb_browsers.yml"))
 
           rejected_browsers = browser.reject { |br| browsers.include? br }
-          unless rejected_browsers.empty?
+          if rejected_browsers.empty?
+            if options[Option::BROWSER_VERSION].nil?
+              browser.each do |br|
+                next if browsers[br].include?('version')
+                errors << "--#{Option::BROWSER_VERSION} must be specified for browser '#{br}'"
+              end
+            end
+          else
             browser_list = browsers.keys.join ', '
             errors << "Browser types '#{rejected_browsers.join(', ')}' unknown on BitBar.  Must be one of: #{browser_list}."
           end
 
-          if options[Option::BROWSER_VERSION].nil?
-            browser.each do |br|
-              next if browsers[br].include?('version')
-              errors << "--#{Option::BROWSER_VERSION} must be specified for browser '#{br}'"
-            end
-          end
         elsif !device.empty?
           app = Maze::Helper.read_at_arg_file options[Option::APP]
           if app.nil?
@@ -127,7 +128,7 @@ module Maze
 
       # Validates Local device options
       def validate_local(options, errors)
-        if options[Option::BROWSER].nil?
+        if options[Option::BROWSER].empty?
           errors << "--#{Option::APP} must be specified" if options[Option::APP].nil?
 
           # OS

--- a/test/option/parser_test.rb
+++ b/test/option/parser_test.rb
@@ -38,7 +38,7 @@ class ParserTest < Test::Unit::TestCase
     # Device-farm-only options
     assert_equal('/BrowserStackLocal', options[Maze::Option::BS_LOCAL])
     assert_equal([], options[Maze::Option::DEVICE])
-    assert_nil(options[Maze::Option::BROWSER])
+    assert_equal([], options[Maze::Option::BROWSER])
     assert_nil(options[Maze::Option::USERNAME])
     assert_nil(options[Maze::Option::ACCESS_KEY])
     assert_nil(options[Maze::Option::APPIUM_VERSION])
@@ -106,7 +106,7 @@ class ParserTest < Test::Unit::TestCase
     # Device-farm-only options
     assert_equal('ARG_BS_LOCAL', options[Maze::Option::BS_LOCAL])
     assert_equal(['ARG_DEVICE'], options[Maze::Option::DEVICE])
-    assert_equal('ARG_BROWSER', options[Maze::Option::BROWSER])
+    assert_equal(['ARG_BROWSER'], options[Maze::Option::BROWSER])
     assert_equal('ARG_BROWSER_VERSION', options[Maze::Option::BROWSER_VERSION])
     assert_equal('ARG_USERNAME', options[Maze::Option::USERNAME])
     assert_equal('ARG_ACCESS_KEY', options[Maze::Option::ACCESS_KEY])

--- a/test/option/validator_test.rb
+++ b/test/option/validator_test.rb
@@ -48,7 +48,7 @@ class ValidatorTest < Test::Unit::TestCase
     errors = @validator.validate options
 
     assert_equal 1, errors.length
-    assert_match 'Browser type \'MADE_UP\' unknown on BitBar.  Must be one of', errors[0]
+    assert_match 'Browser types \'MADE_UP\' unknown on BitBar.  Must be one of', errors[0]
   end
 
   def test_bitbar_missing_browser_version
@@ -102,7 +102,7 @@ class ValidatorTest < Test::Unit::TestCase
     errors = @validator.validate options
 
     assert_equal 1, errors.length
-    assert_match 'Browser type \'MADE_UP\' unknown on BrowserStack.  Must be one of', errors[0]
+    assert_match 'Browser types \'MADE_UP\' unknown on BrowserStack.  Must be one of', errors[0]
   end
 
   def test_browser_stack_missing_device


### PR DESCRIPTION
## Goal

Allows multiple browsers to be specified when running against a browser farm.  This will utilise them in the order given until either the driver successfully boots or we run out of connection attempts.

The main bulk of the changes consist of refactoring the selenium driver start process, which should now function by:

- start_session is called on the appropriate BB or BS driver
  - Local tunnels and initial capabilities are created according to the drivers needs
- start_driver is called, which sits in the base client
  - start_driver attempts to start the driver with the existing attributes
  - If this fails, the error is handled by the base client to determine if it is recoverable (it's assumed they all are currently)
  - If multiple targets exist in the config browser_list the next one will be cycled in and capabilities repopulated by the create_capabilities methods
  - Repeat the above until we succeed or fail more than the allowed amount of times.

## Tests

I've fixed up the unit tests, and extended the test pipeline to show it runs everything, but need to consider how to actually test it in anger given the browser tests are unlikely to randomly and identifiably run the code on their own.