### PR TITLE
Skip hooks for skipped scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Fixes
 
-- Do not run Cucumber `Before` and `After` hooks when skipping scenarios [728](https://github.com/bugsnag/maze-runner/pull/728)
+- Do not run Cucumber `Before` and `After` hooks when skipping scenarios [723](https://github.com/bugsnag/maze-runner/pull/723)
 - Ensure we parse the correct line from AWS lambda responses [722](https://github.com/bugsnag/maze-runner/pull/722)
 
 # 9.22.0 - 2025/01/08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-# TBD
+# 9.23.0 - 2025/02/18
 
 ## Enhancements
 
+- Allow multiple browser options to be presented to BitBar and BrowserStack test runs [712](https://github.com/bugsnag/maze-runner/pull/712)
+- Output device information as a JSON file during appium tests [717](https://github.com/bugsnag/maze-runner/pull/717)
 - Failed driver guards added to File Manager API [709](https://github.com/bugsnag/maze-runner/pull/709)
 - Add App Manager API [712](https://github.com/bugsnag/maze-runner/pull/712)
 - Add Device Manager API [712](https://github.com/bugsnag/maze-runner/pull/713)
@@ -9,14 +11,8 @@
 
 ## Fixes
 
+- Do not run Cucumber `Before` and `After` hooks when skipping scenarios [728](https://github.com/bugsnag/maze-runner/pull/728)
 - Ensure we parse the correct line from AWS lambda responses [722](https://github.com/bugsnag/maze-runner/pull/722)
-
-# 9.23.0 - 2025/01/XX
-
-## Enhancements
-
-- Allow multiple browser options to be presented to BitBar and BrowserStack test runs [712](https://github.com/bugsnag/maze-runner/pull/712)
-- Output device information as a JSON file during appium tests [717](https://github.com/bugsnag/maze-runner/pull/717)
 
 # 9.22.0 - 2025/01/08
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -8,7 +8,6 @@ require 'selenium-webdriver'
 require 'uri'
 
 BeforeAll do
-
   Maze.check = Maze::Checks::AssertCheck.new
 
   # Infer mode of operation from config, one of:
@@ -101,6 +100,8 @@ end
 
 # Before each scenario
 Before do |scenario|
+  next if scenario.status == :skipped
+
   Maze.scenario = Maze::Api::Cucumber::Scenario.new(scenario)
 
   # Skip scenario if the driver it needs has failed
@@ -133,6 +134,8 @@ end
 
 # General processing to be run after each scenario
 After do |scenario|
+  next if scenario.status == :skipped
+
   # If we're running on macos, take a screenshot if the scenario fails
   if Maze.config.os == "macos" && scenario.status == :failed
     Maze::MacosUtils.capture_screen(scenario)
@@ -225,6 +228,8 @@ end
 #
 # Furthermore, this hook should appear after the general hook as they are executed in reverse order by Cucumber.
 After do |scenario|
+  next if scenario.status == :skipped
+
   # Call any pre_complete hooks registered by the client
   Maze.hooks.call_pre_complete scenario
 
@@ -239,6 +244,8 @@ end
 # Test all requests against schemas or extra validation rules.  These will only run if the schema/validation is
 # specified for the specific endpoint
 After do |scenario|
+  next if scenario.status == :skipped
+
   ['error', 'session', 'build', 'trace'].each do |endpoint|
     Maze::Schemas::Validator.validate_payload_elements(Maze::Server.list_for(endpoint), endpoint)
   end


### PR DESCRIPTION
## Goal

Do not run `Before` and `After` hooks for scenarios that are being skipped - avoiding unnecessary processing and errors from things like using a failed Appium driver.

## Tests

Changes like this are hard to include in automated tests for this repo, but I have:
- Inspected the value of `scenario.status` in each hook block for skipped and not-skipped scenarios.
- Run a [full build](https://buildkite.com/bugsnag/bugsnag-android/builds/12555#_) for `bugsnag-android` against it to check nothing unexpected happens.