### PR TITLE
Update environment variables used by datadog metrics utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.35.3 - 2025/08/22
+
+## Fixes
+
+- Update environment variables used by datadog metrics utility [780](https://github.com/bugsnag/maze-runner/pull/780)
+
 # 9.35.2 - 2025/08/21
 
 ## Fixes

--- a/bin/benchmarks-to-datadog
+++ b/bin/benchmarks-to-datadog
@@ -34,19 +34,21 @@ class DatadogMetricsIngester
     end
 
     csv_file = opts[:csv_file]
-    api_key = opts[:api_key] || ENV['DATADOG_API_KEY']
-    app_key = opts[:app_key] || ENV['DATADOG_APP_KEY']
+    api_key = opts[:api_key] || ENV['DD_API_KEY']
+    app_key = opts[:app_key] || ENV['DD_APP_KEY']
 
-    abort_with_help(parser, "CSV file is missing") if csv_file.to_s.empty?
-    abort_with_help(parser, "API key is missing") if api_key.to_s.empty?
-    abort_with_help(parser, "App key is missing") if app_key.to_s.empty?
+    errors = []
+    errors << "CSV file is missing" if csv_file.to_s.empty?
+    errors << "API key is missing" if api_key.to_s.empty?
+    errors << "App key is missing" if app_key.to_s.empty?
+    abort(errors) unless errors.empty?
 
     new(api_key: api_key, app_key: app_key).ingest_csv(csv_file)
   end
 
-  def self.abort_with_help(parser, message)
-    $logger.warn message
-    Optimist::with_standard_exception_handling(parser) { raise Optimist::HelpNeeded }
+  def self.abort(errors)
+    errors.each { |error| $logger.error error }
+    exit 1
   end
 
   def ingest_csv(file_path)

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.35.2'
+  VERSION = '9.35.3'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

Update the environment variables used by the benchmarks datadog entry point to match those in the infrastructure. 

## Design

I considered changing the environment variable names in Ansible, but "DD" rather than "DATADOG" is a widespread convention there and so I thought it best just to change them here.

## Changeset

I've also amended the CL processing logic slightly so that a non-zero exit code is given when options are missing.

## Tests

Tested locally.