### PR TITLE
Update browser session links to match BrowserStack dashboard change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.29.2 - 2025/04/24
+
+## Fixes
+
+- Correct BrowserStack session link in response to dashboard change [746](https://github.com/bugsnag/maze-runner/pull/746)
+
 # 9.29.1 - 2025/04/23
 
 ## Fixes

--- a/lib/maze/client/selenium/bs_client.rb
+++ b/lib/maze/client/selenium/bs_client.rb
@@ -94,7 +94,7 @@ module Maze
 
         def log_session_info
           # Log a link to the BrowserStack session search dashboard
-          url = "https://automate.browserstack.com/projects/#{project_name_capabilities[:project]}/builds/#{Maze.run_uuid}/1?tab=tests"
+          url = "https://automate.browserstack.com/dashboard/v2/search?query=#{Maze.run_uuid}"
           $logger.info Maze::Loggers::LogUtil.linkify url, 'BrowserStack session(s)'
         end
       end


### PR DESCRIPTION
## Goal

Update browser session links to match (another) BrowserStack dashboard change.

## Tests

Covered by CI - I've inspected the links in the two Buildkite jobs.
