### PR TITLE
Add get_log to DeviceManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.27.0 - TDB
+
+## Enhancements
+
+- Add Appium API method for retrieving device logs [732](https://github.com/bugsnag/maze-runner/pull/732)
+
 # 9.26.0 - 2025/03/18
 
 ## Enhancements

--- a/lib/maze/api/appium/device_manager.rb
+++ b/lib/maze/api/appium/device_manager.rb
@@ -40,6 +40,23 @@ module Maze
           raise e
         end
 
+        # Gets logs from the device.
+        # @param log_type [String] The type pf log to get as recognised by Appium, such as 'syslog'
+        #
+        # @returns [Array, nil] Array of Selenium::WebDriver::LogEntry, or nil if the driver has failed
+        def get_log(log_type)
+          if failed_driver?
+            $logger.error 'Cannot get logs - Appium driver failed.'
+            return nil
+          end
+
+          @driver.get_log(log_type)
+        rescue Selenium::WebDriver::Error::ServerError => e
+          # Assume the remote appium session has stopped, so crash out of the session
+          fail_driver(e.message)
+          raise e
+        end
+
         # Sets the rotation of the device.
         # @param orientation [Symbol] The orientation to set the device to, :portrait or :landscape
         # @returns [Boolean] Success status

--- a/test/e2e/appium-api/features/appium-api.feature
+++ b/test/e2e/appium-api/features/appium-api.feature
@@ -13,6 +13,7 @@ Feature: Exercise the Appium Manager APIs
 
   Scenario: Device Manager operations
     When I unlock the device
+    And I get the device logs
     And I set the device rotation to "landscape"
     And I wait for 2 seconds
     And I set the device rotation to "portrait"

--- a/test/e2e/appium-api/features/steps/steps.rb
+++ b/test/e2e/appium-api/features/steps/steps.rb
@@ -34,3 +34,14 @@ When('I log the device info') do
   info = Maze::Api::Appium::DeviceManager.new.info
   $logger.info "Device info is: #{info}"
 end
+
+When('I get the device logs') do
+  log_type = if Maze.config.device.include?('ANDROID')
+               'logcat'
+             else
+               'syslog'
+             end
+  logs = Maze::Api::Appium::DeviceManager.new.get_log(log_type)
+  $logger.info "#{logs.length} device logs entries returned"
+end
+

--- a/test/unit/maze/api/appium/device_manager_test.rb
+++ b/test/unit/maze/api/appium/device_manager_test.rb
@@ -23,6 +23,20 @@ module Maze
           assert_false(@manager.unlock)
         end
 
+        def test_back_failed_driver
+          @mock_driver.expects(:failed?).returns(true)
+          $logger.expects(:error).with("Cannot press the Back button - Appium driver failed.")
+
+          assert_false(@manager.back)
+        end
+
+        def test_get_log_failed_driver
+          @mock_driver.expects(:failed?).returns(true)
+          $logger.expects(:error).with("Cannot get logs - Appium driver failed.")
+
+          assert_nil(@manager.get_log('syslog'))
+        end
+
         def test_set_rotation_failed_driver
           @mock_driver.expects(:failed?).returns(true)
           $logger.expects(:error).with("Cannot set the device rotation - Appium driver failed.")
@@ -66,6 +80,28 @@ module Maze
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.info
+          end
+          assert_equal 'Timeout', error.message
+        end
+
+        def test_back_server_error
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:fail_driver)
+          @mock_driver.expects(:back).raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+
+          error = assert_raises Selenium::WebDriver::Error::ServerError do
+            @manager.back
+          end
+          assert_equal 'Timeout', error.message
+        end
+
+        def test_get_log_server_error
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:fail_driver)
+          @mock_driver.expects(:get_log).with('syslog').raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+
+          error = assert_raises Selenium::WebDriver::Error::ServerError do
+            @manager.get_log('syslog')
           end
           assert_equal 'Timeout', error.message
         end


### PR DESCRIPTION
## Goal

Add get_log to the DeviceManager API.

## Design

Follows the existing pattern for API methods.

## Tests

Unit and e2e tests updated.  