### PR TITLE
 Add the unity-line-mappings endpoint to the mock server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- Add `unity-line-mappings` endpoint to the mock server []()
+- Add `unity-line-mappings` endpoint to the mock server [764](https://github.com/bugsnag/maze-runner/pull/764)
 
 # 9.31.2 - 2025/05/29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.31.3 - 2025/06/02
+
+## Enhancements
+
+- Add `unity-line-mappings` endpoint to the mock server []()
+
 # 9.31.2 - 2025/05/29
 
 ## Fixes

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.31.2'
+  VERSION = '9.31.3'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -253,6 +253,7 @@ module Maze
             server.mount '/proguard', Servlets::Servlet, :sourcemaps
             server.mount '/dsym', Servlets::Servlet, :sourcemaps
             server.mount '/breakpad-symbol', Servlets::Servlet, :sourcemaps
+            server.mount '/unity-line-mappings', Servlets::Servlet, :sourcemaps
             server.mount '/command', Servlets::CommandServlet
             server.mount '/commands', Servlets::AllCommandsServlet
             server.mount '/logs', Servlets::LogServlet

--- a/test/unit/maze/server_test.rb
+++ b/test/unit/maze/server_test.rb
@@ -52,6 +52,7 @@ module Maze
       mock_http_server.expects(:mount).with('/proguard', any_parameters).once
       mock_http_server.expects(:mount).with('/dsym', any_parameters).once
       mock_http_server.expects(:mount).with('/breakpad-symbol', any_parameters).once
+      mock_http_server.expects(:mount).with('/unity-line-mappings', any_parameters).once
       mock_http_server.expects(:mount).with('/command', any_parameters).once
       mock_http_server.expects(:mount).with('/commands', any_parameters).once
       mock_http_server.expects(:mount).with('/logs', any_parameters).once
@@ -104,6 +105,7 @@ module Maze
       mock_http_server.expects(:mount).with('/proguard', any_parameters).once
       mock_http_server.expects(:mount).with('/dsym', any_parameters).once
       mock_http_server.expects(:mount).with('/breakpad-symbol', any_parameters).once
+      mock_http_server.expects(:mount).with('/unity-line-mappings', any_parameters).once
       mock_http_server.expects(:mount).with('/logs', any_parameters).once
       mock_http_server.expects(:mount).with('/reflect', any_parameters).once
       mock_http_server.expects(:mount).with('/command', any_parameters).once


### PR DESCRIPTION
## Goal

To allow us to test the unity-line-mappings changes to the BugSnag CLI we need to mock the unity-line-mappings endpoint within Maze Runner.

## Tests

Covered by CI
