### PR TITLE
Explicitly fail remining scenarios if driver fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.27.4 - 2025/04/14
+
+## Fixes
+
+- Explicitly fail remaining scenarios if driver fails [741](https://github.com/bugsnag/maze-runner/pull/741)
+
 # 9.27.3 - 2025/04/10
 
 ## Fixes

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -106,7 +106,7 @@ Before do |scenario|
   Maze.scenario = Maze::Api::Cucumber::Scenario.new(scenario)
 
   # Skip scenario if the driver it needs has failed
-  $logger.debug "Before hook - Mae.driver&.failed?: #{Maze.driver&.failed?}"
+  $logger.debug "Before hook - Maze.driver&.failed?: #{Maze.driver&.failed?}"
   if (Maze.mode == :appium || Maze.mode == :browser) && Maze.driver.failed?
     $logger.debug "Failing scenario because the #{Maze.mode.to_s} driver failed: #{Maze.driver.failure_reason}"
     scenario.fail('Cannot run scenario - driver failed')
@@ -243,9 +243,9 @@ After do |scenario|
     Maze.scenario.mark_as_failed msg
   end
 
-  # Fail the scenario if the Appium driver failed
+  # Fail the scenario if the driver failed, if the scenario hasn't already failed
   $logger.debug "After hook 2 - Maze.driver&.failed?: #{Maze.driver&.failed?}"
-  if Maze.mode == :appium && Maze.driver.failed?
+  if (Maze.mode == :appium || Maze.mode == :browser) && Maze.driver.failed? && !scenario.failed?
     $logger.debug "Marking scenario as failed because driver failed: #{Maze.driver.failure_reason}"
     Maze.scenario.mark_as_failed Maze.driver.failure_reason
   end

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -106,7 +106,7 @@ Before do |scenario|
   Maze.scenario = Maze::Api::Cucumber::Scenario.new(scenario)
 
   # Skip scenario if the driver it needs has failed
-  $logger.debug "Before hook - Mae.driver.failed?: #{Maze.driver.failed?}"
+  $logger.debug "Before hook - Mae.driver&.failed?: #{Maze.driver&.failed?}"
   if (Maze.mode == :appium || Maze.mode == :browser) && Maze.driver.failed?
     $logger.debug "Skipping scenario because driver failed: #{Maze.driver.failure_reason}"
     skip_this_scenario
@@ -244,7 +244,7 @@ After do |scenario|
   end
 
   # Fail the scenario if the Appium driver failed
-  $logger.debug "After hook 2 - Maze.driver.failed?: #{Maze.driver.failed?}"
+  $logger.debug "After hook 2 - Maze.driver&.failed?: #{Maze.driver&.failed?}"
   if Maze.mode == :appium && Maze.driver.failed?
     $logger.debug "Marking scenario as failed because driver failed: #{Maze.driver.failure_reason}"
     Maze.scenario.mark_as_failed Maze.driver.failure_reason

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -109,7 +109,7 @@ Before do |scenario|
   $logger.debug "Before hook - Mae.driver&.failed?: #{Maze.driver&.failed?}"
   if (Maze.mode == :appium || Maze.mode == :browser) && Maze.driver.failed?
     $logger.debug "Skipping scenario because driver failed: #{Maze.driver.failure_reason}"
-    skip_this_scenario
+    scenario.fail('Cannot run scenario - driver failed')
   end
 
   # Default to no dynamic retry

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -100,12 +100,15 @@ end
 
 # Before each scenario
 Before do |scenario|
+  $logger.debug "Before hook - scenario.status: #{scenario.status}"
   next if scenario.status == :skipped
 
   Maze.scenario = Maze::Api::Cucumber::Scenario.new(scenario)
 
   # Skip scenario if the driver it needs has failed
+  $logger.debug "Before hook - Mae.driver.failed?: #{Maze.driver.failed?}"
   if (Maze.mode == :appium || Maze.mode == :browser) && Maze.driver.failed?
+    $logger.debug "Skipping scenario because driver failed: #{Maze.driver.failure_reason}"
     skip_this_scenario
   end
 
@@ -134,6 +137,7 @@ end
 
 # General processing to be run after each scenario
 After do |scenario|
+  $logger.debug "After hook 1 - scenario.status: #{scenario.status}"
   next if scenario.status == :skipped
 
   # If we're running on macos, take a screenshot if the scenario fails
@@ -227,6 +231,7 @@ end
 #
 # Furthermore, this hook should appear after the general hook as they are executed in reverse order by Cucumber.
 After do |scenario|
+  $logger.debug "After hook 2 - scenario.status: #{scenario.status}"
   next if scenario.status == :skipped
 
   # Call any pre_complete hooks registered by the client
@@ -239,7 +244,9 @@ After do |scenario|
   end
 
   # Fail the scenario if the Appium driver failed
+  $logger.debug "After hook 2 - Maze.driver.failed?: #{Maze.driver.failed?}"
   if Maze.mode == :appium && Maze.driver.failed?
+    $logger.debug "Marking scenario as failed because driver failed: #{Maze.driver.failure_reason}"
     Maze.scenario.mark_as_failed Maze.driver.failure_reason
   end
 
@@ -249,6 +256,7 @@ end
 # Test all requests against schemas or extra validation rules.  These will only run if the schema/validation is
 # specified for the specific endpoint
 After do |scenario|
+  $logger.debug "After hook 3 - scenario.status: #{scenario.status}"
   next if scenario.status == :skipped
 
   ['error', 'session', 'build', 'trace'].each do |endpoint|

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -108,7 +108,7 @@ Before do |scenario|
   # Skip scenario if the driver it needs has failed
   $logger.debug "Before hook - Mae.driver&.failed?: #{Maze.driver&.failed?}"
   if (Maze.mode == :appium || Maze.mode == :browser) && Maze.driver.failed?
-    $logger.debug "Skipping scenario because driver failed: #{Maze.driver.failure_reason}"
+    $logger.debug "Failing scenario because the #{Maze.mode.to_s} driver failed: #{Maze.driver.failure_reason}"
     scenario.fail('Cannot run scenario - driver failed')
   end
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.27.3'
+  VERSION = '9.27.4'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -37,7 +37,7 @@ module Maze
               $logger.warn 'terminate_app failed, using the slower but more forceful close_app instead'
               manager.close
             else
-              $logger.warn 'terminate_app failed, future errors may occur if the application did not close remotely'
+              $logger.warn 'terminate_app failed, future errors may occur if the application did not close properly'
             end
           end
 

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -24,6 +24,8 @@ module Maze
       end
 
       def after(scenario)
+        $logger.debug "Appium after hook"
+
         manager = Maze::Api::Appium::AppManager.new
         if Maze.config.os == 'macos'
           # Close the app - without the sleep launching the app for the next scenario intermittently fails


### PR DESCRIPTION
## Goal

Fail, rather than skip, remaining scenarios if the Appium/Selenium driver fails.

## Design

#740 attempted to fail any scenario that the driver failed in, but there was a gap in the logic.  

There are multiple Cucumber `After` hooks, of which:
- One will mark the scenario as failed if the driver failed.
- One will terminate then activate the app - both of these operations could result in a failed driver.

The problem is that they get executed in that order (implicitly due to the order in which they are declared in files).  That meant the driver could fail and not fail the current scenario.  The `Before` hook for the next scenario would then run and skip the scenario because of the failed driver - so the run as a whole would never be failed.

This change ensures subsequent scenarios and therefore the run as a whole fail.  If there are no further scenarios it doesn't matter that the run passes.

This change instead ideal in the long run as it will skew results in TestAnalytis, but it's better that false-passing runs.

## Changeset

I've also added a bunch of debug logging to help unpick anything that may arise in future.

## Tests

This build demonstrates scenarios failing after an Appium driver failure:
https://buildkite.com/bugsnag/bugsnag-android/builds/12728/steps?sid=019634f4-72ff-430d-a2c8-7119f1d94577#019634f4-7351-4821-89b8-0b5d43efca43/554-633
