### PR TITLE
Correct dependency on Datadog API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.35.2 - 2025/08/21
+
+## Fixes
+
+- Make Datadog API client dependency not dev-only [779](https://github.com/bugsnag/maze-runner/pull/779)
+
 # 9.35.1 - 2025/08/13
 
 ## Fixes

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
 gem 'yard-cucumber', git: 'https://github.com/bugsnag/yard-cucumber'
-gem 'datadog_api_client'
 
 gemspec

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -64,7 +64,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'yard', '~> 0.9.1'
   spec.add_development_dependency 'timecop', '~> 0.9.6'
-
-  # Benchmark to Datadog dependencies
-  spec.add_development_dependency 'datadog_api_client', '~> 2.40.0'
 end

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bugsnag', '~> 6.24'
   spec.add_dependency 'cucumber-expressions', '~> 6.0.0'
   spec.add_dependency 'curb', '~> 1.0.5'
+  spec.add_dependency 'dogstatsd-ruby', '~> 5.5.0'
   spec.add_dependency 'datadog_api_client', '2.40.0'
   spec.add_dependency 'optimist', '~> 3.0.1'
   spec.add_dependency 'rake', '~> 12.3.3'

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bugsnag', '~> 6.24'
   spec.add_dependency 'cucumber-expressions', '~> 6.0.0'
   spec.add_dependency 'curb', '~> 1.0.5'
-  spec.add_dependency 'dogstatsd-ruby', '~> 5.5.0'
+  spec.add_dependency 'datadog_api_client', '2.40.0'
   spec.add_dependency 'optimist', '~> 3.0.1'
   spec.add_dependency 'rake', '~> 12.3.3'
   spec.add_dependency 'json_schemer', '~> 0.2.24'

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.35.1'
+  VERSION = '9.35.2'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

Correct dependency on Datadog API client.

## Tests

I was able to reproduce the error caused after running `bundle clean` locally.  After the fix I could then run `bundle exec benchmarks-to-datadog` and get the usage output without error.