### PR TITLE
Guard logging of invalid request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# 9.30.2 - 2025/05/12
+# 9.30.2 - 2025/05/13
 
 ## Fixes
 
 - Improve grouping of reported Selenium/Appium errors [753](https://github.com/bugsnag/maze-runner/pull/753)
+- Correct logging of invalid messages [754](https://github.com/bugsnag/maze-runner/pull/754)
 
 # 9.30.1 - 2025/05/02
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -217,8 +217,10 @@ def output_received_requests(request_type)
       $logger.info 'Request digests:'
       Maze::Loggers::LogUtil.log_hash(Logger::Severity::INFO, request[:digests])
 
-      $logger.info "Response: #{request[:response].body}"
-      log_headers(request[:response])
+      unless request[:response].nil?
+        $logger.info "Response: #{request[:response].body}"
+        log_headers(request[:response])
+      end
     end
   end
 end

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -228,8 +228,8 @@ end
 def log_headers(container)
   header = if container.respond_to?(:header)
              container.header
-           elsif container.key?('header')
-             container['header']
+           elsif container.key?('header') || container.key?(:header)
+             container['header'] || container[:header]
            else
              nil
            end

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -210,19 +210,30 @@ def output_received_requests(request_type)
     request_queue.all.each.with_index(1) do |request, number|
       $stdout.puts "--- #{request_type} #{number} of #{count}"
 
-      $logger.info 'Request body:'
+      $logger.info 'Request:'
       Maze::Loggers::LogUtil.log_hash(Logger::Severity::INFO, request[:body])
-
-      $logger.info 'Request headers:'
-      Maze::Loggers::LogUtil.log_hash(Logger::Severity::INFO, request[:request].header)
+      log_headers(request[:request])
 
       $logger.info 'Request digests:'
       Maze::Loggers::LogUtil.log_hash(Logger::Severity::INFO, request[:digests])
 
-      $logger.info "Response body: #{request[:response].body}"
-      $logger.info 'Response headers:'
-      Maze::Loggers::LogUtil.log_hash(Logger::Severity::INFO, request[:response].header)
+      $logger.info "Response: #{request[:response].body}"
+      log_headers(request[:response])
     end
+  end
+end
+
+def log_headers(container)
+  header = if container.respond_to?(:header)
+             container.header
+           elsif container.key?('header')
+             container['header']
+           else
+             nil
+           end
+  unless header.nil?
+    $logger.info 'Headers:'
+    Maze::Loggers::LogUtil.log_hash(Logger::Severity::INFO, header)
   end
 end
 


### PR DESCRIPTION
## Goal

Attempts to fix this issue when logging received invalid requests to console:

![image](https://github.com/user-attachments/assets/e590deae-04ec-422a-894c-6403ef22e127)

## Tests

This is a difficult area to test as it relies on an error condition occurring to exercise the code, although the change should not make anything worse when the tests were failing and code crashing in the first place.  I'm going to try and create some form of automated test for this area in upcoming work.