### PR TITLE
Add hook to retrieve and write device info

### DIFF
--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -33,6 +33,9 @@ module Maze
             $logger.debug "session_capabilities: #{Maze.driver.session_capabilities.inspect}"
           end
 
+          # Log the device information after it's started
+          write_device_info
+
           # Ensure the device is unlocked
           begin
             Maze.driver.unlock
@@ -54,6 +57,16 @@ module Maze
 
         def retry_start_driver?
           raise 'Method not implemented by this class'
+        end
+
+        def write_device_info
+          info = Maze.driver.device_info
+          filepath = File.join(Dir.pwd, 'maze_output', 'device_info.json')
+          File.open(filepath, 'w+') do |file|
+            file.puts(JSON.pretty_generate(info))
+          end
+        rescue => error
+          $logger.warn "Could not write device information file, #{error.message}"
         end
 
         def attempt_start_driver(config)

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -73,7 +73,6 @@ module Maze
       end
 
       def at_exit
-        write_device_info
         if @client
           @client.log_run_outro
           $logger.info 'Stopping the Appium session'
@@ -82,19 +81,6 @@ module Maze
       end
 
       private
-
-      def write_device_info
-        driver = Maze.driver
-        unless driver.nil?
-          info = driver.device_info
-          filepath = File.join(Dir.pwd, 'maze_output', 'device_info.json')
-          File.open(filepath, 'w+') do |file|
-            file.puts(JSON.pretty_generate(info))
-          end
-        end
-      rescue => error
-        $logger.warn "Could not write device information file, #{error.message}"
-      end
 
       def driver_has_failed?
         return false if Maze::ErrorCaptor.empty?


### PR DESCRIPTION
## Goal

Gives us a bit more feedback when running tests both locally and on CI.

## Tests

See artifacts output at: https://buildkite.com/bugsnag/maze-runner/builds/4418#0194cc87-2670-4dda-bc56-cb2e6529e4fa
and: https://buildkite.com/bugsnag/maze-runner/builds/4418#0194cc87-2671-4473-ae0a-e1ae362d5646 
