### PR TITLE
Remove reporting of Appium metrics to Datadog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.32.4 - TBD
+
+## Removals
+
+- Remove reporting of Appium metrics to Datadog. [771](https://github.com/bugsnag/maze-runner/pull/771)
+
 # 9.32.3 - 2025/07/23
 
 ## Enhancements

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.32.3'
+  VERSION = '9.32.4'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/hooks/appium_hooks.rb
+++ b/lib/maze/hooks/appium_hooks.rb
@@ -7,7 +7,6 @@ module Maze
       @client
 
       def before_all
-        Maze::Plugins::DatadogMetricsPlugin.send_increment('appium.test_started')
         @client = Maze::Client::Appium.start
       rescue => error
         # Notify and re-raise for Cucumber to handle
@@ -55,12 +54,6 @@ module Maze
       end
 
       def after_all
-        if $success
-          Maze::Plugins::DatadogMetricsPlugin.send_increment('appium.test_succeeded')
-        else
-          Maze::Plugins::DatadogMetricsPlugin.send_increment('appium.test_failed')
-        end
-
         if @client
           @client.log_run_outro
           $logger.info 'Stopping the Appium session'


### PR DESCRIPTION
## Goal

Remove reporting of Appium metrics to Datadog.

## Design

This functionality has now been overtaken by reporting Appium session outcomes to a Bugsnag dashboard.

## Tests

Covered by CI.