### PR TITLE
Stop using BitBar deviceGroupId capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add test support for Bugsnag remote config [793](https://github.com/bugsnag/maze-runner/pull/793)
 - Avoid latest round of deprecated BrowserStack devices and add iOS 26 [794](https://github.com/bugsnag/maze-runner/pull/794)
+- Add `name`, `location` and `tags` to interface of `Maze.scenario [795](https://github.com/bugsnag/maze-runner/pull/795)
 
 # v10.2.0 - 2025/09/12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# v10.3.1 - 2025/09/18
+# v10.3.1 - 2025/09/19
 
 ## Fixes
 
 - Unfold `undefined` scenarios on Buildkite [795](https://github.com/bugsnag/maze-runner/pull/795)
+- Stop using BitBar `deviceGroupId` capability [796](https://github.com/bugsnag/maze-runner/pull/796)
 
 # v10.3.0 - 2025/09/17
 

--- a/lib/maze/api/cucumber/scenario.rb
+++ b/lib/maze/api/cucumber/scenario.rb
@@ -11,6 +11,18 @@ module Maze
           @fail_override_reason = nil
         end
 
+        def name
+          @scenario.name
+        end
+
+        def location
+          @scenario.location
+        end
+
+        def tags
+          @scenario.tags
+        end
+
         def mark_as_failed(reason)
           @fail_override = true
           @fail_override_reason = reason

--- a/lib/maze/client/appium/bb_devices.rb
+++ b/lib/maze/client/appium/bb_devices.rb
@@ -18,19 +18,11 @@ module Maze
             if device_group_ids
               # Device group found - find a free device in it
               $logger.trace "Got group ids #{device_group_ids} for #{device_or_group_names}"
-              if device_group_ids.size > 1
-                group_id = false
-                group_count, device = api_client.find_device_in_groups(device_group_ids)
-                if device.nil?
-                  raise 'There are no devices available'
-                else
-                  $logger.info "#{group_count} device(s) currently available in group(s) '#{device_or_group_names}'"
-                end
+              group_count, device = api_client.find_device_in_groups(device_group_ids)
+              if device.nil?
+                raise 'There are no devices available'
               else
-                # Since there is only one group, we can use it verbatim
-                $logger.info "Using device group #{device_or_group_names}"
-                group_id = true
-                device_name = device_group_ids.first
+                $logger.info "#{group_count} device(s) currently available in group(s) '#{device_or_group_names}'"
               end
             else
               # See if there is a device with the given name
@@ -64,9 +56,9 @@ module Maze
 
             case platform
             when 'android'
-              make_android_hash(device_name, group_id)
+              make_android_hash(device_name)
             when 'ios'
-              make_ios_hash(device_name, group_id)
+              make_ios_hash(device_name)
             else
               throw "Invalid device platform specified #{platform}"
             end


### PR DESCRIPTION
## Goal

Stop using the `deviceGroupId` capability as it no longer consistently provides an available device.

## Design

I've simply removed the `if device_group_ids.size > 1` guard and what was its `else` branch, meaning that we will always query the API for an available device within that group.  Although we might lose a race with another Maze Runner istance, we have retry logic for that and overall it will be more reliable and within our control.

## Tests

A Buildkite job that needed ANDROID_8 failed to get an available device with.the previous version of MR (using the capability).  Seconds later I ran this branch locally and it obtained a device on the first attempt.