### PR TITLE
Prevent crash when writing invalid requests to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.30.3 - 2025/05/14
+
+## Fixes
+
+- Fix crash writing received invalid requests to maze_output [755](https://github.com/bugsnag/maze-runner/pull/755)
+
 # 9.30.2 - 2025/05/13
 
 ## Fixes

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.30.2'
+  VERSION = '9.30.3'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/servlets/servlet.rb
+++ b/lib/maze/servlets/servlet.rb
@@ -107,6 +107,7 @@ module Maze
           Server.invalid_requests.add({
             reason: msg,
             request: request,
+            response: response,
             body: request.body
           })
         else
@@ -124,7 +125,8 @@ module Maze
               request_uri: request.request_uri,
               header: request.header,
               body: request.inspect
-            }
+            },
+            response: response
           })
         else
           $logger.warn msg


### PR DESCRIPTION
## Goal

Prevent the following crash when writing invalid requests to file:
```
undefined method `body' for nil:NilClass (NoMethodError)
maze-runner/lib/maze/maze_output.rb:83:in `block (3 levels) in write_requests'
```

## Tests

Tested locally using curl to send messages with an invalid JSON payload and wrong content-length respectively (exercising the two code paths changed).