### PR TITLE
Add step "I discard all {request_type}"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.31.0 - 2025/05/15
+
+## Enhancements
+
+- Add step `I discard all {request_type}`' [756](https://github.com/bugsnag/maze-runner/pull/756)
+
 # 9.30.3 - 2025/05/14
 
 ## Fixes

--- a/lib/features/steps/request_assertion_steps.rb
+++ b/lib/features/steps/request_assertion_steps.rb
@@ -131,6 +131,15 @@ Then('I discard the oldest {request_type}') do |request_type|
   Maze::Server.list_for(request_type).next
 end
 
+# Moves to the end of the request list
+#
+# @step_input request_type [String] The type of request (error, session, build, etc)
+Then('I discard all {request_type}') do |request_type|
+  raise "No #{request_type} to discard" if Maze::Server.list_for(request_type).current.nil?
+
+  Maze::Server.list_for(request_type).end
+end
+
 Then('the received errors match:') do |table|
   # Checks that each request matches one of the event fields
   requests = Maze::Server.errors.remaining

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.30.3'
+  VERSION = '9.31.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/request_list.rb
+++ b/lib/maze/request_list.rb
@@ -59,6 +59,12 @@ module Maze
       @count -= 1
     end
 
+    # Moves to the end of the list
+    def end
+      @current = @requests.size
+      @count = 0
+    end
+
     # A frozen clone of all requests held, including those already processed
     def all
       @requests.clone.freeze

--- a/test/e2e/payload-helpers/features/breadcrumb_json_fixtures.feature
+++ b/test/e2e/payload-helpers/features/breadcrumb_json_fixtures.feature
@@ -31,7 +31,10 @@ Feature: Breadcrumb helper steps
         And the event has 3 breadcrumbs
 
     Scenario: The payload has no breadcrumbs
-        Given I send a "handled"-type request
+        Given I send a "breadcrumbs"-type request
+        When I wait to receive an error
+        And I discard all errors
+        And I send a "handled"-type request
         When I wait to receive an error
         Then the event has no breadcrumbs
         Then the event has 0 breadcrumbs

--- a/test/unit/maze/request_list_test.rb
+++ b/test/unit/maze/request_list_test.rb
@@ -98,6 +98,24 @@ class RequestListTest < Test::Unit::TestCase
     assert_equal after_add(item4), list.current
   end
 
+  def test_add_after_end
+    item1 = build_item 1
+    item2 = build_item 2
+    item3 = build_item 3
+    item4 = build_item 4
+
+    list = Maze::RequestList.new
+    list.add item1
+    list.add item2
+    list.add item3
+    list.end
+
+    assert_nil list.current
+
+    list.add item4
+    assert_equal after_add(item4), list.current
+  end
+
   def test_clear
     item1 = build_item 1
     item2 = build_item 2


### PR DESCRIPTION
## Goal

Add the Cucumber step `I discard all {request_type}`.

## Design

The step `I clear the error queue` already exists, but it's almost certainly not what clients want as it removes all trace of the errors that were received.  In particular, when received errors are written to file at the end of the scenario they are not included, potentially leading to a great deal of confusion.

## Tests

Unit test added for the `RequestList` update and exist scenario updated to include the new step.