### PR TITLE
Stop and report on Appium session before at_exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-# 9.31.1 - 2025/05/16
+# 9.31.1 - 2025/05/19
 
 ## Fixes
 
 - Ignore precise milliseconds when grouping errors finding a connected Android device [758](https://github.com/bugsnag/maze-runner/pull/758)
 - Avoid double-reporting of Appium errors [759](https://github.com/bugsnag/maze-runner/pull/759)
+- Ensure Appium session result is notified before Bugsnag shuts down [760](https://github.com/bugsnag/maze-runner/pull/760)
 
 # 9.31.0 - 2025/05/15
 

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -60,18 +60,16 @@ module Maze
         else
           Maze::Plugins::DatadogMetricsPlugin.send_increment('appium.test_failed')
         end
-      rescue => error
-        # Notify and re-raise for Cucumber to handle
-        Bugsnag.notify error
-        raise
-      end
 
-      def at_exit
         if @client
           @client.log_run_outro
           $logger.info 'Stopping the Appium session'
           @client.stop_session
         end
+      rescue => error
+        # Notify and re-raise for Cucumber to handle
+        Bugsnag.notify error
+        raise
       end
     end
   end


### PR DESCRIPTION
## Goal

Ensure Bugsnag reports for the Appium session status are sent before Bugsnag shuts down.

## Design

We were trying to send the report for the Appium session during `at_exit`, but the Bugsnag notifier shuts its internal queue down in `at_exit` and so the reports were often not getting sent (despite it indicating that it was on the console).

## Tests

Tested locally and by CI.