### PR TITLE
Add App Manger API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Failed driver guards added to File Manager API [709](https://github.com/bugsnag/maze-runner/pull/709)
+- Added App Manager API [712](https://github.com/bugsnag/maze-runner/pull/712)
 
 # 9.22.0 - 2025/01/08
 

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -12,6 +12,7 @@ require_relative '../lib/maze'
 
 require_relative '../lib/maze/appium_server'
 require_relative '../lib/maze/api/appium/manager'
+require_relative '../lib/maze/api/appium/app_manager'
 require_relative '../lib/maze/api/appium/file_manager'
 require_relative '../lib/maze/api/cucumber/scenario'
 require_relative '../lib/maze/api/exit_code'

--- a/lib/maze/api/appium/app_manager.rb
+++ b/lib/maze/api/appium/app_manager.rb
@@ -48,6 +48,25 @@ module Maze
           fail_driver
           raise e
         end
+
+        # Gets the app state.
+        # @returns [Symbol, nil] The app state, such as :not_running, :running_in_foreground, :running_in_background - of nil if the driver has failed.
+        def state
+
+          if failed_driver?
+            $logger.error 'Cannot get the app state - Appium driver failed.'
+            return nil
+          end
+
+          @driver.app_state(@driver.app_id)
+        rescue Selenium::WebDriver::Error::UnknownError => e
+          $logger.error "Error closing the app: #{e.message}"
+          mil
+        rescue Selenium::WebDriver::Error::ServerError => e
+          # Assume the remote appium session has stopped, so crash out of the session
+          fail_driver
+          raise e
+        end
       end
     end
   end

--- a/lib/maze/api/appium/app_manager.rb
+++ b/lib/maze/api/appium/app_manager.rb
@@ -10,6 +10,8 @@ module Maze
         # Launches the app.
         # @returns [Boolean] Whether the app was successfully launched
         def launch
+          $logger.info 'SKW Launch the app'
+
           if failed_driver?
             $logger.error 'Cannot launch the app - Appium driver failed.'
             return false
@@ -29,6 +31,8 @@ module Maze
         # Closes the app.
         # @returns [Boolean] Whether the app was successfully closed
         def close
+          $logger.info 'SKW Close the app'
+
           if failed_driver?
             $logger.error 'Cannot close the app - Appium driver failed.'
             return false

--- a/lib/maze/api/appium/app_manager.rb
+++ b/lib/maze/api/appium/app_manager.rb
@@ -1,0 +1,50 @@
+require_relative '../../helper'
+require_relative './manager'
+
+module Maze
+  module Api
+    module Appium
+      # Provides operations for working with the app.
+      class AppManager < Maze::Api::Appium::Manager
+
+        # Launches the app.
+        # @returns [Boolean] Whether the app was successfully launched
+        def launch
+          if failed_driver?
+            $logger.error 'Cannot launch the app - Appium driver failed.'
+            return false
+          end
+
+          @driver.launch_app
+          true
+        rescue Selenium::WebDriver::Error::UnknownError => e
+          $logger.error "Error launching the app: #{e.message}"
+          false
+        rescue Selenium::WebDriver::Error::ServerError => e
+          # Assume the remote appium session has stopped, so crash out of the session
+          fail_driver
+          raise e
+        end
+
+        # Closes the app.
+        # @returns [Boolean] Whether the app was successfully closed
+        def close
+          if failed_driver?
+            $logger.error 'Cannot close the app - Appium driver failed.'
+            return false
+          end
+
+          @driver.close_app
+          true
+        rescue Selenium::WebDriver::Error::UnknownError => e
+          $logger.error "Error closing the app: #{e.message}"
+          false
+        rescue Selenium::WebDriver::Error::ServerError => e
+          # Assume the remote appium session has stopped, so crash out of the session
+          fail_driver
+          raise e
+        end
+      end
+    end
+  end
+end

--- a/lib/maze/api/appium/app_manager.rb
+++ b/lib/maze/api/appium/app_manager.rb
@@ -10,8 +10,6 @@ module Maze
         # Launches the app.
         # @returns [Boolean] Whether the app was successfully launched
         def launch
-          $logger.info 'SKW Launch the app'
-
           if failed_driver?
             $logger.error 'Cannot launch the app - Appium driver failed.'
             return false
@@ -19,9 +17,6 @@ module Maze
 
           @driver.launch_app
           true
-        rescue Selenium::WebDriver::Error::UnknownError => e
-          $logger.error "Error launching the app: #{e.message}"
-          false
         rescue Selenium::WebDriver::Error::ServerError => e
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver
@@ -31,8 +26,6 @@ module Maze
         # Closes the app.
         # @returns [Boolean] Whether the app was successfully closed
         def close
-          $logger.info 'SKW Close the app'
-
           if failed_driver?
             $logger.error 'Cannot close the app - Appium driver failed.'
             return false
@@ -40,9 +33,6 @@ module Maze
 
           @driver.close_app
           true
-        rescue Selenium::WebDriver::Error::UnknownError => e
-          $logger.error "Error closing the app: #{e.message}"
-          false
         rescue Selenium::WebDriver::Error::ServerError => e
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver
@@ -52,16 +42,12 @@ module Maze
         # Gets the app state.
         # @returns [Symbol, nil] The app state, such as :not_running, :running_in_foreground, :running_in_background - of nil if the driver has failed.
         def state
-
           if failed_driver?
-            $logger.error 'Cannot get the app state - Appium driver failed.'
+            $logger.error('Cannot get the app state - Appium driver failed.')
             return nil
           end
 
           @driver.app_state(@driver.app_id)
-        rescue Selenium::WebDriver::Error::UnknownError => e
-          $logger.error "Error closing the app: #{e.message}"
-          mil
         rescue Selenium::WebDriver::Error::ServerError => e
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver

--- a/test/api/appium/app_manager_test.rb
+++ b/test/api/appium/app_manager_test.rb
@@ -1,0 +1,76 @@
+require 'appium_lib'
+
+require_relative '../../test_helper'
+require_relative '../../../lib/maze'
+require_relative '../../../lib/maze/api/appium/app_manager'
+
+module Maze
+  module Api
+    module Appium
+      class AppManagerTest < Test::Unit::TestCase
+
+        def setup()
+          $logger = mock('logger')
+          @mock_driver = mock('driver')
+          Maze.driver = @mock_driver
+          @manager = Maze::Api::Appium::AppManager.new
+        end
+
+        def test_state_failed_driver
+          @mock_driver.expects(:failed?).returns(true)
+          $logger.expects(:error).with("Cannot get the app state - Appium driver failed.")
+
+          assert_nil(@manager.state)
+        end
+
+        def test_close_failed_driver
+          @mock_driver.expects(:failed?).returns(true)
+          $logger.expects(:error).with("Cannot close the app - Appium driver failed.")
+
+          assert_false(@manager.close)
+        end
+
+        def test_launch_failed_driver
+          @mock_driver.expects(:failed?).returns(true)
+          $logger.expects(:error).with("Cannot launch the app - Appium driver failed.")
+
+          assert_false(@manager.launch)
+        end
+
+        def test_state_server_error
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:app_id).returns('app1')
+          @mock_driver.expects(:fail_driver)
+          @mock_driver.expects(:app_state).with('app1').raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+
+          error = assert_raises Selenium::WebDriver::Error::ServerError do
+            @manager.state
+          end
+          assert_equal 'Timeout', error.message
+        end
+
+        def test_close_server_error
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:fail_driver)
+          @mock_driver.expects(:close_app).raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+
+          error = assert_raises Selenium::WebDriver::Error::ServerError do
+            @manager.close
+          end
+          assert_equal 'Timeout', error.message
+        end
+
+        def test_launch_server_error
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:fail_driver)
+          @mock_driver.expects(:launch_app).raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+
+          error = assert_raises Selenium::WebDriver::Error::ServerError do
+            @manager.launch
+          end
+          assert_equal 'Timeout', error.message
+        end
+      end
+    end
+  end
+end

--- a/test/api/appium/file_manager_test.rb
+++ b/test/api/appium/file_manager_test.rb
@@ -1,4 +1,4 @@
-require 'selenium-webdriver'
+require 'appium_lib'
 
 require_relative '../../test_helper'
 require_relative '../../../lib/maze'

--- a/test/fixtures/appium-api/README.md
+++ b/test/fixtures/appium-api/README.md
@@ -1,0 +1,1 @@
+The tests here are designed to exercise the Appium API methods.  Any app can be provided when invoking Maze Runner.

--- a/test/fixtures/appium-api/features/app-manager.feature
+++ b/test/fixtures/appium-api/features/app-manager.feature
@@ -1,0 +1,8 @@
+Feature: Exercise the App Manager API
+
+  Scenario: App Manager operations
+    When The app state is "running_in_foreground"
+    And I close the app
+    Then The app state is "not_running"
+    And I launch the app
+    Then The app state is "running_in_foreground"

--- a/test/fixtures/appium-api/features/steps/steps.rb
+++ b/test/fixtures/appium-api/features/steps/steps.rb
@@ -1,0 +1,11 @@
+When('The app state is {string}') do |state|
+  Maze.check.equal state.to_sym, Maze::Api::Appium::AppManager.new.state
+end
+
+When('I close the app') do
+  Maze::Api::Appium::AppManager.new.close
+end
+
+When('I launch the app') do
+  Maze::Api::Appium::AppManager.new.launch
+end


### PR DESCRIPTION
## Goal

Add an official API for performing operations and queries against an app with Appium.  Currently supports launch/close of the app, as well as getting the state of the run (running in forgeround, not running, etc).

## Design

Follows the same pattern as the File Manage API just added.

## Changeset

Adds a single class, `Maze::API::Appium::AppManager`.

## Tests

New set of e2e tests added; not added to CI as yet but could be as part of the integration branch.