### PR TITLE
Log BitBar device name used in Appium sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.24.0 - 2025/02/??
+
+## Enhancements
+
+- Log name of device used in BitBar sessions [726](https://github.com/bugsnag/maze-runner/pull/726)
+
 # 9.23.2 - 2025/02/20
 
 ## Fixes

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.23.2'
+  VERSION = '9.24.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -95,9 +95,9 @@ module Maze
           @session_ids.each do |id|
             info = api_client.get_device_session_info(id)
             if info
-              link = Maze::Loggers::LogUtil.linkify(info[:ui_link], "BitBar session: #{id}")
-              device = info[:device_name]
-              $logger.info "#{link} on device #{device}"
+              link = Maze::Loggers::LogUtil.linkify(info[:dashboard_link], "BitBar session: #{id}")
+              $logger.info link
+              $logger.info "Device used: #{info[:device_name]}"
             end
           end
         end

--- a/lib/maze/client/bb_api_client.rb
+++ b/lib/maze/client/bb_api_client.rb
@@ -83,7 +83,7 @@ module Maze
         data = query_api('device-sessions', query)['data']
         if data.size == 1
           {
-            :ui_link => data[0]['uiLink'],
+            :dashboard_link => data[0]['uiLink'],
             :device_name => data[0]['device']['displayName']
           }
         else

--- a/lib/maze/client/selenium/bb_client.rb
+++ b/lib/maze/client/selenium/bb_client.rb
@@ -35,7 +35,7 @@ module Maze
 
           $logger.info 'Selenium session created:'
           id = Maze.driver.session_id
-          link = api_client.get_device_session_ui_link(id)
+          link = api_client.get_device_session_info(id)[:dashboard_link]
           $logger.info Maze::Loggers::LogUtil.linkify link, 'BitBar session(s)' if link
         end
 


### PR DESCRIPTION
## Goal

Log the device model used in BitBar Appium tests.

## Tests

Covered by CI, by inspection of both of the device and browser tests against BitBar.