### PR TITLE
Set metadata 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 9.32.4 - TBD
+# 9.32.4 - 2025/08/01
+
+## Fixes
+
+- Set metadata token header when retrieving public IP of Docker container [772](https://github.com/bugsnag/maze-runner/pull/772)
 
 ## Removals
 

--- a/lib/maze/aws_public_ip.rb
+++ b/lib/maze/aws_public_ip.rb
@@ -34,7 +34,8 @@ module Maze
     def determine_public_ip
       # 169.254.169.254 is the address of the AWS instance metadata service
       # See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-      `curl --silent -XGET http://169.254.169.254/latest/meta-data/public-ipv4`
+      token = `curl --silent -H "X-aws-ec2-metadata-token-ttl-seconds: 120" -XPUT http://169.254.169.254/latest/api/token`
+      `curl -H "X-aws-ec2-metadata-token: #{token}" --silent -XGET http://169.254.169.254/latest/meta-data/public-ipv4`
     end
 
     # Determines the external port of the running Docker container that's associated with the port given

--- a/lib/maze/plugins/datadog_metrics_plugin.rb
+++ b/lib/maze/plugins/datadog_metrics_plugin.rb
@@ -63,7 +63,8 @@ module Maze
         #
         # @returns [String] The local ipv4 address the Datadog agent is running on
         def aws_instance_ip
-          `curl --silent -XGET http://169.254.169.254/latest/meta-data/local-ipv4`
+          token = `curl --silent -H "X-aws-ec2-metadata-token-ttl-seconds: 120" -XPUT http://169.254.169.254/latest/api/token`
+          `curl -H "X-aws-ec2-metadata-token: #{token}" --silent -XGET http://169.254.169.254/latest/meta-data/local-ipv4`
         end
       end
     end


### PR DESCRIPTION
## Goal

Set metadata token header when retrieving public IP of Docker container.

## Design

Response to an infrastructure change that meant Maze Runner was unable to retrieve the public IP of the running Docker contain, breaking any tests that required it (all of our BitBar CI tests in particular).

## Tests

Core use case is covered by CI, I'll test the DataDog aspect in slower time as the priority is getting CI moving again.