### PR TITLE
Add step to store fields from named spans

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -163,7 +163,9 @@ steps:
     plugins:
       artifacts#v1.9.0:
         download: "bugsnag-cocoa/features/fixtures/ios/output/iOSTestApp_Release.ipa"
-        upload: "bugsnag-cocoa/maze_output/**/*"
+        upload:
+          - "bugsnag-cocoa/maze_output/failed/*"
+          - "bugsnag-cocoa/maze_output/maze_output.zip"
       docker-compose#v4.14.0:
         pull: appium-test-bs
         run: appium-test-bs
@@ -214,7 +216,9 @@ steps:
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.9.0:
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.14.0:
         pull: browser-tests-bitbar
         run: browser-tests-bitbar
@@ -238,7 +242,9 @@ steps:
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.9.0:
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.14.0:
         pull: browser-tests-bitbar
         run: browser-tests-bitbar
@@ -264,7 +270,9 @@ steps:
     plugins:
       artifacts#v1.9.0:
         download: "bugsnag-android-performance/build/test-fixture.apk"
-        upload: "bugsnag-android-performance/maze_output/**/*"
+        upload:
+          - "bugsnag-android-performance/maze_output/**/*"
+          - "bugsnag-android-performance/maze_output/maze_output.zip"
       docker-compose#v4.14.0:
         pull: appium-test-bb
         run: appium-test-bb
@@ -301,7 +309,9 @@ steps:
         download:
           - from: "bugsnag-android-performance/build/test-fixture.apk"
             to: "./test/e2e/appium-api/build/test-fixture.apk"
-        upload: "test/e2e/appium-api/maze_output/**/*"
+        upload:
+          - "test/e2e/appium-api/maze_output/failed/*"
+          - "test/e2e/appium-api/maze_output/maze_output.zip"
       docker-compose#v4.14.0:
         pull: appium-test-bb
         run: appium-test-bb
@@ -335,7 +345,9 @@ steps:
     plugins:
       artifacts#v1.9.0:
         download: "bugsnag-cocoa/features/fixtures/ios/output/iOSTestApp_Release.ipa"
-        upload: "bugsnag-cocoa/maze_output/**/*"
+        upload:
+          - "bugsnag-cocoa/maze_output/failed/*"
+          - "bugsnag-cocoa/maze_output/maze_output.zip"
       docker-compose#v4.14.0:
         pull: appium-test-bb
         run: appium-test-bb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# v10.6.0 - TBD
+# v10.6.0 - 2025/10/24
 
 ## Enhancements
 
-- Add step to store properties of named spans [805](https://github.com/bugsnag/maze-runner/pull/805)
+- Add step to store fields of named spans [805](https://github.com/bugsnag/maze-runner/pull/805)
 
 ## Refactor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v10.6.0 - TBD
 
+## Enhancements
+
+- Add step to store properties of named spans [805](https://github.com/bugsnag/maze-runner/pull/805)
+
 ## Refactor
 
 - Split trace and span step definition into separate files [804](https://github.com/bugsnag/maze-runner/pull/804)

--- a/lib/features/steps/span_steps.rb
+++ b/lib/features/steps/span_steps.rb
@@ -10,7 +10,7 @@ end
 #
 # @step_input span_count [Integer] The number of spans to wait for
 Then('I wait to receive {int} span(s)') do |span_count|
-  assert_received_span_count Maze::Server.list_for('traces'), span_count
+  assert_received_span_count Maze::Server.traces, span_count
 end
 
 # Waits for a minimum number of spans to be received, which may be spread across one or more trace requests.
@@ -18,7 +18,7 @@ end
 #
 # @step_input span_min [Integer] The minimum number of spans to wait for
 Then('I wait to receive at least {int} span(s)') do |span_min|
-  assert_received_minimum_span_count Maze::Server.list_for('traces'), span_min
+  assert_received_minimum_span_count Maze::Server.traces, span_min
 end
 
 # Waits for a minimum number of spans to be received, which may be spread across one or more trace requests.
@@ -27,94 +27,91 @@ end
 # @step_input span_min [Integer] The minimum number of spans to wait for
 # @step_input span_max [Integer] The maximum number of spans to receive before failure
 Then('I wait to receive between {int} and {int} span(s)') do |span_min, span_max|
-  assert_received_ranged_span_count Maze::Server.list_for('traces'), span_min, span_max
+  assert_received_ranged_span_count Maze::Server.traces, span_min, span_max
 end
 
 Then('I should have received no spans') do
   sleep Maze.config.receive_no_requests_wait
-  Maze.check.equal spans_from_request_list(Maze::Server.list_for('traces')).size, 0
+  Maze.check.equal SpanSupport.spans_from_request_list(Maze::Server.traces).size, 0
 end
 
 Then('a span {word} equals {string}') do |attribute, expected|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   selected_attributes = spans.map { |span| span[attribute] }
   Maze.check.includes selected_attributes, expected
 end
 
 Then('every span field {string} equals {string}') do |key, expected|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   selected_keys = spans.map { |span| span[key] == expected }
   Maze.check.not_includes selected_keys, false
 end
 
 Then('every span field {string} matches the regex {string}') do |key, pattern|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   spans.map { |span| Maze.check.match pattern, span[key] }
 end
 
 Then('every span string attribute {string} exists') do |attribute|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   spans.map { |span| Maze.check.not_nil span['attributes'].find { |a| a['key'] == attribute }['value']['stringValue'] }
 end
 
 Then('every span string attribute {string} equals {string}') do |attribute, expected|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   spans.map { |span| Maze.check.equal expected, span['attributes'].find { |a| a['key'] == attribute }['value']['stringValue'] }
 end
 
 Then('every span string attribute {string} matches the regex {string}') do |attribute, pattern|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   spans.map { |span| Maze.check.match pattern, span['attributes'].find { |a| a['key'] == attribute }['value']['stringValue'] }
 end
 
 Then('every span integer attribute {string} is greater than {int}') do |attribute, expected|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   spans.map { |span| Maze::check.true span['attributes'].find { |a| a['key'] == attribute }['value']['intValue'].to_i > expected }
 end
 
 Then('every span bool attribute {string} is true') do |attribute|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   spans.map { |span| Maze::check.true span['attributes'].find { |a| a['key'] == attribute }['value']['boolValue'] }
 end
 
 Then('a span string attribute {string} exists') do |attribute|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('stringValue') } }.compact
   Maze.check.false(selected_attributes.empty?)
 end
 
 Then('a span string attribute {string} equals {string}') do |attribute, expected|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('stringValue') } }.compact
   attribute_values = selected_attributes.map { |a| a['value']['stringValue'] }
   Maze.check.includes attribute_values, expected
 end
 
 Then('a span field {string} equals {string}') do |key, expected|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   selected_keys = spans.map { |span| span[key] }
   Maze.check.includes selected_keys, expected
 end
 
 Then('a span field {string} equals {int}') do |key, expected|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   selected_keys = spans.map { |span| span[key] }
   Maze.check.includes selected_keys, expected
 end
 
 Then('a span field {string} matches the regex {string}') do |attribute, pattern|
   regex = Regexp.new pattern
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   selected_attributes = spans.select { |span| regex.match? span[attribute] }
 
   Maze.check.false(selected_attributes.empty?)
 end
 
 Then('a span named {string} contains the attributes:') do |span_name, table|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
-  named_spans = spans.find_all { |span| span['name'].eql?(span_name) }
-  raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{span_name}" if named_spans.empty?
-
+  named_spans = SpanSupport.get_named_spans(span_name)
   expected_attributes = table.hashes
 
   match = false
@@ -135,7 +132,7 @@ Then('a span named {string} contains the attributes:') do |span_name, table|
 end
 
 Then('a span named {string} has a parent named {string}') do |child_name, parent_name|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
   child_spans = spans.find_all { |span| span['name'].eql?(child_name) }
   raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{child_name}" if child_spans.empty?
   parent_spans = spans.find_all { |span| span['name'].eql?(parent_name) }
@@ -151,14 +148,11 @@ Then('a span named {string} has a parent named {string}') do |child_name, parent
 end
 
 Then('a span named {string} has the following properties:') do |span_name, table|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
-  found_spans = spans.find_all { |span| span['name'].eql?(span_name) }
-  raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{span_name}" if found_spans.empty?
-
+  named_spans = SpanSupport.get_named_spans(span_name)
   expected_properties = table.hashes
 
   match = false
-  found_spans.each do |span|
+  named_spans.each do |span|
     matches = expected_properties.map do |expected_property|
       property = Maze::Helper.read_key_path(span, expected_property['property'])
       expected_property['value'].eql?(property.to_s)
@@ -194,8 +188,8 @@ def assert_received_spans(list, min_received, max_received = nil)
   timeout = Maze.config.receive_requests_wait
   wait = Maze::Wait.new(timeout: timeout)
 
-  received = wait.until { spans_from_request_list(list).size >= min_received }
-  received_count = spans_from_request_list(list).size
+  received = wait.until { SpanSupport.spans_from_request_list(list).size >= min_received }
+  received_count = SpanSupport.spans_from_request_list(list).size
 
   unless received
     raise Test::Unit::AssertionFailedError.new <<-MESSAGE
@@ -212,12 +206,4 @@ def assert_received_spans(list, min_received, max_received = nil)
   Maze.check.operator(max_received, :>=, received_count, "#{received_count} spans received") if max_received
 
   Maze::Schemas::Validator.validate_payload_elements(list, 'trace')
-end
-
-def spans_from_request_list list
-  list.remaining
-      .flat_map { |req| req[:body]['resourceSpans'] }
-      .flat_map { |r| r['scopeSpans'] }
-      .flat_map { |s| s['spans'] }
-      .select { |s| !s.nil? }
 end

--- a/lib/features/steps/span_steps.rb
+++ b/lib/features/steps/span_steps.rb
@@ -174,6 +174,10 @@ Then('a span named {string} has the following properties:') do |span_name, table
   end
 end
 
+Then('the {string} field of the span named {string} is stored as the value {string}') do |field, span_name, store_key|
+
+end
+
 def assert_received_span_count(list, count)
   assert_received_spans(list, count, count)
 end
@@ -211,9 +215,9 @@ def assert_received_spans(list, min_received, max_received = nil)
 end
 
 def spans_from_request_list list
-  return list.remaining
-             .flat_map { |req| req[:body]['resourceSpans'] }
-             .flat_map { |r| r['scopeSpans'] }
-             .flat_map { |s| s['spans'] }
-             .select { |s| !s.nil? }
+  list.remaining
+      .flat_map { |req| req[:body]['resourceSpans'] }
+      .flat_map { |r| r['scopeSpans'] }
+      .flat_map { |s| s['spans'] }
+      .select { |s| !s.nil? }
 end

--- a/lib/features/steps/span_steps.rb
+++ b/lib/features/steps/span_steps.rb
@@ -169,7 +169,7 @@ Then('a span named {string} has the following properties:') do |span_name, table
 end
 
 Then('the {string} field of the span named {string} is stored as the value {string}') do |field, span_name, store_key|
-  SpanSupport.store_span_field_as_value(field, span_name, store_key)
+  SpanSupport.store_named_span_field(span_name, field, store_key)
 end
 
 

--- a/lib/features/steps/value_steps.rb
+++ b/lib/features/steps/value_steps.rb
@@ -69,6 +69,11 @@ Then('the {request_type} payload field {string} does not equal the stored value 
   Maze.check.false(result.equal?, "Payload value: #{payload_value} equals stored value: #{stored_value}")
 end
 
+Then('the stored value {string} equals {string}') do |key, value|
+  stored_value = Maze::Store.values[key]
+  Maze.check.equal(value, stored_value)
+end
+
 # Tests whether a payload field is a number (Numeric according to Ruby)
 #
 # @step_input request_type [String] The type of request (error, session, build, etc)

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -292,7 +292,7 @@ AfterAll do
     Maze.timers.report
   end
 
-  $stdout.puts '+++ All scenarios complete'
+  $stdout.puts '+++ Test run complete'
 
   # Stop the mock server
   Maze::Server.stop

--- a/lib/features/support/span_support.rb
+++ b/lib/features/support/span_support.rb
@@ -12,6 +12,7 @@ class SpanSupport
       spans = spans_from_request_list(Maze::Server.traces)
       named_spans = spans.find_all { |span| span['name'].eql?(span_name) }
       raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{span_name}" if named_spans.empty?
+      named_spans
     end
   end
 end

--- a/lib/features/support/span_support.rb
+++ b/lib/features/support/span_support.rb
@@ -1,0 +1,11 @@
+class SpanSupport
+  class << self
+
+
+    spans = spans_from_request_list(Maze::Server.list_for('traces'))
+    found_spans = spans.find_all { |span| span['name'].eql?(span_name) }
+    raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{span_name}" if found_spans.empty?
+
+
+  end
+end

--- a/lib/features/support/span_support.rb
+++ b/lib/features/support/span_support.rb
@@ -50,5 +50,14 @@ MESSAGE
 
       Maze::Schemas::Validator.validate_payload_elements(list, 'trace')
     end
+
+    def store_named_span_field(span_name, field, store_key)
+      spans = SpanSupport.get_named_spans(span_name)
+      values = spans.map { |span| span[field] }.compact
+      raise Test::Unit::AssertionFailedError.new "Expected 1 span named #{span_name}, found #{values.size}" unless values.size == 1
+
+      value = Maze::Helper.read_key_path(spans[0], field)
+      Maze::Store.values[store_key] = value.dup
+    end
   end
 end

--- a/lib/features/support/span_support.rb
+++ b/lib/features/support/span_support.rb
@@ -1,11 +1,17 @@
 class SpanSupport
   class << self
+    def spans_from_request_list(list)
+      list.remaining
+          .flat_map { |req| req[:body]['resourceSpans'] }
+          .flat_map { |r| r['scopeSpans'] }
+          .flat_map { |s| s['spans'] }
+          .select { |s| !s.nil? }
+    end
 
-
-    spans = spans_from_request_list(Maze::Server.list_for('traces'))
-    found_spans = spans.find_all { |span| span['name'].eql?(span_name) }
-    raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{span_name}" if found_spans.empty?
-
-
+    def get_named_spans(span_name)
+      spans = spans_from_request_list(Maze::Server.traces)
+      named_spans = spans.find_all { |span| span['name'].eql?(span_name) }
+      raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{span_name}" if named_spans.empty?
+    end
   end
 end

--- a/lib/features/support/span_support.rb
+++ b/lib/features/support/span_support.rb
@@ -14,5 +14,41 @@ class SpanSupport
       raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{span_name}" if named_spans.empty?
       named_spans
     end
+
+    def assert_received_span_count(list, count)
+      assert_received_spans(list, count, count)
+    end
+
+    def assert_received_minimum_span_count(list, minimum)
+      assert_received_spans(list, minimum)
+    end
+
+    def assert_received_ranged_span_count(list, minimum, maximum)
+      assert_received_spans(list, minimum, maximum)
+    end
+
+    def assert_received_spans(list, min_received, max_received = nil)
+      timeout = Maze.config.receive_requests_wait
+      wait = Maze::Wait.new(timeout: timeout)
+
+      received = wait.until { SpanSupport.spans_from_request_list(list).size >= min_received }
+      received_count = SpanSupport.spans_from_request_list(list).size
+
+      unless received
+        raise Test::Unit::AssertionFailedError.new <<-MESSAGE
+Expected #{min_received} spans but received #{received_count} within the #{timeout}s timeout.
+This could indicate that:
+- Bugsnag crashed with a fatal error.
+- Bugsnag did not make the requests that it should have done.
+- The requests were made, but not deemed to be valid (e.g. missing integrity header).
+- The requests made were prevented from being received due to a network or other infrastructure issue.
+Please check the Maze Runner and device logs to confirm.)
+MESSAGE
+      end
+
+      Maze.check.operator(max_received, :>=, received_count, "#{received_count} spans received") if max_received
+
+      Maze::Schemas::Validator.validate_payload_elements(list, 'trace')
+    end
   end
 end

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '10.5.0'
+  VERSION = '10.6.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/test/e2e/payload-helpers/features/span_support.feature
+++ b/test/e2e/payload-helpers/features/span_support.feature
@@ -1,7 +1,8 @@
 Feature: Testing support for span receipt and interrogation
 
     Scenario: An exact amount of spans
-        When I send a span request with 3 spans
+        When I should have received no spans
+        And I send a span request with 3 spans
         Then I wait to receive 3 spans
 
     Scenario: An exact amount of spans across payloads

--- a/test/e2e/payload-helpers/features/span_support.feature
+++ b/test/e2e/payload-helpers/features/span_support.feature
@@ -58,9 +58,11 @@ Feature: Testing support for span receipt and interrogation
     Scenario: Spans can be tested for specific properties
         When I send a span request with 1 spans
         Then I wait to receive 1 span
+        Then the "spanId" field of the span named "AppStart\134/Cold" is stored as the value "spanId"
         Then a span named "AppStart\134/Cold" has the following properties:
             | property                       | value              |
             | kind                           | 1                  |
             | spanId                         | 7af51275a21aa300   |
             | attributes.0.key               | bugsnag.sampling.p |
             | attributes.3.value.stringValue | wifi               |
+        And the stored value "spanId" equals "7af51275a21aa300"

--- a/test/unit/features/support/span_support_test.rb
+++ b/test/unit/features/support/span_support_test.rb
@@ -1,14 +1,31 @@
 # frozen_string_literal: true
-
+require 'json'
+require 'ostruct'
+require_relative '../../../../lib/maze/server'
 require_relative '../../../../lib/features/support/span_support'
 require_relative '../../test_helper'
 
 class SpanSupportTest < Test::Unit::TestCase
 
   def setup
+    Maze.scenario = OpenStruct.new(name: 'scenario_name', location: 'scenario_location')
   end
 
-  def test_1
-    SpanSupport
+  def test_spans_from_request_list
+    trace = load_hash_from_json_file('test/unit/features/support/span_support_test_data/instrumentation_spans.json')
+    add_trace_to_request_list(trace)
+    spans = SpanSupport.spans_from_request_list(Maze::Server.traces)
+
+    assert_equal(10, spans.size)
+    assert_equal('[AppStartPhase/Framework]', spans[0]['name'])
+    assert_equal('[ViewLoadPhase/ActivityCreate]SplashScreenActivity', spans[1]['name'])
+    assert_equal('[ViewLoadPhase/ActivityStart]SplashScreenActivity', spans[2]['name'])
+    assert_equal('[ViewLoadPhase/ActivityResume]SplashScreenActivity', spans[3]['name'])
+    assert_equal('[ViewLoadPhase/ActivityCreate]MainActivity', spans[4]['name'])
+    assert_equal('[ViewLoadPhase/ActivityStart]MainActivity', spans[5]['name'])
+    assert_equal('[ViewLoadPhase/ActivityResume]MainActivity', spans[6]['name'])
+    assert_equal('[ViewLoad/Activity]SplashScreenActivity', spans[7]['name'])
+    assert_equal('[AppStart/AndroidCold]SplashScreen', spans[8]['name'])
+    assert_equal('[ViewLoad/Activity]MainActivity', spans[9]['name'])
   end
 end

--- a/test/unit/features/support/span_support_test.rb
+++ b/test/unit/features/support/span_support_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../../../../lib/features/support/span_support'
+require_relative '../../test_helper'
+
+class SpanSupportTest < Test::Unit::TestCase
+
+  def setup
+  end
+
+  def test_1
+    SpanSupport
+  end
+end

--- a/test/unit/features/support/span_support_test.rb
+++ b/test/unit/features/support/span_support_test.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 require 'json'
 require 'ostruct'
+require_relative '../../../../lib/maze/helper'
 require_relative '../../../../lib/maze/server'
+require_relative '../../../../lib/maze/store'
 require_relative '../../../../lib/features/support/span_support'
 require_relative '../../test_helper'
 
 class SpanSupportTest < Test::Unit::TestCase
 
   def setup
+    Maze::Server.traces.clear
     Maze.scenario = OpenStruct.new(name: 'scenario_name', location: 'scenario_location')
   end
 
@@ -27,5 +30,27 @@ class SpanSupportTest < Test::Unit::TestCase
     assert_equal('[ViewLoad/Activity]SplashScreenActivity', spans[7]['name'])
     assert_equal('[AppStart/AndroidCold]SplashScreen', spans[8]['name'])
     assert_equal('[ViewLoad/Activity]MainActivity', spans[9]['name'])
+  end
+
+  def test_store_named_span_field_success
+    trace = load_hash_from_json_file('test/unit/features/support/span_support_test_data/instrumentation_spans.json')
+    add_trace_to_request_list(trace)
+
+    name = '[ViewLoadPhase/ActivityResume]SplashScreenActivity'
+    SpanSupport.store_named_span_field(name, 'spanId', 'spanId')
+
+    assert_equal('c8c29cec3976becf', Maze::Store.values['spanId'])
+  end
+
+  def test_store_named_span_field_duplicate_name
+    trace = load_hash_from_json_file('test/unit/features/support/span_support_test_data/duplicate_span_name.json')
+    add_trace_to_request_list(trace)
+
+    name = '[AppStartPhase/Framework]'
+    error = assert_raises(Test::Unit::AssertionFailedError) do
+      SpanSupport.store_named_span_field(name, 'spanId', 'spanId')
+    end
+
+    assert_equal('Expected 1 span named [AppStartPhase/Framework], found 2', error.message)
   end
 end

--- a/test/unit/features/support/span_support_test_data/duplicate_span_name.json
+++ b/test/unit/features/support/span_support_test_data/duplicate_span_name.json
@@ -1,0 +1,200 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "os.type",
+            "value": {
+              "stringValue": "linux"
+            }
+          },
+          {
+            "key": "os.name",
+            "value": {
+              "stringValue": "android"
+            }
+          },
+          {
+            "key": "os.version",
+            "value": {
+              "stringValue": "16"
+            }
+          },
+          {
+            "key": "bugsnag.device.android_api_version",
+            "value": {
+              "stringValue": "36"
+            }
+          },
+          {
+            "key": "device.model.identifier",
+            "value": {
+              "stringValue": "SM-S926B"
+            }
+          },
+          {
+            "key": "device.manufacturer",
+            "value": {
+              "stringValue": "samsung"
+            }
+          },
+          {
+            "key": "deployment.environment",
+            "value": {
+              "stringValue": "production"
+            }
+          },
+          {
+            "key": "bugsnag.app.version_code",
+            "value": {
+              "stringValue": "1"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "com.bugsnag.mazeracer"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "bugsnag.performance.android"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.0.0"
+            }
+          },
+          {
+            "key": "device.id",
+            "value": {
+              "stringValue": "6a5d750d-1e76-4b05-875c-a03bea2129ca"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "name": "[AppStartPhase/Framework]",
+              "kind": 1,
+              "spanId": "39483a1ecaffbe1b",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150452534219",
+              "endTimeUnixNano": "1761240150454439336",
+              "parentSpanId": "21b6c2b0046b0de3",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "app_start_phase"
+                  }
+                },
+                {
+                  "key": "bugsnag.span.first_class",
+                  "value": {
+                    "boolValue": false
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.phase",
+                  "value": {
+                    "stringValue": "FrameworkLoad"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[AppStartPhase/Framework]",
+              "kind": 1,
+              "spanId": "551c6b70dea89d53",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150474802070",
+              "endTimeUnixNano": "1761240150487316602",
+              "parentSpanId": "3470404c1019efbf",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "view_load_phase"
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.view.name",
+                  "value": {
+                    "stringValue": "SplashScreenActivity"
+                  }
+                },
+                {
+                  "key": "bugsnag.view.type",
+                  "value": {
+                    "stringValue": "activity"
+                  }
+                },
+                {
+                  "key": "bugsnag.phase",
+                  "value": {
+                    "stringValue": "ActivityCreate"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/features/support/span_support_test_data/instrumentation_spans.json
+++ b/test/unit/features/support/span_support_test_data/instrumentation_spans.json
@@ -1,0 +1,635 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "os.type",
+            "value": {
+              "stringValue": "linux"
+            }
+          },
+          {
+            "key": "os.name",
+            "value": {
+              "stringValue": "android"
+            }
+          },
+          {
+            "key": "os.version",
+            "value": {
+              "stringValue": "16"
+            }
+          },
+          {
+            "key": "bugsnag.device.android_api_version",
+            "value": {
+              "stringValue": "36"
+            }
+          },
+          {
+            "key": "device.model.identifier",
+            "value": {
+              "stringValue": "SM-S926B"
+            }
+          },
+          {
+            "key": "device.manufacturer",
+            "value": {
+              "stringValue": "samsung"
+            }
+          },
+          {
+            "key": "deployment.environment",
+            "value": {
+              "stringValue": "production"
+            }
+          },
+          {
+            "key": "bugsnag.app.version_code",
+            "value": {
+              "stringValue": "1"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "com.bugsnag.mazeracer"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "bugsnag.performance.android"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.0.0"
+            }
+          },
+          {
+            "key": "device.id",
+            "value": {
+              "stringValue": "6a5d750d-1e76-4b05-875c-a03bea2129ca"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "name": "[AppStartPhase/Framework]",
+              "kind": 1,
+              "spanId": "39483a1ecaffbe1b",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150452534219",
+              "endTimeUnixNano": "1761240150454439336",
+              "parentSpanId": "21b6c2b0046b0de3",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "app_start_phase"
+                  }
+                },
+                {
+                  "key": "bugsnag.span.first_class",
+                  "value": {
+                    "boolValue": false
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.phase",
+                  "value": {
+                    "stringValue": "FrameworkLoad"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[ViewLoadPhase/ActivityCreate]SplashScreenActivity",
+              "kind": 1,
+              "spanId": "551c6b70dea89d53",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150474802070",
+              "endTimeUnixNano": "1761240150487316602",
+              "parentSpanId": "3470404c1019efbf",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "view_load_phase"
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.view.name",
+                  "value": {
+                    "stringValue": "SplashScreenActivity"
+                  }
+                },
+                {
+                  "key": "bugsnag.view.type",
+                  "value": {
+                    "stringValue": "activity"
+                  }
+                },
+                {
+                  "key": "bugsnag.phase",
+                  "value": {
+                    "stringValue": "ActivityCreate"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[ViewLoadPhase/ActivityStart]SplashScreenActivity",
+              "kind": 1,
+              "spanId": "9aa902393cf864b3",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150487568906",
+              "endTimeUnixNano": "1761240150487715273",
+              "parentSpanId": "3470404c1019efbf",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "view_load_phase"
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.view.name",
+                  "value": {
+                    "stringValue": "SplashScreenActivity"
+                  }
+                },
+                {
+                  "key": "bugsnag.view.type",
+                  "value": {
+                    "stringValue": "activity"
+                  }
+                },
+                {
+                  "key": "bugsnag.phase",
+                  "value": {
+                    "stringValue": "ActivityStart"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[ViewLoadPhase/ActivityResume]SplashScreenActivity",
+              "kind": 1,
+              "spanId": "c8c29cec3976becf",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150493103008",
+              "endTimeUnixNano": "1761240150494519023",
+              "parentSpanId": "3470404c1019efbf",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "view_load_phase"
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.view.name",
+                  "value": {
+                    "stringValue": "SplashScreenActivity"
+                  }
+                },
+                {
+                  "key": "bugsnag.view.type",
+                  "value": {
+                    "stringValue": "activity"
+                  }
+                },
+                {
+                  "key": "bugsnag.phase",
+                  "value": {
+                    "stringValue": "ActivityResume"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[ViewLoadPhase/ActivityCreate]MainActivity",
+              "kind": 1,
+              "spanId": "8915da6e43deb150",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150757082891",
+              "endTimeUnixNano": "1761240150772205781",
+              "parentSpanId": "db78feffc57d5ebb",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "view_load_phase"
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.view.name",
+                  "value": {
+                    "stringValue": "MainActivity"
+                  }
+                },
+                {
+                  "key": "bugsnag.view.type",
+                  "value": {
+                    "stringValue": "activity"
+                  }
+                },
+                {
+                  "key": "bugsnag.phase",
+                  "value": {
+                    "stringValue": "ActivityCreate"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[ViewLoadPhase/ActivityStart]MainActivity",
+              "kind": 1,
+              "spanId": "0fd0507858ce8bee",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150772553398",
+              "endTimeUnixNano": "1761240150772738242",
+              "parentSpanId": "db78feffc57d5ebb",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "view_load_phase"
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.view.name",
+                  "value": {
+                    "stringValue": "MainActivity"
+                  }
+                },
+                {
+                  "key": "bugsnag.view.type",
+                  "value": {
+                    "stringValue": "activity"
+                  }
+                },
+                {
+                  "key": "bugsnag.phase",
+                  "value": {
+                    "stringValue": "ActivityStart"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[ViewLoadPhase/ActivityResume]MainActivity",
+              "kind": 1,
+              "spanId": "3ed08fcb3151501b",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150772909375",
+              "endTimeUnixNano": "1761240150773111563",
+              "parentSpanId": "db78feffc57d5ebb",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "view_load_phase"
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.view.name",
+                  "value": {
+                    "stringValue": "MainActivity"
+                  }
+                },
+                {
+                  "key": "bugsnag.view.type",
+                  "value": {
+                    "stringValue": "activity"
+                  }
+                },
+                {
+                  "key": "bugsnag.phase",
+                  "value": {
+                    "stringValue": "ActivityResume"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[ViewLoad/Activity]SplashScreenActivity",
+              "kind": 1,
+              "spanId": "3470404c1019efbf",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150474707734",
+              "endTimeUnixNano": "1761240150494534180",
+              "parentSpanId": "21b6c2b0046b0de3",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "view_load"
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.view.type",
+                  "value": {
+                    "stringValue": "activity"
+                  }
+                },
+                {
+                  "key": "bugsnag.view.name",
+                  "value": {
+                    "stringValue": "SplashScreenActivity"
+                  }
+                },
+                {
+                  "key": "bugsnag.span.first_class",
+                  "value": {
+                    "boolValue": true
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[AppStart/AndroidCold]SplashScreen",
+              "kind": 1,
+              "spanId": "21b6c2b0046b0de3",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150451965625",
+              "endTimeUnixNano": "1761240150773119336",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "app_start"
+                  }
+                },
+                {
+                  "key": "bugsnag.span.first_class",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.app_start.type",
+                  "value": {
+                    "stringValue": "cold"
+                  }
+                },
+                {
+                  "key": "bugsnag.view.type",
+                  "value": {
+                    "stringValue": "activity"
+                  }
+                },
+                {
+                  "key": "bugsnag.app_start.first_view_name",
+                  "value": {
+                    "stringValue": "SplashScreenActivity"
+                  }
+                },
+                {
+                  "key": "bugsnag.app_start.name",
+                  "value": {
+                    "stringValue": "SplashScreen"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[ViewLoad/Activity]MainActivity",
+              "kind": 1,
+              "spanId": "db78feffc57d5ebb",
+              "traceId": "31367d8fff1646f1a358ea69ccbd345e",
+              "startTimeUnixNano": "1761240150757008047",
+              "endTimeUnixNano": "1761240150773119336",
+              "parentSpanId": "21b6c2b0046b0de3",
+              "attributes": [
+                {
+                  "key": "bugsnag.sampling.p",
+                  "value": {
+                    "doubleValue": 1.0
+                  }
+                },
+                {
+                  "key": "bugsnag.span.category",
+                  "value": {
+                    "stringValue": "view_load"
+                  }
+                },
+                {
+                  "key": "net.host.connection.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "bugsnag.app.in_foreground",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "bugsnag.view.type",
+                  "value": {
+                    "stringValue": "activity"
+                  }
+                },
+                {
+                  "key": "bugsnag.view.name",
+                  "value": {
+                    "stringValue": "MainActivity"
+                  }
+                },
+                {
+                  "key": "bugsnag.span.first_class",
+                  "value": {
+                    "boolValue": true
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/test_helper.rb
+++ b/test/unit/test_helper.rb
@@ -11,3 +11,12 @@ require 'timecop'
 # being safe.
 # https://github.com/travisjeffery/timecop#timecopsafe_mode
 Timecop.safe_mode = true
+
+def load_hash_from_json_file(filename)
+  file = File.join(File.dirname(__FILE__), '..', '..', filename)
+  JSON.parse(File.read(file))
+end
+
+def add_trace_to_request_list(trace)
+  Maze::Server.traces.add({ body: trace })
+end


### PR DESCRIPTION
## Goal

Provide a mechanism for looking up and storing fields from names spans, rather than rely on the ordering of spans within a trace.

## Design

I've used this as an opportunity to further separate the implementation of Cucumber step definitions from the Cucumber-specific definitions under `features/steps`.  This allows the unit testing of often fairly complex logic.

## Changeset

A number of existing functions are moved into the new `SpanSupport` class, with a new method `store_named_span_field`added .

## Tests

Existing e2e tests updated and new unit tests created.