### PR TITLE
Add Edge 81 on BrowserStack and fix inconsistent capability names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Addition Edge browsers added on BrowserStack and corrections to others [747](https://github.com/bugsnag/maze-runner/pull/747)
+- Add Edge 81 on BrowserStack and make corrections to others [747](https://github.com/bugsnag/maze-runner/pull/747)
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 9.29.2 - 2025/04/24
+# 9.30.0 - 2025/04/24
+
+## Enhancements
+
+- Addition Edge browsers added on BrowserStack and corrections to others [747](https://github.com/bugsnag/maze-runner/pull/747)
 
 ## Fixes
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.29.2'
+  VERSION = '9.30.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/selenium/bs_browsers.yml
+++ b/lib/maze/client/selenium/bs_browsers.yml
@@ -54,66 +54,6 @@ edge_81:
   os: "windows"
   osVersion: "11"
 
-edge_82:
-  browserName: "edge"
-  browserVersion: "82"
-  os: "windows"
-  osVersion: "11"
-
-edge_83:
-  browserName: "edge"
-  browserVersion: "83"
-  os: "windows"
-  osVersion: "11"
-
-edge_84:
-  browserName: "edge"
-  browserVersion: "84"
-  os: "windows"
-  osVersion: "11"
-
-edge_85:
-  browserName: "edge"
-  browserVersion: "85"
-  os: "windows"
-  osVersion: "11"
-
-edge_86:
-  browserName: "edge"
-  browserVersion: "86"
-  os: "windows"
-  osVersion: "11"
-
-edge_87:
-  browserName: "edge"
-  browserVersion: "87"
-  os: "windows"
-  osVersion: "11"
-
-edge_88:
-  browserName: "edge"
-  browserVersion: "88"
-  os: "windows"
-  osVersion: "11"
-
-edge_89:
-  browserName: "edge"
-  browserVersion: "89"
-  os: "windows"
-  osVersion: "11"
-
-edge_100:
-  browserName: "edge"
-  browserVersion: "100"
-  os: "windows"
-  osVersion: "11"
-
-edge_110:
-  browserName: "edge"
-  browserVersion: "110"
-  os: "windows"
-  osVersion: "11"
-
 edge_latest:
   browserName: "edge"
   browserVersion: "latest"

--- a/lib/maze/client/selenium/bs_browsers.yml
+++ b/lib/maze/client/selenium/bs_browsers.yml
@@ -48,9 +48,57 @@ edge_80:
   os: "windows"
   osVersion: "11"
 
-edge_90:
+edge_81:
   browserName: "edge"
-  browserVersion: "90"
+  browserVersion: "81"
+  os: "windows"
+  osVersion: "11"
+
+edge_82:
+  browserName: "edge"
+  browserVersion: "82"
+  os: "windows"
+  osVersion: "11"
+
+edge_83:
+  browserName: "edge"
+  browserVersion: "83"
+  os: "windows"
+  osVersion: "11"
+
+edge_84:
+  browserName: "edge"
+  browserVersion: "84"
+  os: "windows"
+  osVersion: "11"
+
+edge_85:
+  browserName: "edge"
+  browserVersion: "85"
+  os: "windows"
+  osVersion: "11"
+
+edge_86:
+  browserName: "edge"
+  browserVersion: "86"
+  os: "windows"
+  osVersion: "11"
+
+edge_87:
+  browserName: "edge"
+  browserVersion: "87"
+  os: "windows"
+  osVersion: "11"
+
+edge_88:
+  browserName: "edge"
+  browserVersion: "88"
+  os: "windows"
+  osVersion: "11"
+
+edge_89:
+  browserName: "edge"
+  browserVersion: "89"
   os: "windows"
   osVersion: "11"
 

--- a/lib/maze/client/selenium/bs_browsers.yml
+++ b/lib/maze/client/selenium/bs_browsers.yml
@@ -37,22 +37,40 @@ edge_15:
   osVersion: "10"
 
 edge_17:
-  browser: "edge"
-  browser_version: "17"
+  browserName: "edge"
+  browserVersion: "17"
   os: "windows"
-  os_version: "10"
+  osVersion: "10"
 
 edge_80:
-  browser: "edge"
-  browser_version: "80"
+  browserName: "edge"
+  browserVersion: "80"
   os: "windows"
-  os_version: "11"
+  osVersion: "11"
+
+edge_90:
+  browserName: "edge"
+  browserVersion: "90"
+  os: "windows"
+  osVersion: "11"
+
+edge_100:
+  browserName: "edge"
+  browserVersion: "100"
+  os: "windows"
+  osVersion: "11"
+
+edge_110:
+  browserName: "edge"
+  browserVersion: "110"
+  os: "windows"
+  osVersion: "11"
 
 edge_latest:
-  browser: "edge"
-  browser_version: "latest"
+  browserName: "edge"
+  browserVersion: "latest"
   os: "windows"
-  os_version: "11"
+  osVersion: "11"
 
 safari_6:
   browserName: "safari"
@@ -219,10 +237,10 @@ firefox_60:
   osVersion: "10"
 
 firefox_78:
-  browser: "firefox"
-  browser_version: "78"
+  browserName: "firefox"
+  browserVersion: "78"
   os: "windows"
-  os_version: "10"
+  osVersion: "10"
 
 firefox_latest:
   browserName: "firefox"
@@ -279,10 +297,10 @@ chrome_43:
   osVersion: "7"
 
 chrome_53:
-  browser: "chrome"
-  browser_version: "53.0"
+  browserName: "chrome"
+  browserVersion: "53.0"
   os: "windows"
-  os_version: "10"
+  osVersion: "10"
 
 chrome_61:
   browserName: "chrome"
@@ -291,14 +309,13 @@ chrome_61:
   osVersion: "10"
 
 chrome_72:
-  browser: "chrome"
-  browser_version: "72.0"
+  browserName: "chrome"
+  browserVersion: "72.0"
   os: "windows"
-  os_version: "10"
+  osVersion: "10"
 
 chrome_latest:
   browserName: "chrome"
   browserVersion: "latest"
   os: "windows"
   osVersion: "10"
-  seleniumVersion: "3.14.0"


### PR DESCRIPTION
## Goal

Add Edge 81 on BrowserStack and fix inconsistent capability names.

## Design

The are two styles of capability - for the legacy JWP mode (`snake_case`) and W3C (`camelCase`).  There's code in Maze Runner to convert from W3C to JWP when in the legacy mode, so everything should appear in camel case in the YAML file.

## Tests

I've run a test against all of the browsers changed, in both legcy and W3C mode, checking in the BS dashboard that the right browser was used.