### PR TITLE
Group Appium session reports on sanitised message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# 9.31.2 - 2025/05/28
+# 9.31.2 - 2025/05/29
 
 ## Fixes
 
 - Retry BitBar device session creation for `Error executing adbExec` errors [762](https://github.com/bugsnag/maze-runner/pull/762)
+- Group Appium session reports on sanitised message [763](https://github.com/bugsnag/maze-runner/pull/763)
 
 # 9.31.1 - 2025/05/19
 

--- a/lib/maze/client/appium/base_client.rb
+++ b/lib/maze/client/appium/base_client.rb
@@ -163,11 +163,10 @@ module Maze
 
         def report_session
           message = @session_metadata.success ? 'Success' : @session_metadata.failure_message
-          error = Exception.new(message)
+          error = ::Selenium::WebDriver::Error::ServerError.new(message)
 
           Bugsnag.notify(error) do |event|
             event.api_key = ENV['MAZE_APPIUM_BUGSNAG_API_KEY']
-            event.grouping_hash = event.exceptions.first[:message]
 
             metadata = {
               'session id': @session_metadata.id,


### PR DESCRIPTION
## Goal

Ensure that Appium session reported are grouped by sanitised messaged.

## Design

Changed the error type used to report the Appium session status, so that the existing middleware class handles the grouping (it contains a guard to ignore any error types not starting with `Selenium::WebDriver`).

## Tests

Tested locally by forcing an error in an Appium method and verifying that the errors group as intended in
[the Bugsnag dashboard](https://app.bugsnag.com/bugsnag/maze-runner-appium-sessions/errors/683740c771e48b17c5225ee2?filters[error.status]=open&filters[event.since]=30d).