### PR TITLE
Remove flaky test checks

### DIFF
--- a/test/e2e/appium-api/features/appium-api.feature
+++ b/test/e2e/appium-api/features/appium-api.feature
@@ -11,9 +11,7 @@ Feature: Exercise the Appium Manager APIs
     And I activate the app
     Then The app state is "running_in_foreground"
     And I send the app to the background
-    Then The app state is "running_in_background"
     And I activate the app
-    Then The app state is "running_in_foreground"
     And I send the app to the background for 5 seconds
 
   Scenario: Device Manager operations


### PR DESCRIPTION
## Goal

Background of the app is inherently flaky with Appium, but there's nothing we can do that.  Just removing these checks to avoid annoying failures.

## Tests

Covered by CI.