### PR TITLE
Add API method to pull app folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-# 9.30.0 - 2025/04/24
+# 9.30.0 - 2025/04/29
 
 ## Enhancements
 
 - Add Edge 81 on BrowserStack and make corrections to others [747](https://github.com/bugsnag/maze-runner/pull/747)
+- Add File Manager API method for pulling Documents/Files directory from mobile devices [749](https://github.com/bugsnag/maze-runner/pull/749)
+
+# 9.29.2 - 2025/04/24
 
 ## Fixes
 

--- a/test/unit/maze/api/appium/file_manager_test.rb
+++ b/test/unit/maze/api/appium/file_manager_test.rb
@@ -44,6 +44,35 @@ module Maze
           assert_false(@manager.write_app_file('contents', 'filename.json'))
         end
 
+        def test_read_app_folder_failed_driver
+          @mock_driver.expects(:failed?).returns(true)
+          $logger.expects(:error).with("Cannot read folder from device - Appium driver failed.")
+
+          @manager.read_app_folder
+        end
+
+        def test_read_app_folder_success
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:app_id).returns('app1')
+          Maze::Helper.expects(:get_current_platform).returns('android')
+          $logger.expects(:trace).with("Attempting to read folder from '/sdcard/Android/data/app1'")
+          @mock_driver.expects(:pull_folder).returns('contents')
+
+          assert_equal('contents', @manager.read_app_folder)
+        end
+
+        def test_read_app_folder_failure
+          @mock_driver.expects(:failed?).returns(false)
+          @mock_driver.expects(:app_id).returns('app1')
+          Maze::Helper.expects(:get_current_platform).returns('android')
+          $logger.expects(:trace).with("Attempting to read folder from '/sdcard/Android/data/app1'")
+          @mock_driver.expects(:pull_folder).raises(Selenium::WebDriver::Error::UnknownError, 'error')
+
+          $logger.expects(:error).with("Error reading folder from device: error")
+
+          assert_nil(@manager.read_app_folder)
+        end
+
         def test_read_app_file_failed_driver
           @mock_driver.expects(:failed?).returns(true)
           $logger.expects(:error).with("Cannot read file from device - Appium driver failed.")


### PR DESCRIPTION
## Goal

Adds a FileManager API method to pull the whole app folder (and a zip file in a byte array).

## Tests

Unit tests added for the basic logic and I've tested it locally with both iOS and Android.