### PR TITLE
Downgrade Ruby to avoid repetitive frozen string literal warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v10.1.1 - TBD
+
+## Fixes
+
+- Downgrade Ruby in published Docker image to 3.3 to avoid repetitive frozen string literal warnings [788](https://github.com/bugsnag/maze-runner/pull/788)
+
 # v10.1.0 - 2025/09/02
 
 ## Enhancements

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Ruby image are based on Debian
-FROM ruby:3.4-bullseye as ci
+FROM ruby:3.3-bullseye as ci
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     apt-get install -y apt-utils wget unzip bash bundler \

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '10.1.0'
+  VERSION = '10.1.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

Downgrade Ruby in the published Docker image to avoid repetitive frozen string literal warnings like this:

```
/usr/local/bundle/gems/rubyzip-2.3.2/lib/zip/ioextras.rb:9: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

## Design

An alternative approach might have been to upgrade our dependency on`rubyzip` to 3.0, but `selenium-webriver` (a sub-dependency) places a constraint of `< 3.0` on it and there is not yet a version of `appium_lib_core` that depends on a version without it. 

## Tests

Covered by CI - checking that the warnings are no longer shown at the end of each run in a Docker container.