### PR TITLE
Ensure an empty string in the repeater key options is interpreted as null

### DIFF
--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -22,8 +22,10 @@ module Maze
           config.aws_public_ip = options[Maze::Option::AWS_PUBLIC_IP]
           config.enable_retries = options[Maze::Option::RETRIES]
           config.enable_bugsnag = options[Maze::Option::BUGSNAG]
-          config.aspecto_repeater_api_key = options[Maze::Option::ASPECTO_REPEATER_API_KEY]
-          config.bugsnag_repeater_api_key = options[Maze::Option::BUGSNAG_REPEATER_API_KEY]
+          aspecto_repeater_api_key = options[Maze::Option::ASPECTO_REPEATER_API_KEY]
+          config.aspecto_repeater_api_key = aspecto_repeater_api_key unless aspecto_repeater_api_key&.empty?
+          bugsnag_repeater_api_key = options[Maze::Option::BUGSNAG_REPEATER_API_KEY]
+          config.bugsnag_repeater_api_key = bugsnag_repeater_api_key unless bugsnag_repeater_api_key&.empty? 
 
           # Document server options
           config.document_server_root = options[Maze::Option::DS_ROOT]

--- a/test/unit/maze/option/processor_test.rb
+++ b/test/unit/maze/option/processor_test.rb
@@ -98,6 +98,7 @@ class ProcessorTest < Test::Unit::TestCase
     assert_false config.always_log
     assert_false config.https
     assert_nil config.bugsnag_repeater_api_key
+    assert_nil config.aspecto_repeater_api_key
   end
 
   def test_overriden_defaults
@@ -138,6 +139,42 @@ class ProcessorTest < Test::Unit::TestCase
 
     # Local-only options
     assert_equal('file-contents', config.app)
+  end
+
+  def test_repeater_key_responses
+    normal_args = %w[--repeater-api-key=foo --aspecto-repeater-api-key=bar]
+    normal_options = Maze::Option::Parser.parse normal_args
+    normal_config = Maze::Configuration.new
+    Maze::Option::Processor.populate normal_config, normal_options
+    assert_equal 'foo', normal_config.bugsnag_repeater_api_key
+    assert_equal 'bar', normal_config.aspecto_repeater_api_key
+
+    empty_args = %w[--repeater-api-key= --aspecto-repeater-api-key=]
+    empty_options = Maze::Option::Parser.parse empty_args
+    empty_config = Maze::Configuration.new
+    Maze::Option::Processor.populate empty_config, empty_options
+    assert_nil empty_config.bugsnag_repeater_api_key
+    assert_nil empty_config.aspecto_repeater_api_key
+
+    ENV['MAZE_ASPECTO_REPEATER_API_KEY'] = 'test_1'
+    ENV['MAZE_REPEATER_API_KEY'] = 'test_2'
+    env_options = Maze::Option::Parser.parse []
+    env_config = Maze::Configuration.new
+    Maze::Option::Processor.populate env_config, env_options
+    assert_equal 'test_1', env_config.aspecto_repeater_api_key
+    assert_equal 'test_2', env_config.bugsnag_repeater_api_key
+    ENV.delete('MAZE_ASPECTO_REPEATER_API_KEY')
+    ENV.delete('MAZE_REPEATER_API_KEY')
+
+    ENV['MAZE_ASPECTO_REPEATER_API_KEY'] = ''
+    ENV['MAZE_REPEATER_API_KEY'] = ''
+    empty_env_options = Maze::Option::Parser.parse []
+    empty_env_config = Maze::Configuration.new
+    Maze::Option::Processor.populate empty_env_config, empty_env_options
+    assert_nil empty_env_config.bugsnag_repeater_api_key
+    assert_nil empty_env_config.aspecto_repeater_api_key
+    ENV.delete('MAZE_ASPECTO_REPEATER_API_KEY')
+    ENV.delete('MAZE_REPEATER_API_KEY')
   end
 
   def test_environment_options


### PR DESCRIPTION
## Goal

This should fix the issue where empty environment variables and empty string environment variables may cause maze to crash.

## Tests

Added unit tests, @yousif-bugsnag it would be good if you could repeat your tests with this branch/build as a base for maze to ensure it works fully before we release it.