### PR TITLE
Add background to AppManager API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 9.27.5 - 2025/04/15
+# 9.28.0 - 2025/04/15
+
+## Enhancements
+
+- Add `background` to AppManager API [743](https://github.com/bugsnag/maze-runner/pull/743)
 
 ## Fixes
 

--- a/lib/features/steps/app_automator_steps.rb
+++ b/lib/features/steps/app_automator_steps.rb
@@ -38,7 +38,7 @@ end
 # Sends the app to the background indefinitely
 # Requires a running Appium driver
 When('I send the app to the background') do
-  Maze.driver.background_app(-1)
+  Maze::Api::Appium::AppManager.new.background(-1)
 end
 
 # Sends the app to the background for a number of seconds
@@ -46,7 +46,7 @@ end
 #
 # @step_input timeout [Integer] The amount of time the app is in the background in seconds
 When('I send the app to the background for {int} second(s)') do |timeout|
-  Maze.driver.background_app(timeout)
+  Maze::Api::Appium::AppManager.new.background(timeout)
 end
 
 # Clears a given element

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.27.5'
+  VERSION = '9.28.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/api/appium/app_manager.rb
+++ b/lib/maze/api/appium/app_manager.rb
@@ -26,7 +26,7 @@ module Maze
 
         # Terminates the app.  If terminate fails then clients may wish to ty the legacy close method, so an option
         # is provided to not fail the Appium driver.
-        # @fail_driver [Boolean] Whether to fail the Appium driver if the app cannot be terminated
+        # @param fail_driver [Boolean] Whether to fail the Appium driver if the app cannot be terminated
         # @returns [Boolean] Whether the app was successfully closed
         def terminate(fail_driver = true)
           if failed_driver?
@@ -40,6 +40,24 @@ module Maze
           $logger.error "Failed to terminate app: #{e.message}"
           # Assume the remote appium session has stopped, so crash out of the session
           fail_driver(e.message) if fail_driver
+          raise e
+        end
+
+        # Instructs Appium to background the app
+        # @param seconds [Integers] The number of seconds to background the app for, or -1 for indefinitely
+        # @returns [Boolean] Whether the instruction to Appium was successfully made
+        def background(seconds = -1)
+          if failed_driver?
+            $logger.error 'Cannot background the app - Appium driver failed.'
+            return false
+          end
+
+          @driver.background_app(seconds)
+          true
+        rescue Selenium::WebDriver::Error::ServerError, Selenium::WebDriver::Error::UnknownError => e
+          $logger.error "Failed to background app: #{e.message}"
+          # Assume the remote appium session has stopped, so crash out of the session
+          fail_driver(e.message)
           raise e
         end
 

--- a/test/e2e/appium-api/features/appium-api.feature
+++ b/test/e2e/appium-api/features/appium-api.feature
@@ -8,8 +8,12 @@ Feature: Exercise the Appium Manager APIs
     Then The app state is "running_in_foreground"
     And I terminate the app
     Then The app state is "not_running"
+    And I send the app to the background
+    Then The app state is "running_in_background"
     And I activate the app
     Then The app state is "running_in_foreground"
+    And I send the app to the background for 5 seconds
+    Then The app state is "running_in_background"
 
   Scenario: Device Manager operations
     When I unlock the device

--- a/test/e2e/appium-api/features/appium-api.feature
+++ b/test/e2e/appium-api/features/appium-api.feature
@@ -11,11 +11,10 @@ Feature: Exercise the Appium Manager APIs
     And I activate the app
     Then The app state is "running_in_foreground"
     And I send the app to the background
-    Then The app state is "not_running"
+    Then The app state is "running_in_background"
     And I activate the app
     Then The app state is "running_in_foreground"
     And I send the app to the background for 5 seconds
-    Then The app state is "not_running"
 
   Scenario: Device Manager operations
     When I unlock the device

--- a/test/e2e/appium-api/features/appium-api.feature
+++ b/test/e2e/appium-api/features/appium-api.feature
@@ -8,12 +8,14 @@ Feature: Exercise the Appium Manager APIs
     Then The app state is "running_in_foreground"
     And I terminate the app
     Then The app state is "not_running"
+    And I activate the app
+    Then The app state is "running_in_foreground"
     And I send the app to the background
-    Then The app state is "running_in_background"
+    Then The app state is "not_running"
     And I activate the app
     Then The app state is "running_in_foreground"
     And I send the app to the background for 5 seconds
-    Then The app state is "running_in_background"
+    Then The app state is "not_running"
 
   Scenario: Device Manager operations
     When I unlock the device

--- a/test/unit/maze/api/appium/app_manager_test.rb
+++ b/test/unit/maze/api/appium/app_manager_test.rb
@@ -51,6 +51,13 @@ module Maze
           assert_false(@manager.activate)
         end
 
+        def test_background_failed_driver
+          @mock_driver.expects(:failed?).returns(true)
+          $logger.expects(:error).with("Cannot background the app - Appium driver failed.")
+
+          assert_false(@manager.background)
+        end
+
         def test_state_unknown_error
           @mock_driver.expects(:failed?).returns(false)
           @mock_driver.expects(:app_id).returns('app1')
@@ -84,6 +91,18 @@ module Maze
 
           error = assert_raises Selenium::WebDriver::Error::ServerError do
             @manager.launch
+          end
+          assert_equal 'Timeout', error.message
+        end
+
+        def test_background_server_error
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:fail_driver)
+          @mock_driver.expects(:background_app).with(-1).raises(Selenium::WebDriver::Error::ServerError, 'Timeout')
+          $logger.expects(:error).with("Failed to background app: Timeout")
+
+          error = assert_raises Selenium::WebDriver::Error::ServerError do
+            @manager.background
           end
           assert_equal 'Timeout', error.message
         end


### PR DESCRIPTION
## Goal

Adds `background` to the `AppManager` API class.

## Tests

e2e and unit tests updated.