### PR TITLE
Minimum Ruby version increased to 3.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -183,6 +183,10 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: 103  # Appium client failure
+          limit: 2
 
   - label: ':browserstack: Firefox'
     depends_on: "push-branch-cli"
@@ -258,6 +262,10 @@ steps:
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: 103  # Appium client failure
+          limit: 2
 
   - label: ':bitbar: Appium API'
     timeout_in_minutes: 20
@@ -290,6 +298,10 @@ steps:
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: 103  # Appium client failure
+          limit: 2
 
   - label: ':bitbar: iOS'
     timeout_in_minutes: 20
@@ -322,6 +334,10 @@ steps:
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: 103  # Appium client failure
+          limit: 2
 
   - wait
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Update to Cucumber 10 [773](https://github.com/bugsnag/maze-runner/pull/773)
+- Minimum Ruby version increased to 3.1 [781](https://github.com/bugsnag/maze-runner/pull/781)
 
 ## Removals
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,6 +19,10 @@ The legacy JSON-WP protocol drivers (using Selenium v3 and Appium v11) are no lo
 | `I send the keys {string} to the element {string}` | None.                                    |
 | `I clear and send the keys {string} to the element {string}` | None.                                    |
 
+# Minimum Ruby version
+
+The minimum supported Ruby version is now 3.1 (due to Cucumber being updated to v10).
+
 ## v8 to v9
 
 ### Clearing app data between test scenarios

--- a/bugsnag-maze-runner.gemspec
+++ b/bugsnag-maze-runner.gemspec
@@ -3,25 +3,19 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require_relative 'lib/maze'
 
 Gem::Specification.new do |spec|
-  ruby_version = Gem::Version.new(RUBY_VERSION.dup)
-
   spec.name    = 'bugsnag-maze-runner'
   spec.version = Maze::VERSION
-  spec.authors = ['Steve Kirkland']
-  spec.email   = ['steve@bugsnag.com']
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.authors = ['Steve Kirkland', 'Josh Edney']
+  spec.email   = ['notifiers@bugsnag.com']
+  spec.required_ruby_version = '>= 3.1'
   spec.description = 'Automation steps and mock server to validate' \
                      'request payloads response.'
-  spec.summary = 'Bugsnag API request validation harness'
+  spec.summary = 'Bugsnag SDK test harness'
   spec.license = 'MIT'
   spec.require_paths = ['lib']
   spec.files = Dir.glob('{bin,lib}/**/*').select { |fn| File.file?(fn) }
 
   spec.executables = spec.files.grep(%r{^bin/[\w\-]+$}) { |f| File.basename(f) }
-
-  if ruby_version < Gem::Version.new('3.0.0')
-    spec.add_dependency 'ffi', '1.16.3'
-  end
 
   spec.add_dependency 'cucumber', '~> 10.0'
   spec.add_dependency 'os', '~> 1.0.0'

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '9.35.3'
+  VERSION = '10.0.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

Minimum Ruby version increased to 3.1 (due to Cucumber upgrade to v10).

## Changeset

Also a few other minor unrelated changes.

## Tests

Covered by CI.