### PR TITLE
Retry BitBar Appium session creation if beaten to device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.27.5 - 2025/04/15
+
+## Fixes
+
+- Retry BitBar Appium session creation if beaten to selected device [742](https://github.com/bugsnag/maze-runner/pull/742)
+
 # 9.27.4 - 2025/04/14
 
 ## Fixes

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.27.4'
+  VERSION = '9.27.5'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/bb_client.rb
+++ b/lib/maze/client/appium/bb_client.rb
@@ -38,6 +38,8 @@ module Maze
             interval = 10
           elsif error.message.include? '\'platformVersion\' must be a valid version number.'
             interval = 10
+          elsif error.message.include?('Device model with name') && error.message.include?('is currently unavailable')
+            interval = 10
           else
             # Do not retry in any other case
           end


### PR DESCRIPTION
## Goal

Retry BitBar Appium session creation if beaten to device.

## Design

There's an inherent race condition if using the BB API to find a free device before trying to start an Appium session with it.  Another user (or just ourselves in another CI job) can get to the device first.  This change means MR will simply retry if it gets an error of the following form:

```
Status code 400.  Payload: {"sessionId"=>nil, "message"=>"com.testdroid.api.APIException: Failed to submit test run! Device model with name 'Apple iPhone XS A1920 14.0.1 -US' is currently unavailable.", "value"=>{"message"=>"com.testdroid.api.APIException: Failed to submit test run! Device model with name 'Apple iPhone XS A1920 14.0.1 -US' is currently unavailable.", "origValue"=>"com.testdroid.api.APIException: Failed to submit test run! Device model with name 'Apple iPhone XS A1920 14.0.1 -US' is currently unavailable."}, "status"=>33}
```

## Tests

Verified by review only.