### PR TITLE
Add Appium API method for pressing the back button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.26.0 - 2025/03/18
+
+## Enhancements
+
+- Add Appium API method for pressing the Back button [731](https://github.com/bugsnag/maze-runner/pull/731)
+
 # 9.25.0 - 2025/03/06
 
 ## Enhancements

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.25.0'
+  VERSION = '9.26.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/api/appium/device_manager.rb
+++ b/lib/maze/api/appium/device_manager.rb
@@ -24,6 +24,22 @@ module Maze
           raise e
         end
 
+        # Presses the Back button.
+        # @returns [Boolean] Success status
+        def back
+          if failed_driver?
+            $logger.error 'Cannot press the Back button - Appium driver failed.'
+            return false
+          end
+
+          @driver.back
+          true
+        rescue Selenium::WebDriver::Error::ServerError => e
+          # Assume the remote appium session has stopped, so crash out of the session
+          fail_driver(e.message)
+          raise e
+        end
+
         # Sets the rotation of the device.
         # @param orientation [Symbol] The orientation to set the device to, :portrait or :landscape
         # @returns [Boolean] Success status

--- a/test/e2e/appium-api/features/appium-api.feature
+++ b/test/e2e/appium-api/features/appium-api.feature
@@ -17,3 +17,4 @@ Feature: Exercise the Appium Manager APIs
     And I wait for 2 seconds
     And I set the device rotation to "portrait"
     And I log the device info
+    And I press the back button

--- a/test/e2e/appium-api/features/steps/steps.rb
+++ b/test/e2e/appium-api/features/steps/steps.rb
@@ -22,6 +22,10 @@ When('I unlock the device') do
   Maze::Api::Appium::DeviceManager.new.unlock
 end
 
+When('I press the back button') do
+  Maze::Api::Appium::DeviceManager.new.back
+end
+
 When('I set the device rotation to {string}') do |orientation|
   Maze::Api::Appium::DeviceManager.new.set_rotation(orientation.to_sym)
 end


### PR DESCRIPTION
## Goal

Provide a mechanism for pressing the back button using Appium, whilst detecting a failed Appium driver.

## Design

For now this follows the existing pattern.  In a future change I'll reactor all the API methods to avoid duplicating the error handling.

## Tests

e2e test updated and ran locally, inspecting the BrowserStack dashboard to be sure that the back button from pressed.