### PR TITLE
Remove pin for `uri` standard gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.31.4 - 2025/06/09
+
+## Fixes
+
+- Remove pin for `uri` standard Gem [766](https://github.com/bugsnag/maze-runner/pull/766)
+
 # 9.31.3 - 2025/06/02
 
 ## Enhancements

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'test-unit', '~> 3.5.2'
   spec.add_dependency 'rack', '~> 2.2'
   spec.add_dependency 'webrick', '~> 1.7.0'
-  spec.add_dependency 'uri', '~> 0.13.0'
 
   # Appium 12/Selenium 4 enforce the use of W3C
   if ENV['USE_LEGACY_DRIVER']

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.31.3'
+  VERSION = '9.31.4'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

Removes the pin for the `uri` Gem, allowing different versions of Ruby to use the version included with it.

## Design

#700 introduced the pin to deal with errors when making requests to the `/command` endpoint, but it no longer seems to be necessary (Maze Runner CI failed before the pin and it now passes again without).  `uri` is a [standard gem](https://stdgems.org/uri/) and different versions of Ruby include different versions of it.  Pinning it to a later version was causing issues in the Ruby notifier tests.

## Tests

Covered by CI.