### PR TITLE
Handle Appium UnknownError in AppManager routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.27.2 - 2025/04/07
+
+## Fixes
+
+- Handle Appium `UnknownError` in `AppManager` [738](https://github.com/bugsnag/maze-runner/pull/738)
+
 # 9.27.1 - 2025/04/04
 
 ## Fixes

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.27.1'
+  VERSION = '9.27.2'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/api/appium/app_manager.rb
+++ b/lib/maze/api/appium/app_manager.rb
@@ -17,7 +17,7 @@ module Maze
 
           @driver.activate_app(@driver.app_id)
           true
-        rescue Selenium::WebDriver::Error::ServerError => e
+        rescue Selenium::WebDriver::Error::ServerError, Selenium::WebDriver::Error::UnknownError => e
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -33,7 +33,7 @@ module Maze
 
           @driver.terminate_app(@driver.app_id)
           true
-        rescue Selenium::WebDriver::Error::ServerError => e
+        rescue Selenium::WebDriver::Error::ServerError, Selenium::WebDriver::Error::UnknownError => e
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -49,7 +49,7 @@ module Maze
 
           @driver.launch_app
           true
-        rescue Selenium::WebDriver::Error::ServerError => e
+        rescue Selenium::WebDriver::Error::ServerError, Selenium::WebDriver::Error::UnknownError => e
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -65,7 +65,7 @@ module Maze
 
           @driver.close_app
           true
-        rescue Selenium::WebDriver::Error::ServerError => e
+        rescue Selenium::WebDriver::Error::ServerError, Selenium::WebDriver::Error::UnknownError => e
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -80,7 +80,7 @@ module Maze
           end
 
           @driver.app_state(@driver.app_id)
-        rescue Selenium::WebDriver::Error::ServerError => e
+        rescue Selenium::WebDriver::Error::ServerError, Selenium::WebDriver::Error::UnknownError => e
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e

--- a/test/unit/maze/api/appium/app_manager_test.rb
+++ b/test/unit/maze/api/appium/app_manager_test.rb
@@ -51,13 +51,13 @@ module Maze
           assert_false(@manager.activate)
         end
 
-        def test_state_server_error
+        def test_state_unknown_error
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:app_id).returns('app1')
           @mock_driver.expects(:fail_driver)
-          @mock_driver.expects(:app_state).with('app1').raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          @mock_driver.expects(:app_state).with('app1').raises(Selenium::WebDriver::Error::UnknownError, 'Timeout')
 
-          error = assert_raises Selenium::WebDriver::Error::ServerError do
+          error = assert_raises Selenium::WebDriver::Error::UnknownError do
             @manager.state
           end
           assert_equal 'Timeout', error.message


### PR DESCRIPTION
## Goal

Ensure that `UnknownError`s occurring in `AppManager` routines are handled and lead to the driver being marked as failed.

## Tests

Unit test updated for some basic coverage.