### PR TITLE
Avoid deprecated devices and add iOS 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Enhancements
 
 - Add test support for Bugsnag remote config [793](https://github.com/bugsnag/maze-runner/pull/793)
-- Avoid latest round of deprecated BrowserStack devices [794](https://github.com/bugsnag/maze-runner/pull/794)
+- Avoid latest round of deprecated BrowserStack devices and add iOS 26 [794](https://github.com/bugsnag/maze-runner/pull/794)
 
 # v10.2.0 - 2025/09/12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Add test support for Bugsnag remote config [793](https://github.com/bugsnag/maze-runner/pull/793)
+- Avoid latest round of deprecated BrowserStack devices [794](https://github.com/bugsnag/maze-runner/pull/794)
 
 # v10.2.0 - 2025/09/12
 

--- a/lib/maze/client/appium/bs_devices.rb
+++ b/lib/maze/client/appium/bs_devices.rb
@@ -82,6 +82,7 @@ module Maze
               'ANDROID_8' => make_android_hash('Samsung Galaxy Note 9', '8.1'),
 
               # iOS devices
+              'IOS_26' => make_ios_hash('iPhone 15', '26'),
               'IOS_18' => make_ios_hash('iPhone 14', '18'),
               'IOS_17' => make_ios_hash('iPhone 15', '17'),
               'IOS_16' => make_ios_hash('iPhone 14', '16'),

--- a/lib/maze/client/appium/bs_devices.rb
+++ b/lib/maze/client/appium/bs_devices.rb
@@ -77,9 +77,9 @@ module Maze
               'ANDROID_13' => make_android_hash('Google Pixel 6 Pro', '13.0'),
               'ANDROID_12' => make_android_hash('Google Pixel 6', '12.0'),
               'ANDROID_11' => make_android_hash('Samsung Galaxy S21', '11.0'),
-              'ANDROID_10' => make_android_hash('Google Pixel 4 XL', '10.0'),
-              'ANDROID_9' => make_android_hash('Google Pixel 3', '9.0'),
-              'ANDROID_8' => make_android_hash('Samsung Galaxy S9', '8.0'),
+              'ANDROID_10' => make_android_hash('Samsung Galaxy S20', '10.0'),
+              'ANDROID_9' => make_android_hash('Samsung Galaxy S10', '9.0'),
+              'ANDROID_8' => make_android_hash('Samsung Galaxy Note 9', '8.1'),
 
               # iOS devices
               'IOS_18' => make_ios_hash('iPhone 14', '18'),
@@ -88,7 +88,7 @@ module Maze
               'IOS_15' => make_ios_hash('iPhone 13', '15'),
               'IOS_14' => make_ios_hash('iPhone 12', '14'),
               'IOS_13' => make_ios_hash('iPhone 11', '13'),
-              'IOS_12' => make_ios_hash('iPhone XS', '12'),
+              'IOS_12' => make_ios_hash('iPad Pro 12.9 2018', '12'),
             }
 
             # Specific Android devices


### PR DESCRIPTION
## Goal

Avoid the latest round of deprecated BrowserStack devices whilst adding iOS 26.

## Tests

Tested locally that each device name changed/added works.