### PR TITLE
Add activate and terminate methods to App Manager API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Failed driver guards added to File Manager API [709](https://github.com/bugsnag/maze-runner/pull/709)
 - Add App Manager API [712](https://github.com/bugsnag/maze-runner/pull/712)
 - Add Device Manager API [712](https://github.com/bugsnag/maze-runner/pull/713)
+- Add terminate and activate methods to App Manager API [716](https://github.com/bugsnag/maze-runner/pull/716)
 
 # 9.23.0 - 2025/01/XX
 

--- a/lib/maze/api/appium/app_manager.rb
+++ b/lib/maze/api/appium/app_manager.rb
@@ -7,7 +7,39 @@ module Maze
       # Provides operations for working with the app.
       class AppManager < Maze::Api::Appium::Manager
 
-        # Launches the app.
+        # Activates the app
+        # @returns [Boolean] Whether the app was successfully launched
+        def activate
+          if failed_driver?
+            $logger.error 'Cannot activate the app - Appium driver failed.'
+            return false
+          end
+
+          @driver.activate_app(@driver.app_id)
+          true
+        rescue Selenium::WebDriver::Error::ServerError => e
+          # Assume the remote appium session has stopped, so crash out of the session
+          fail_driver
+          raise e
+        end
+
+        # Terminates the app
+        # @returns [Boolean] Whether the app was successfully closed
+        def terminate
+          if failed_driver?
+            $logger.error 'Cannot terminate the app - Appium driver failed.'
+            return false
+          end
+
+          @driver.terminate_app(@driver.app_id)
+          true
+        rescue Selenium::WebDriver::Error::ServerError => e
+          # Assume the remote appium session has stopped, so crash out of the session
+          fail_driver
+          raise e
+        end
+
+        # Launches the app (legacy method).
         # @returns [Boolean] Whether the app was successfully launched
         def launch
           if failed_driver?
@@ -23,7 +55,7 @@ module Maze
           raise e
         end
 
-        # Closes the app.
+        # Closes the app (legacy method).
         # @returns [Boolean] Whether the app was successfully closed
         def close
           if failed_driver?

--- a/test/api/appium/app_manager_test.rb
+++ b/test/api/appium/app_manager_test.rb
@@ -37,6 +37,20 @@ module Maze
           assert_false(@manager.launch)
         end
 
+        def test_terminate_failed_driver
+          @mock_driver.expects(:failed?).returns(true)
+          $logger.expects(:error).with("Cannot terminate the app - Appium driver failed.")
+
+          assert_false(@manager.terminate)
+        end
+
+        def test_activate_failed_driver
+          @mock_driver.expects(:failed?).returns(true)
+          $logger.expects(:error).with("Cannot activate the app - Appium driver failed.")
+
+          assert_false(@manager.activate)
+        end
+
         def test_state_server_error
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:app_id).returns('app1')

--- a/test/fixtures/appium-api/features/appium-api.feature
+++ b/test/fixtures/appium-api/features/appium-api.feature
@@ -6,6 +6,10 @@ Feature: Exercise the Appium Manager APIs
     Then The app state is "not_running"
     And I launch the app
     Then The app state is "running_in_foreground"
+    And I terminate the app
+    Then The app state is "not_running"
+    And I activate the app
+    Then The app state is "running_in_foreground"
 
   Scenario: Device Manager operations
     When I unlock the device

--- a/test/fixtures/appium-api/features/steps/steps.rb
+++ b/test/fixtures/appium-api/features/steps/steps.rb
@@ -2,6 +2,14 @@ When('The app state is {string}') do |state|
   Maze.check.equal state.to_sym, Maze::Api::Appium::AppManager.new.state
 end
 
+When('I activate the app') do
+  Maze::Api::Appium::AppManager.new.activate
+end
+
+When('I terminate the app') do
+  Maze::Api::Appium::AppManager.new.terminate
+end
+
 When('I close the app') do
   Maze::Api::Appium::AppManager.new.close
 end


### PR DESCRIPTION
## Goal

Follow on from #713 , adding the `activate` and `terminate` methods.  These are now the preferred methods to use - close and launch are included for legacy purposes.

## Tests

Existing unit and e2e tests updated to cover success and failure cases.