### PR TITLE
Ignore precise milliseconds when grouping errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.31.1 - 2025/05/16
+
+## Fixes
+
+- Ignore precise milliseconds when grouping errors finding a connected Android device [758](https://github.com/bugsnag/maze-runner/pull/758)
+
 # 9.31.0 - 2025/05/15
 
 ## Enhancements

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.31.0'
+  VERSION = '9.31.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/error_monitor/selenium_error_middleware.rb
+++ b/lib/maze/error_monitor/selenium_error_middleware.rb
@@ -24,6 +24,10 @@ module Maze
           {
             pattern: /(unexpected end of stream on )(http:\/\/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:[0-9]{1,5}\/\.\.\.)/,
             replacement: '\1URL'
+          },
+          {
+            pattern: /(Could not find a connected Android device in )([0-9]+)ms/,
+            replacement: '\1TIME'
           }
         ]
 

--- a/test/unit/maze/error_monitor/selenium_error_middleware_test.rb
+++ b/test/unit/maze/error_monitor/selenium_error_middleware_test.rb
@@ -19,4 +19,11 @@ class SeleniumErrorMiddlewareTest < Test::Unit::TestCase
 
     assert_equal("unexpected end of stream on URL", sanitised)
   end
+
+  def test_sanitise_3
+    plain = "An unknown server-side error occurred while processing the command. Original error: Could not find a connected Android device in 20088ms."
+    sanitised = @middleware.sanitise(plain)
+
+    assert_equal("An unknown server-side error occurred while processing the command. Original error: Could not find a connected Android device in TIME.", sanitised)
+  end
 end


### PR DESCRIPTION
## Goal

Ignore precise milliseconds when grouping errors in our Bugsnag dashbaoard.

## Design

The mechanism that makes this work is already built, it's just a matter of adding anther regex and substitution.

## Tests

Unit test updated.