### PR TITLE
Auto-unfold undefined scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v10.3.1 - 2025/09/18
+
+## Fixes
+
+- Unfold `undefined` scenarios on Buildkite [795](https://github.com/bugsnag/maze-runner/pull/795)
+
 # v10.3.0 - 2025/09/17
 
 ## Enhancements

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       args:
         BRANCH_NAME:
     environment:
+      <<: *common-environment
       MAZE_BUGSNAG_API_KEY:
 
   comparison-tests:
@@ -84,6 +85,7 @@ services:
       args:
         BRANCH_NAME:
     environment:
+      <<: *common-environment
       MAZE_BUGSNAG_API_KEY:
 
   doc-server-tests:
@@ -92,6 +94,7 @@ services:
       args:
         BRANCH_NAME:
     environment:
+      <<: *common-environment
       MAZE_BUGSNAG_API_KEY:
 
   exit-codes-tests:
@@ -100,6 +103,7 @@ services:
       args:
         BRANCH_NAME:
     environment:
+      <<: *common-environment
       MAZE_BUGSNAG_API_KEY:
 
   framework-tests:
@@ -108,6 +112,7 @@ services:
       args:
         BRANCH_NAME:
     environment:
+      <<: *common-environment
       MAZE_BUGSNAG_API_KEY:
 
   docker-tests:
@@ -116,6 +121,7 @@ services:
       args:
         BRANCH_NAME:
     environment:
+      <<: *common-environment
       MAZE_BUGSNAG_API_KEY:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -126,6 +132,7 @@ services:
       args:
         BRANCH_NAME:
     environment:
+      <<: *common-environment
       MAZE_BUGSNAG_API_KEY:
 
   payload-helper-tests:
@@ -134,6 +141,7 @@ services:
       args:
         BRANCH_NAME:
     environment:
+      <<: *common-environment
       MAZE_BUGSNAG_API_KEY:
     volumes:
       - ./test/e2e/payload-helpers/maze_output:/app/maze_output
@@ -144,6 +152,7 @@ services:
       args:
         BRANCH_NAME:
     environment:
+      <<: *common-environment
       MAZE_BUGSNAG_API_KEY:
     volumes:
       - ./test/e2e/command-workflow/maze_output:/app/maze_output
@@ -154,6 +163,7 @@ services:
       args:
         BRANCH_NAME:
     environment:
+      <<: *common-environment
       MAZE_BUGSNAG_API_KEY:
 
   unit-test:

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -154,7 +154,7 @@ After do |scenario|
   Maze::Proxy.instance.stop
 
   # Unfold the previous scenario on Buildkite if it failed or had undefined steps
-  $stdout.puts '^^^ +++' if ENV['BUILDKITE'] && (scenario.failed? || scenario.status == :undefined?)
+  $stdout.puts '^^^ +++' if ENV['BUILDKITE'] && (scenario.failed? || scenario.status == :undefined)
 
   # Log all received requests to the console if the scenario fails and/or config says to
   if (scenario.failed? && Maze.config.log_requests) || Maze.config.always_log

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -153,9 +153,11 @@ After do |scenario|
 
   Maze::Proxy.instance.stop
 
+  # Unfold the previous scenario on Buildkite if it failed or had undefined steps
+  $stdout.puts '^^^ +++' if ENV['BUILDKITE'] && (scenario.failed? || scenario.status == :undefined?)
+
   # Log all received requests to the console if the scenario fails and/or config says to
   if (scenario.failed? && Maze.config.log_requests) || Maze.config.always_log
-    $stdout.puts '^^^ +++' if ENV['BUILDKITE']
     output_received_requests('errors')
     output_received_requests('error config requests')
     output_received_requests('sessions')

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '10.3.0'
+  VERSION = '10.3.1'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,


### PR DESCRIPTION
## Goal

If a scenario contains undefined Cucumber steps it end with a status of `undefined` (which is not included in the criteria for `failed?`).  Although the test run will fail overall (because we inject the `--strict` option into Cucumber), any `undefined` scenarios were not being unfolded automatically in the Buildkite UI - making it easy to miss why the run failed.

This change outputs the special string (`^^^ +++`) for undefined scenarios, needed for Buildkite to unfold the relevant section of console output.

## Changeset

I've also allow the common environment variables into all docker containers used by the pipeline in order that they can all be Buildkite--aware.

## Tests

Tested by forcing a test run with failed and undefined scenaros:
https://buildkite.com/bugsnag/maze-runner/builds/4844/steps/canvas?sid=01995c84-fdd9-4326-bf2c-a7c481d570e8