### PR TITLE
Fail scenario when Appium driver fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.27.3 - 2025/04/10
+
+## Fixes
+
+- Fail test run when Appium driver fails [739](https://github.com/bugsnag/maze-runner/pull/739)
+
 # 9.27.2 - 2025/04/07
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Fixes
 
-- Fail test run when Appium driver fails [739](https://github.com/bugsnag/maze-runner/pull/739)
+- Fail test run when Appium driver fails [740](https://github.com/bugsnag/maze-runner/pull/740)
 
 # 9.27.2 - 2025/04/07
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -232,9 +232,15 @@ After do |scenario|
   # Call any pre_complete hooks registered by the client
   Maze.hooks.call_pre_complete scenario
 
+  # Fail the scenario if there are any invalid requests
   unless Maze::Server.invalid_requests.size_all == 0
     msg = "#{Maze::Server.invalid_requests.size_all} invalid request(s) received during scenario"
     Maze.scenario.mark_as_failed msg
+  end
+
+  # Fail the scenario if the Appium driver failed
+  if Maze.mode == :appium && Maze.driver.failed?
+    Maze.scenario.mark_as_failed Maze.driver.failure_reason
   end
 
   Maze.scenario.complete

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.27.2'
+  VERSION = '9.27.3'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/api/appium/app_manager.rb
+++ b/lib/maze/api/appium/app_manager.rb
@@ -18,14 +18,17 @@ module Maze
           @driver.activate_app(@driver.app_id)
           true
         rescue Selenium::WebDriver::Error::ServerError, Selenium::WebDriver::Error::UnknownError => e
+          $logger.error "Failed to activate app: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
         end
 
-        # Terminates the app
+        # Terminates the app.  If terminate fails then clients may wish to ty the legacy close method, so an option
+        # is provided to not fail the Appium driver.
+        # @fail_driver [Boolean] Whether to fail the Appium driver if the app cannot be terminated
         # @returns [Boolean] Whether the app was successfully closed
-        def terminate
+        def terminate(fail_driver = true)
           if failed_driver?
             $logger.error 'Cannot terminate the app - Appium driver failed.'
             return false
@@ -34,8 +37,9 @@ module Maze
           @driver.terminate_app(@driver.app_id)
           true
         rescue Selenium::WebDriver::Error::ServerError, Selenium::WebDriver::Error::UnknownError => e
+          $logger.error "Failed to terminate app: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
-          fail_driver(e.message)
+          fail_driver(e.message) if fail_driver
           raise e
         end
 
@@ -50,6 +54,7 @@ module Maze
           @driver.launch_app
           true
         rescue Selenium::WebDriver::Error::ServerError, Selenium::WebDriver::Error::UnknownError => e
+          $logger.error "Failed to launch app: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -66,6 +71,7 @@ module Maze
           @driver.close_app
           true
         rescue Selenium::WebDriver::Error::ServerError, Selenium::WebDriver::Error::UnknownError => e
+          $logger.error "Failed to close app: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -81,6 +87,7 @@ module Maze
 
           @driver.app_state(@driver.app_id)
         rescue Selenium::WebDriver::Error::ServerError, Selenium::WebDriver::Error::UnknownError => e
+          $logger.error "Failed to get app state: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e

--- a/lib/maze/api/appium/device_manager.rb
+++ b/lib/maze/api/appium/device_manager.rb
@@ -19,6 +19,7 @@ module Maze
           @driver.unlock
           true
         rescue Selenium::WebDriver::Error::ServerError => e
+          $logger.error "Failed to unlock the device: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -35,6 +36,7 @@ module Maze
           @driver.back
           true
         rescue Selenium::WebDriver::Error::ServerError => e
+          $logger.error "Failed to press back: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -52,6 +54,7 @@ module Maze
 
           @driver.get_log(log_type)
         rescue Selenium::WebDriver::Error::ServerError => e
+          $logger.error "Failed to get logs: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -69,6 +72,7 @@ module Maze
           @driver.set_rotation(orientation)
           true
         rescue Selenium::WebDriver::Error::ServerError => e
+          $logger.error "Failed to set the device rotation: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -84,6 +88,7 @@ module Maze
 
           JSON.generate(@driver.device_info)
         rescue Selenium::WebDriver::Error::ServerError => e
+          $logger.error "Failed to get the device info: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e

--- a/lib/maze/api/appium/file_manager.rb
+++ b/lib/maze/api/appium/file_manager.rb
@@ -35,6 +35,7 @@ module Maze
           $logger.error "Error writing file to device: #{e.message}"
           false
         rescue Selenium::WebDriver::Error::ServerError => e
+          $logger.error "Error writing file to device: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -72,6 +73,7 @@ module Maze
           $logger.error "Error reading file from device: #{e.message}"
           nil
         rescue Selenium::WebDriver::Error::ServerError => e
+          $logger.error "Error reading file from device: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e

--- a/lib/maze/api/appium/ui_manager.rb
+++ b/lib/maze/api/appium/ui_manager.rb
@@ -22,6 +22,7 @@ module Maze
 
           @driver.wait_for_element(element_id, timeout, retry_if_stale)
         rescue Selenium::WebDriver::Error::ServerError => e
+          $logger.error "Error waiting for element #{element_id}: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -41,6 +42,7 @@ module Maze
           @driver.click_element(element_id)
           true
         rescue Selenium::WebDriver::Error::ServerError => e
+          $logger.error "Error clicking element #{element_id}: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e
@@ -59,6 +61,7 @@ module Maze
 
           @driver.click_element_if_present(element_id)
         rescue Selenium::WebDriver::Error::ServerError => e
+          $logger.error "Error clicking element #{element_id}: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message)
           raise e

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -26,21 +26,23 @@ module Maze
       def after(scenario)
         manager = Maze::Api::Appium::AppManager.new
         if Maze.config.os == 'macos'
-          # Close the app - without the sleep, launching the app for the next scenario intermittently fails
+          # Close the app - without the sleep launching the app for the next scenario intermittently fails
           system("killall -KILL #{Maze.config.app} && sleep 1")
         elsif [:bb, :bs, :local].include? Maze.config.farm
-          # Reset the server to ensure that test fixtures cannot fetch
-          # commands from the previous scenario (in idempotent mode).
+          close_fallback = Maze.config.appium_version && Maze.config.appium_version.to_f < 2.0
           begin
-            manager.terminate
+            manager.terminate(!close_fallback)
           rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::InvalidSessionIdError
-            if Maze.config.appium_version && Maze.config.appium_version.to_f < 2.0
+            if close_fallback
               $logger.warn 'terminate_app failed, using the slower but more forceful close_app instead'
               manager.close
             else
               $logger.warn 'terminate_app failed, future errors may occur if the application did not close remotely'
             end
           end
+
+          # Reset the server before relaunching the app to ensure that test fixtures cannot fetch
+          # commands from the previous scenario (in idempotent mode).
           Maze::Server.reset!
           manager.activate
         end

--- a/test/unit/maze/api/appium/app_manager_test.rb
+++ b/test/unit/maze/api/appium/app_manager_test.rb
@@ -56,6 +56,7 @@ module Maze
           @mock_driver.expects(:app_id).returns('app1')
           @mock_driver.expects(:fail_driver)
           @mock_driver.expects(:app_state).with('app1').raises(Selenium::WebDriver::Error::UnknownError, 'Timeout')
+          $logger.expects(:error).with("Failed to get app state: Timeout")
 
           error = assert_raises Selenium::WebDriver::Error::UnknownError do
             @manager.state
@@ -67,6 +68,7 @@ module Maze
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:fail_driver)
           @mock_driver.expects(:close_app).raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          $logger.expects(:error).with("Failed to close app: Timeout")
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.close
@@ -78,6 +80,7 @@ module Maze
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:fail_driver)
           @mock_driver.expects(:launch_app).raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          $logger.expects(:error).with("Failed to launch app: Timeout")
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.launch

--- a/test/unit/maze/api/appium/device_manager_test.rb
+++ b/test/unit/maze/api/appium/device_manager_test.rb
@@ -55,6 +55,7 @@ module Maze
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:fail_driver)
           @mock_driver.expects(:unlock).raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          $logger.expects(:error).with("Failed to unlock the device: Timeout")
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.unlock
@@ -66,6 +67,7 @@ module Maze
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:fail_driver)
           @mock_driver.expects(:set_rotation).with(:landscape).raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          $logger.expects(:error).with("Failed to set the device rotation: Timeout")
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.set_rotation(:landscape)
@@ -77,6 +79,7 @@ module Maze
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:fail_driver)
           @mock_driver.expects(:device_info).raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          $logger.expects(:error).with("Failed to get the device info: Timeout")
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.info
@@ -88,6 +91,7 @@ module Maze
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:fail_driver)
           @mock_driver.expects(:back).raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          $logger.expects(:error).with("Failed to press back: Timeout")
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.back
@@ -99,6 +103,7 @@ module Maze
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:fail_driver)
           @mock_driver.expects(:get_log).with('syslog').raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          $logger.expects(:error).with("Failed to get logs: Timeout")
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.get_log('syslog')

--- a/test/unit/maze/api/appium/ui_manager_test.rb
+++ b/test/unit/maze/api/appium/ui_manager_test.rb
@@ -41,6 +41,7 @@ module Maze
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:fail_driver)
           @mock_driver.expects(:wait_for_element).with('element1', 15, true).raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          $logger.expects(:error).with("Error waiting for element element1: Timeout")
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.wait_for_element('element1')
@@ -52,6 +53,7 @@ module Maze
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:fail_driver)
           @mock_driver.expects(:click_element).with('element1').raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          $logger.expects(:error).with("Error clicking element element1: Timeout")
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.click_element('element1')
@@ -63,6 +65,7 @@ module Maze
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:fail_driver)
           @mock_driver.expects(:click_element_if_present).with('element1').raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          $logger.expects(:error).with("Error clicking element element1: Timeout")
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.click_element_if_present('element1')


### PR DESCRIPTION
## Goal

Ensure the scenario fails when the Appium driver fails.  Whilst the skipping of scenarios after an Appium driver failure has been working well, it was leading to false passes. 

## Design

The scenario will now be explicitly failed is the Appium driver has failed - either during the scenario steps themselves or in a previous `After` hook (note that `After` hooks are execute in reverse order of appearance in the file).

## Changeset

- Due to how we fall back to `close` if `terminate` fails, I've added an argument to allow us to suppress failing of the driver in that specific case.
- Logging improved so we can see which operation an error occurred on.  This may make the logs a little verbose in the short term due to logging in the driver itself, but this should resolve itself in due course when the driver is refactored.

## Tests

This is difficult to test in automated tests, so I made a temporary change to simulate an Appium fail after the third scenario.
https://buildkite.com/bugsnag/maze-runner/builds/4549/steps?jid=01961f97-0109-4d0d-93f2-50935597f11b#01961f97-0109-4d0d-93f2-50935597f11b/272-278