### PR TITLE
Remote config support corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## Fixes
 
-- Remote config support corrections [797](https://github.com/bugsnag/maze-runner/pull/797)
+- Remote config support corrections [798](https://github.com/bugsnag/maze-runner/pull/798)
 
 # v10.3.1 - 2025/09/19
 
 ## Fixes
 
-- Unfold `undefined` scenarios on Buildkite [795](https://github.com/bugsnag/maze-runner/pull/795)
-- Stop using BitBar `deviceGroupId` capability [796](https://github.com/bugsnag/maze-runner/pull/796)
+- Unfold `undefined` scenarios on Buildkite [796](https://github.com/bugsnag/maze-runner/pull/796)
+- Stop using BitBar `deviceGroupId` capability [797](https://github.com/bugsnag/maze-runner/pull/797)
 
 # v10.3.0 - 2025/09/17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v10.3.2 - 2025/09/29
+
+## Fixes
+
+- Remote config support corrections [797](https://github.com/bugsnag/maze-runner/pull/797)
+
 # v10.3.1 - 2025/09/19
 
 ## Fixes

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '10.3.1'
+  VERSION = '10.3.2'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/server.rb
+++ b/lib/maze/server.rb
@@ -316,6 +316,8 @@ module Maze
         # Clear request lists
         commands.clear
         errors.clear
+        error_configs.clear
+        error_config_requests.clear
         sessions.clear
         builds.clear
         uploads.clear

--- a/lib/maze/servlets/error_config_servlet.rb
+++ b/lib/maze/servlets/error_config_servlet.rb
@@ -28,7 +28,7 @@ module Maze
             response.header[key] = value
           end
           response.body = error_config[:body]
-          response.status = 200
+          response.status = error_config[:status]
 
           Server.error_configs.next
         else

--- a/test/e2e/comparison/features/error_config.feature
+++ b/test/e2e/comparison/features/error_config.feature
@@ -3,9 +3,9 @@ Feature: Error config requests and responses
   Scenario: Basic handling of error-config request
     When I prepare an error config with:
       | type     | name           | value                               |
-      | header   | Cache-Control  | max-age=604800                      |
+      | header   | Cache-Control  | max-age=222                         |
       | property | body           | @features/support/error_config.json |
-      | property | status         | 200                                 |
+      | property | status         | 500                                 |
     And I request an "android" type error config and store the response
     And I wait for 1 error config to be requested
 
@@ -15,7 +15,28 @@ Feature: Error config requests and responses
     And the error config request "releaseStage" query parameter equals "production"
     And the error config request "osVersion" query parameter equals "11"
 
-    And the stored error config status code equals "200"
+    And the stored error config status code equals "500"
     And the stored error config body matches the contents of "features/support/error_config.json"
-    And the stored error config "Cache-Control" header equals "max-age=604800"
+    And the stored error config "Cache-Control" header equals "max-age=222"
+    And the stored error config "Etag" header equals "43ec7d2b971daba752e9546da4e1dca8094107e0"
+
+  # This scenario ensures that error config state is not leaked between scenarios
+  Scenario: Ensure error-config request lists are cleared between scenarios
+    When I prepare an error config with:
+      | type     | name           | value                               |
+      | header   | Cache-Control  | max-age=333                         |
+      | property | body           | @features/support/error_config.json |
+      | property | status         | 400                                 |
+    And I request an "ios" type error config and store the response
+    And I wait for 1 error config to be requested
+
+    Then the error config request "Bugsnag-Api-Key" header equals "12312312312312312312312312312312"
+    And the error config request "version" query parameter equals "3.2.1"
+    And the error config request "bundleVersion" query parameter equals "321"
+    And the error config request "releaseStage" query parameter equals "development"
+    And the error config request "osVersion" query parameter equals "15"
+
+    And the stored error config status code equals "400"
+    And the stored error config body matches the contents of "features/support/error_config.json"
+    And the stored error config "Cache-Control" header equals "max-age=333"
     And the stored error config "Etag" header equals "43ec7d2b971daba752e9546da4e1dca8094107e0"

--- a/test/e2e/comparison/features/support/get_request.rb
+++ b/test/e2e/comparison/features/support/get_request.rb
@@ -7,7 +7,7 @@ def get_error_config(request_type)
   when 'android'
     { :version => '1.2.3', :versionCode => '123', :releaseStage => 'production', :osVersion => '11' }
   when 'ios'
-    { :version => '3.2.1', :bundleVersion => '321', :releaseStage => 'production', :osVersion => '15' }
+    { :version => '3.2.1', :bundleVersion => '321', :releaseStage => 'development', :osVersion => '15' }
   else
     $logger.error("Unknown request type '#{request_type}'")
     exit(1)


### PR DESCRIPTION
## Goal

Corrects a couple of minor but crucial error in the support for Remote Config testing.

## Changeset

- Error config response status should not have been hard-coded.
- Error config lists should be cleared between scenarios.

I've also corrected a couple of PR numbers in the changelog that were wrong in previous PRs.

## Tests

e2e tests added and updated - these fail without the fixes in this PR.