### PR TITLE
Avoid double-reporting of Appium errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Ignore precise milliseconds when grouping errors finding a connected Android device [758](https://github.com/bugsnag/maze-runner/pull/758)
+- Avoid double-reporting of Appium errors [759](https://github.com/bugsnag/maze-runner/pull/759)
 
 # 9.31.0 - 2025/05/15
 

--- a/lib/maze/api/appium/manager.rb
+++ b/lib/maze/api/appium/manager.rb
@@ -13,6 +13,7 @@ module Maze
 
         def fail_driver(exception)
           Bugsnag.notify(exception)
+          exception.instance_eval { def skip_bugsnag; true; end }
           @driver.fail_driver(exception.message)
         end
       end


### PR DESCRIPTION
## Goal

Avoid double-reporting of Appium errors.

## Design

Uses the [documented approach](https://docs.bugsnag.com/platforms/ruby/other/#avoiding-re-notifying-exceptions) for this situation.

## Tests

Tested locally by forcing an error in an Appium method called by the Cucumber `After` hook.  The error is notified just once and the scenario still fails as we expect.