### PR TITLE
Move AWS tests from MacOS boxes to github actions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,8 +8,6 @@ steps:
 
   - label: 'AWS - SAM tests'
     timeout_in_minutes: 30
-    agents:
-      queue: "macos-14"
     env:
       NODE_VERSION: "18"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,17 +6,6 @@ steps:
       queue: macos-14
     command: ./scripts/license_finder.sh
 
-  - label: 'AWS - SAM tests'
-    timeout_in_minutes: 30
-    env:
-      NODE_VERSION: "18"
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
-    command: >-
-      cd test/e2e/aws-sam &&
-      bundle install &&
-      bundle exec maze-runner
-      --no-log-requests
-
   - label: 'Build Android Performance test fixture'
     timeout_in_minutes: 30
     key: android-test-fixture

--- a/.github/workflows/aws-lambda-tests.yml
+++ b/.github/workflows/aws-lambda-tests.yml
@@ -9,13 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # - name: Install curl and samcli
-    #   run: |
-    #     sudo apt-get update
-    #     sudo apt-get install curl unzip
-    #     curl -o sam.zip -L https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-arm64.zip
-    #     unzip sam.zip -d sam-installation
-    #     sam-installation/install
+    - name: Install libcurl4-openssl-dev and net-tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcurl4-openssl-dev
+        sudo apt-get install net-tools
 
     - run: sam --version
 

--- a/.github/workflows/aws-lambda-tests.yml
+++ b/.github/workflows/aws-lambda-tests.yml
@@ -1,6 +1,6 @@
 name: AWS Lambda tests
 
-on
+on:
   push:
   pull_request:
 

--- a/.github/workflows/aws-lambda-tests.yml
+++ b/.github/workflows/aws-lambda-tests.yml
@@ -9,13 +9,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install curl and samcli
-      run: |
-        sudo apt-get update
-        sudo apt-get install curl unzip
-        curl -o sam.zip -L https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-arm64.zip
-        unzip sam.zip -d sam-installation
-        sam-installation/install
+    # - name: Install curl and samcli
+    #   run: |
+    #     sudo apt-get update
+    #     sudo apt-get install curl unzip
+    #     curl -o sam.zip -L https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-arm64.zip
+    #     unzip sam.zip -d sam-installation
+    #     sam-installation/install
+
+    - run: sam --version
 
     - uses: actions/checkout@v2
 

--- a/.github/workflows/aws-lambda-tests.yml
+++ b/.github/workflows/aws-lambda-tests.yml
@@ -1,5 +1,7 @@
 name: AWS Lambda tests
 
+permissions: read-all
+
 on:
   push:
   pull_request:

--- a/.github/workflows/aws-lambda-tests.yml
+++ b/.github/workflows/aws-lambda-tests.yml
@@ -1,0 +1,32 @@
+name: AWS Lambda tests
+
+on
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install curl and samcli
+      run: |
+        sudo apt-get update
+        sudo apt-get install curl unzip
+        curl -o sam.zip -L https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-arm64.zip
+        unzip sam.zip -d sam-installation
+        sam-installation/install
+
+    - uses: actions/checkout@v2
+
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.1'
+        bundler-cache: true
+
+    - name: Run tests
+      run: |
+        cd test/e2e/aws-sam
+        bundle install
+        bundle exec maze-runner --no-log-requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add Device Manager API [712](https://github.com/bugsnag/maze-runner/pull/713)
 - Add terminate and activate methods to App Manager API [716](https://github.com/bugsnag/maze-runner/pull/716)
 
+## Fixes
+
+- Ensure we parse the correct line from AWS lambda responses [722](https://github.com/bugsnag/maze-runner/pull/722)
+
 # 9.23.0 - 2025/01/XX
 
 ## Enhancements

--- a/lib/maze/aws/sam.rb
+++ b/lib/maze/aws/sam.rb
@@ -74,8 +74,6 @@ module Maze
             WARNING
             $logger.warn message
           end
-          
-          pp output
 
           # Attempt to parse response line of the output.
           # It's possible for a Lambda to output nothing,

--- a/lib/maze/aws/sam.rb
+++ b/lib/maze/aws/sam.rb
@@ -75,6 +75,8 @@ module Maze
             $logger.warn message
           end
 
+          pp output
+
           # Attempt to parse the last line of output as this is where a JSON
           # response would be. It's possible for a Lambda to output nothing,
           # e.g. if it forcefully exited, so we allow JSON parse failures here

--- a/lib/maze/aws/sam.rb
+++ b/lib/maze/aws/sam.rb
@@ -65,7 +65,7 @@ module Maze
           unless valid?(output)
             message = <<-WARNING
               The lambda function did not successfully complete.
-              This may be expected and a normal result of the text execution.
+              This may be expected and a normal result of the test execution.
               The listed cause is:
                 > #{output.last.chomp}
 
@@ -74,14 +74,15 @@ module Maze
             WARNING
             $logger.warn message
           end
-
+          
           pp output
 
-          # Attempt to parse the last line of output as this is where a JSON
-          # response would be. It's possible for a Lambda to output nothing,
+          # Attempt to parse response line of the output.
+          # It's possible for a Lambda to output nothing,
           # e.g. if it forcefully exited, so we allow JSON parse failures here
           begin
-            parsed_output = JSON.parse(output.last)
+            response_line = output.find { |line| /{.*}/.match(line.strip) }
+            parsed_output = JSON.parse(response_line)
           rescue JSON::ParserError
             return {}
           end

--- a/test/e2e/aws-sam/features/invoke.feature
+++ b/test/e2e/aws-sam/features/invoke.feature
@@ -1,5 +1,22 @@
 Feature: Using the AWS SAM CLI to directly invoke Lambda functions
 
+
+
+Scenario: Executing a lambda function with 'sam invoke' and an event
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app" with the "events/example-event.json" event
+  Then the lambda response "body.message" equals "Hello World!"
+  And the lambda response "statusCode" equals 200
+  And the SAM exit code equals 0
+
+Scenario: Executing a lambda function with 'sam invoke' that raises
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app" with the "events/error event.json" event
+  Then the lambda response "errorMessage" equals "oh no"
+  And the lambda response "errorType" is not null
+  And the lambda response "stackTrace" is a non-empty array
+  And the lambda response "body" is null
+  And the lambda response "statusCode" is null
+  And the SAM exit code equals 0
+
 Scenario: Executing a lambda function with 'sam invoke'
   Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app"
   Then the lambda response "body.message" equals "Hello World!"
@@ -20,19 +37,44 @@ Scenario: Executing a lambda function with 'sam invoke'
   And the lambda response "statusCode" is less than 201
   And the SAM exit code equals 0
 
-Scenario: Executing a lambda function with 'sam invoke' and an event
-  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app" with the "events/example-event.json" event
+Scenario: Executing a lambda function with 'sam invoke'
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app"
   Then the lambda response "body.message" equals "Hello World!"
+  And the lambda response "body.message" starts with "Hello"
+  And the lambda response "body.message" ends with "World!"
+  And the lambda response "body.message" matches the regex "W[d-r]{4}!$"
+  And the lambda response "body.message" is not null
+  And the lambda response "body.does.not.exist" is null
+  And the lambda response "body.is_lambda" is true
+  And the lambda response "body.is_not_lambda" is false
+  And the lambda response "body.empty_array" is an array with 0 elements
+  And the lambda response "body.numbers" is a non-empty array
+  And the lambda response "body.numbers" is an array with 5 elements
+  And the lambda response "body.numbers.0" equals 1
+  And the lambda response "body.numbers.4" equals 5
   And the lambda response "statusCode" equals 200
+  And the lambda response "statusCode" is greater than 199
+  And the lambda response "statusCode" is less than 201
   And the SAM exit code equals 0
 
-Scenario: Executing a lambda function with 'sam invoke' that raises
-  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app" with the "events/error event.json" event
-  Then the lambda response "errorMessage" equals "oh no"
-  And the lambda response "errorType" is not null
-  And the lambda response "stackTrace" is a non-empty array
-  And the lambda response "body" is null
-  And the lambda response "statusCode" is null
+Scenario: Executing a lambda function with 'sam invoke'
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app"
+  Then the lambda response "body.message" equals "Hello World!"
+  And the lambda response "body.message" starts with "Hello"
+  And the lambda response "body.message" ends with "World!"
+  And the lambda response "body.message" matches the regex "W[d-r]{4}!$"
+  And the lambda response "body.message" is not null
+  And the lambda response "body.does.not.exist" is null
+  And the lambda response "body.is_lambda" is true
+  And the lambda response "body.is_not_lambda" is false
+  And the lambda response "body.empty_array" is an array with 0 elements
+  And the lambda response "body.numbers" is a non-empty array
+  And the lambda response "body.numbers" is an array with 5 elements
+  And the lambda response "body.numbers.0" equals 1
+  And the lambda response "body.numbers.4" equals 5
+  And the lambda response "statusCode" equals 200
+  And the lambda response "statusCode" is greater than 199
+  And the lambda response "statusCode" is less than 201
   And the SAM exit code equals 0
 
 Scenario: Executing a node lambda function with 'sam invoke' and an event

--- a/test/e2e/aws-sam/features/invoke.feature
+++ b/test/e2e/aws-sam/features/invoke.feature
@@ -1,6 +1,24 @@
 Feature: Using the AWS SAM CLI to directly invoke Lambda functions
 
-
+Scenario: Executing a lambda function with 'sam invoke'
+  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app"
+  Then the lambda response "body.message" equals "Hello World!"
+  And the lambda response "body.message" starts with "Hello"
+  And the lambda response "body.message" ends with "World!"
+  And the lambda response "body.message" matches the regex "W[d-r]{4}!$"
+  And the lambda response "body.message" is not null
+  And the lambda response "body.does.not.exist" is null
+  And the lambda response "body.is_lambda" is true
+  And the lambda response "body.is_not_lambda" is false
+  And the lambda response "body.empty_array" is an array with 0 elements
+  And the lambda response "body.numbers" is a non-empty array
+  And the lambda response "body.numbers" is an array with 5 elements
+  And the lambda response "body.numbers.0" equals 1
+  And the lambda response "body.numbers.4" equals 5
+  And the lambda response "statusCode" equals 200
+  And the lambda response "statusCode" is greater than 199
+  And the lambda response "statusCode" is less than 201
+  And the SAM exit code equals 0
 
 Scenario: Executing a lambda function with 'sam invoke' and an event
   Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app" with the "events/example-event.json" event
@@ -15,66 +33,6 @@ Scenario: Executing a lambda function with 'sam invoke' that raises
   And the lambda response "stackTrace" is a non-empty array
   And the lambda response "body" is null
   And the lambda response "statusCode" is null
-  And the SAM exit code equals 0
-
-Scenario: Executing a lambda function with 'sam invoke'
-  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app"
-  Then the lambda response "body.message" equals "Hello World!"
-  And the lambda response "body.message" starts with "Hello"
-  And the lambda response "body.message" ends with "World!"
-  And the lambda response "body.message" matches the regex "W[d-r]{4}!$"
-  And the lambda response "body.message" is not null
-  And the lambda response "body.does.not.exist" is null
-  And the lambda response "body.is_lambda" is true
-  And the lambda response "body.is_not_lambda" is false
-  And the lambda response "body.empty_array" is an array with 0 elements
-  And the lambda response "body.numbers" is a non-empty array
-  And the lambda response "body.numbers" is an array with 5 elements
-  And the lambda response "body.numbers.0" equals 1
-  And the lambda response "body.numbers.4" equals 5
-  And the lambda response "statusCode" equals 200
-  And the lambda response "statusCode" is greater than 199
-  And the lambda response "statusCode" is less than 201
-  And the SAM exit code equals 0
-
-Scenario: Executing a lambda function with 'sam invoke'
-  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app"
-  Then the lambda response "body.message" equals "Hello World!"
-  And the lambda response "body.message" starts with "Hello"
-  And the lambda response "body.message" ends with "World!"
-  And the lambda response "body.message" matches the regex "W[d-r]{4}!$"
-  And the lambda response "body.message" is not null
-  And the lambda response "body.does.not.exist" is null
-  And the lambda response "body.is_lambda" is true
-  And the lambda response "body.is_not_lambda" is false
-  And the lambda response "body.empty_array" is an array with 0 elements
-  And the lambda response "body.numbers" is a non-empty array
-  And the lambda response "body.numbers" is an array with 5 elements
-  And the lambda response "body.numbers.0" equals 1
-  And the lambda response "body.numbers.4" equals 5
-  And the lambda response "statusCode" equals 200
-  And the lambda response "statusCode" is greater than 199
-  And the lambda response "statusCode" is less than 201
-  And the SAM exit code equals 0
-
-Scenario: Executing a lambda function with 'sam invoke'
-  Given I invoke the "HelloWorldFunction" lambda in "features/fixtures/ruby-app"
-  Then the lambda response "body.message" equals "Hello World!"
-  And the lambda response "body.message" starts with "Hello"
-  And the lambda response "body.message" ends with "World!"
-  And the lambda response "body.message" matches the regex "W[d-r]{4}!$"
-  And the lambda response "body.message" is not null
-  And the lambda response "body.does.not.exist" is null
-  And the lambda response "body.is_lambda" is true
-  And the lambda response "body.is_not_lambda" is false
-  And the lambda response "body.empty_array" is an array with 0 elements
-  And the lambda response "body.numbers" is a non-empty array
-  And the lambda response "body.numbers" is an array with 5 elements
-  And the lambda response "body.numbers.0" equals 1
-  And the lambda response "body.numbers.4" equals 5
-  And the lambda response "statusCode" equals 200
-  And the lambda response "statusCode" is greater than 199
-  And the lambda response "statusCode" is less than 201
   And the SAM exit code equals 0
 
 Scenario: Executing a node lambda function with 'sam invoke' and an event


### PR DESCRIPTION
## Goal

This will hopefully be slightly more reliable than our existing test setup with docker on the macs, as it'll be a new environment every time.

This will also serve as a pattern to be used on other repos testing using AWS lambda.

