### PR TITLE
Add missing dep for benchmark tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.35.1 - 2025/08/13
+
+## Fixes
+
+- Add missing `datadog_api_client` dependency to Gemspec [778](https://github.com/bugsnag/maze-runner/pull/778)
+
 # 9.35.0 - 2025/08/12
 
 ## Enhancements

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -64,4 +64,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'yard', '~> 0.9.1'
   spec.add_development_dependency 'timecop', '~> 0.9.6'
+
+  # Benchmark to Datadog dependencies
+  spec.add_development_dependency 'datadog_api_client', '~> 2.40.0'
 end

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.35.0'
+  VERSION = '9.35.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

Include the missing dependency in the gem.spec for the `bencmark-to-datadog` tool


