### PR TITLE
Remove erroneous use of global variable from browser driver `click_element`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.29.1 - 2025/04/23
+
+## Fixes
+
+- Remove erroneous use of global variable from browser driver `click_element` [745](https://github.com/bugsnag/maze-runner/pull/745)
+
 # 9.29.0 - 2025/04/17
 
 ## Enhancements

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.29.0'
+  VERSION = '9.29.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/driver/browser.rb
+++ b/lib/maze/driver/browser.rb
@@ -39,13 +39,7 @@ module Maze
       end
 
       def click_element(id)
-        element = @driver.find_element(id: id)
-
-        if $browser.mobile?
-          element.click
-        else
-          @driver.action.move_to(element).click.perform
-        end
+        @driver.find_element(id: id).click
       end
 
       def navigate


### PR DESCRIPTION
## Goal

Remove erroneous use of global variable from browser driver `click_element`.

## Design

The use of `$browser` was an error resulting from moving the method in from the bugsnag-js-performance repo in a recently PR (the repo had contained a monkey patch).  We didn't notice as that is the only repo using the method and it works in that context.  If another repo tried to use the method an error would be raised for `$browser` not being initialised.

## Tests

This change plays into a wider change - removing the use of legacy driver modes from repos (via `USE_LEGACY_MODE`).  I've run all the JS performance tests against this change in non-legacy mode.  No other repos are using the method changed (as noted above).