### PR TITLE
Add the ability record macOS screens during a test run

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,7 +158,7 @@ steps:
     commands:
       - "cd test/e2e/macos-recording"
       - "bundle install"
-      - "bundle exec maze-runner"
+      - "bundle exec maze-runner --farm=local --browser=firefox --record-screen"
 
   #
   # BrowserStack tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -153,6 +153,8 @@ steps:
 
   - label: "macOS recording tests"
     timeout_in_minutes: 10
+    agents:
+      queue: "macos-15"
     commands:
       - "cd test/e2e/macos-recording"
       - "bundle install"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -151,6 +151,13 @@ steps:
           run: "command-workflow-tests"
     command: "bundle exec maze-runner"
 
+  - label: "macOS recording tests"
+    timeout_in_minutes: 10
+    commands:
+      - "cd test/e2e/macos-recording"
+      - "bundle install"
+      - "bundle exec maze-runner"
+
   #
   # BrowserStack tests
   #

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -162,7 +162,7 @@ steps:
     plugins:
       artifacts#v1.9.0:
         upload: 
-          - "maze_output/**/*"
+          - "test/e2e/macos-recording/features/maze_output/**/*"
 
   #
   # BrowserStack tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -162,7 +162,7 @@ steps:
     plugins:
       artifacts#v1.9.0:
         upload: 
-          - "test/e2e/macos-recording/features/maze_output/**/*"
+          - "test/e2e/macos-recording/maze_output/**/*"
 
   #
   # BrowserStack tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,7 +158,11 @@ steps:
     commands:
       - "cd test/e2e/macos-recording"
       - "bundle install"
-      - "bundle exec maze-runner --farm=local --browser=firefox --record-screen"
+      - "bundle exec maze-runner --farm=local --browser=firefox --record-screen features/macos_recording.feature"
+    plugins:
+      artifacts#v1.9.0:
+        upload: 
+          - "maze_output/**/*"
 
   #
   # BrowserStack tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+## Enhancements
+
+- Add `--record-screen` to the CLI options to record macOS screens during a test run [828](https://github.com/bugsnag/maze-runner/pull/828)
+
 # v11.0.0 - 2026/02/09
 
 ## Enhancements

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -221,6 +221,8 @@ class MazeRunnerEntry
     end
 
     Maze::Option::Processor.populate Maze.config, options
+    # Ensure record_screen is set on Maze.config
+    Maze.config.record_screen = options[Maze::Option::RECORD_SCREEN]
 
     # Adjust CL options before calling down to Cucumber
     remove_maze_runner_args

--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -221,8 +221,6 @@ class MazeRunnerEntry
     end
 
     Maze::Option::Processor.populate Maze.config, options
-    # Ensure record_screen is set on Maze.config
-    Maze.config.record_screen = options[Maze::Option::RECORD_SCREEN]
 
     # Adjust CL options before calling down to Cucumber
     remove_maze_runner_args

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -41,7 +41,7 @@ BeforeAll do
 
   if Maze.config.record_screen
     begin
-      $screen_recording_path = Maze::MacosUtils.start_screen_recording(OpenStruct.new(name: "all_scenarios"))
+      Maze::MacosUtils.start_screen_recording(OpenStruct.new(name: "all_scenarios"))
       $logger.info "Started macOS screen recording."
     rescue => e
       $logger.error "Failed to start screen recording: #{e.message}"

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -6,6 +6,7 @@ require 'json'
 require 'securerandom'
 require 'selenium-webdriver'
 require 'uri'
+require 'ostruct'
 
 BeforeAll do
   Maze.check = Maze::Checks::AssertCheck.new
@@ -37,6 +38,16 @@ BeforeAll do
   end
   maze_output_zip = Dir.glob(File.join(Dir.pwd, 'maze_output.zip'))
   FileUtils.rm_rf(maze_output_zip)
+
+  if Maze.config.os == "macos" && Maze.config.record_screen
+    begin
+      $screen_recording_path = Maze::MacosUtils.start_screen_recording(OpenStruct.new(name: "all_scenarios"))
+      $logger.info "Started macOS screen recording."
+    rescue => e
+      $logger.error "Failed to start screen recording: #{e.message}"
+    end
+  end
+  # Start screen recording on macOS before any tests, if enabled
 
   # Record the local server starting time
   Maze.start_time = Time.now.strftime('%Y-%m-%d %H:%M:%S')
@@ -128,7 +139,7 @@ After do |scenario|
 
   # If we're running on macos, take a screenshot if the scenario fails
   if Maze.config.os == "macos" && scenario.status == :failed
-    Maze::MacosUtils.capture_screen(scenario)
+    Maze::MacosUtils.take_screenshot(scenario)
   end
 
   # Invoke the logger hook for the scenario
@@ -263,6 +274,16 @@ end
 
 # After all tests
 AfterAll do
+  # Stop screen recording on macOS after all tests, if enabled
+  if Maze.config.os == "macos" && Maze.config.record_screen
+    $logger.info "Stopping macOS screen recording..."
+        begin
+      path = Maze::MacosUtils.stop_screen_recording(OpenStruct.new(name: "all_scenarios"))
+      $logger.info "Stopped macOS screen recording. Saved to: #{path}"
+    rescue => e
+      $logger.error "Failed to stop screen recording: #{e.message}"
+    end
+  end
   # Ensure the logger output is in the correct location
   Maze::Hooks::LoggerHooks.after_all
 

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -39,7 +39,7 @@ BeforeAll do
   maze_output_zip = Dir.glob(File.join(Dir.pwd, 'maze_output.zip'))
   FileUtils.rm_rf(maze_output_zip)
 
-  if Maze.config.os == "macos" && Maze.config.record_screen
+  if Maze.config.record_screen
     begin
       $screen_recording_path = Maze::MacosUtils.start_screen_recording(OpenStruct.new(name: "all_scenarios"))
       $logger.info "Started macOS screen recording."
@@ -275,7 +275,7 @@ end
 # After all tests
 AfterAll do
   # Stop screen recording on macOS after all tests, if enabled
-  if Maze.config.os == "macos" && Maze.config.record_screen
+  if Maze.config.record_screen
     $logger.info "Stopping macOS screen recording..."
         begin
       path = Maze::MacosUtils.stop_screen_recording(OpenStruct.new(name: "all_scenarios"))

--- a/lib/features/support/internal_hooks.rb
+++ b/lib/features/support/internal_hooks.rb
@@ -276,8 +276,7 @@ end
 AfterAll do
   # Stop screen recording on macOS after all tests, if enabled
   if Maze.config.record_screen
-    $logger.info "Stopping macOS screen recording..."
-        begin
+    begin
       path = Maze::MacosUtils.stop_screen_recording(OpenStruct.new(name: "all_scenarios"))
       $logger.info "Stopped macOS screen recording. Saved to: #{path}"
     rescue => e

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -2,8 +2,8 @@
 
 module Maze
   # MazeRunner configuration
-  class Configuration
-
+    class Configuration
+      
     # Set default values
     def initialize
       self.receive_no_requests_wait = 30
@@ -212,6 +212,9 @@ module Maze
 
     # The location of the appium server logfile
     attr_accessor :appium_logfile
+
+    # Enable screen recording for the test run
+    attr_accessor :record_screen
 
     #
     # Logging configuration

--- a/lib/maze/configuration.rb
+++ b/lib/maze/configuration.rb
@@ -3,7 +3,6 @@
 module Maze
   # MazeRunner configuration
     class Configuration
-      
     # Set default values
     def initialize
       self.receive_no_requests_wait = 30

--- a/lib/maze/macos_utils.rb
+++ b/lib/maze/macos_utils.rb
@@ -18,20 +18,10 @@ module Maze
         FileUtils.makedirs(path) unless File.exist?(path)
         filename = "#{Maze::Helper.to_friendly_filename(scenario.name)}-screenrecording.mp4"
         @screen_recording_path = File.join(path, filename)
-        # Start ffmpeg screen recording in the background.
-        # The macOS screen index used for capture is configurable via the
-        # MAZE_MACOS_SCREEN_INDEX environment variable. It defaults to "1"
-        # to preserve existing behavior, but note that in AVFoundation device
-        # indexes are 0-based and "0" is often the primary display.
-        screen_index = ENV.fetch('MAZE_MACOS_SCREEN_INDEX', '1')
         begin
           @screen_recording_pid = Process.spawn(
-            'ffmpeg',
-            '-y',
-            '-f', 'avfoundation',
-            '-framerate', '30',
-            '-i', '1:none',
-            '-pix_fmt', 'yuv420p',
+            'screencapture',
+            '-v',
             @screen_recording_path,
             out: File::NULL, err: File::NULL
           )
@@ -46,7 +36,7 @@ module Maze
           pid, status = Process.waitpid2(@screen_recording_pid, Process::WNOHANG)
           if pid
             @screen_recording_pid = nil
-            raise "ffmpeg exited immediately while starting screen recording (status #{status.exitstatus})."
+            raise "screencapture exited immediately while starting screen recording (status #{status.exitstatus})."
           end
 
           begin
@@ -59,7 +49,7 @@ module Maze
 
           if Time.now - start_time > 5
             @screen_recording_pid = nil
-            raise 'ffmpeg did not appear to start screen recording within the expected time.'
+            raise 'screencapture did not appear to start screen recording within the expected time.'
           end
 
           sleep 0.1

--- a/lib/maze/macos_utils.rb
+++ b/lib/maze/macos_utils.rb
@@ -35,6 +35,7 @@ module Maze
           out: File::NULL, err: File::NULL
         )
         Process.detach(@screen_recording_pid)
+        @screen_recording_path
       end
 
       def stop_screen_recording(_scenario)

--- a/lib/maze/macos_utils.rb
+++ b/lib/maze/macos_utils.rb
@@ -24,17 +24,48 @@ module Maze
         # to preserve existing behavior, but note that in AVFoundation device
         # indexes are 0-based and "0" is often the primary display.
         screen_index = ENV.fetch('MAZE_MACOS_SCREEN_INDEX', '1')
-        @screen_recording_pid = Process.spawn(
-          'ffmpeg',
-          '-y',
-          '-f', 'avfoundation',
-          '-framerate', '30',
-          '-i', "#{screen_index}:none",
-          '-pix_fmt', 'yuv420p',
-          @screen_recording_path,
-          out: File::NULL, err: File::NULL
-        )
-        Process.detach(@screen_recording_pid)
+        begin
+          @screen_recording_pid = Process.spawn(
+            'ffmpeg',
+            '-y',
+            '-f', 'avfoundation',
+            '-framerate', '30',
+            '-i', '1:none',
+            '-pix_fmt', 'yuv420p',
+            @screen_recording_path,
+            out: File::NULL, err: File::NULL
+          )
+        rescue StandardError => e
+          raise "Failed to start ffmpeg screen recording: #{e.message}"
+        end
+
+        # Verify that ffmpeg has actually started and is still running before detaching.
+        start_time = Time.now
+        loop do
+          # Check if the process has already exited.
+          pid, status = Process.waitpid2(@screen_recording_pid, Process::WNOHANG)
+          if pid
+            @screen_recording_pid = nil
+            raise "ffmpeg exited immediately while starting screen recording (status #{status.exitstatus})."
+          end
+
+          begin
+            # Signal 0 checks for process existence without sending a real signal.
+            Process.kill(0, @screen_recording_pid)
+            break
+          rescue Errno::ESRCH
+            # Process not yet running or already gone; allow a brief grace period.
+          end
+
+          if Time.now - start_time > 5
+            @screen_recording_pid = nil
+            raise 'ffmpeg did not appear to start screen recording within the expected time.'
+          end
+
+          sleep 0.1
+        end
+
+        Process.detach(@screen_recording_pid) if @screen_recording_pid
         @screen_recording_path
       end
 

--- a/lib/maze/macos_utils.rb
+++ b/lib/maze/macos_utils.rb
@@ -3,11 +3,46 @@
 module Maze
   class MacosUtils
     class << self
-      def capture_screen(scenario)
+      def take_screenshot(scenario)
         path = Maze::MazeOutput.new(scenario).output_folder
         FileUtils.makedirs(path) unless File.exist?(path)
 
         system('/usr/sbin/screencapture', "#{path}/#{Maze::Helper.to_friendly_filename(scenario.name)}-screenshot.jpg")
+      end
+
+      def start_screen_recording(scenario)
+        unless system('which ffmpeg > /dev/null 2>&1')
+          raise 'ffmpeg is not installed or not found in PATH. Please install ffmpeg to use screen recording.'
+        end
+        path = Maze::MazeOutput.new(scenario).recording
+        FileUtils.makedirs(path) unless File.exist?(path)
+        filename = "#{Maze::Helper.to_friendly_filename(scenario.name)}-screenrecording.mp4"
+        @screen_recording_path = File.join(path, filename)
+        # Start ffmpeg screen recording in the background
+        # macOS screen index 1 is usually the main display
+        @screen_recording_pid = Process.spawn(
+          'ffmpeg',
+          '-y',
+          '-f', 'avfoundation',
+          '-framerate', '30',
+          '-i', '1:none',
+          '-pix_fmt', 'yuv420p',
+          @screen_recording_path,
+          out: File::NULL, err: File::NULL
+        )
+        Process.detach(@screen_recording_pid)
+      end
+
+      def stop_screen_recording(_scenario)
+        if @screen_recording_pid
+          begin
+            Process.kill('TERM', @screen_recording_pid)
+          rescue Errno::ESRCH
+            # Process already exited
+          end
+          @screen_recording_pid = nil
+        end
+        @screen_recording_path
       end
     end
   end

--- a/lib/maze/macos_utils.rb
+++ b/lib/maze/macos_utils.rb
@@ -18,14 +18,18 @@ module Maze
         FileUtils.makedirs(path) unless File.exist?(path)
         filename = "#{Maze::Helper.to_friendly_filename(scenario.name)}-screenrecording.mp4"
         @screen_recording_path = File.join(path, filename)
-        # Start ffmpeg screen recording in the background
-        # macOS screen index 1 is usually the main display
+        # Start ffmpeg screen recording in the background.
+        # The macOS screen index used for capture is configurable via the
+        # MAZE_MACOS_SCREEN_INDEX environment variable. It defaults to "1"
+        # to preserve existing behavior, but note that in AVFoundation device
+        # indexes are 0-based and "0" is often the primary display.
+        screen_index = ENV.fetch('MAZE_MACOS_SCREEN_INDEX', '1')
         @screen_recording_pid = Process.spawn(
           'ffmpeg',
           '-y',
           '-f', 'avfoundation',
           '-framerate', '30',
-          '-i', '1:none',
+          '-i', "#{screen_index}:none",
           '-pix_fmt', 'yuv420p',
           @screen_recording_path,
           out: File::NULL, err: File::NULL

--- a/lib/maze/maze_output.rb
+++ b/lib/maze/maze_output.rb
@@ -147,5 +147,12 @@ module Maze
 
       File.join(folder1, folder2, folder3)
     end
+
+    def recording
+      folder1 = File.join(Dir.pwd, 'maze_output')
+      folder2 = "recordings"
+
+      File.join(folder1, folder2)
+    end
   end
 end

--- a/lib/maze/option.rb
+++ b/lib/maze/option.rb
@@ -44,6 +44,7 @@ module Maze
     APPLE_TEAM_ID = 'apple-team-id'
     START_APPIUM = 'start-appium'
     UDID = 'udid'
+    RECORD_SCREEN = 'record-screen'
 
     # Logging options
     ALWAYS_LOG = 'always-log'

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -187,7 +187,6 @@ module Maze
                 'OS type to use ("ios", "android")',
                 short: :none,
                 type: :string,
-                default: 'macos'
             opt Option::OS_VERSION,
                 'The intended OS version when running on a local device',
                 short: :none,

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -186,7 +186,7 @@ module Maze
             opt Option::OS,
                 'OS type to use ("ios", "android")',
                 short: :none,
-                type: :string,
+                type: :string
             opt Option::OS_VERSION,
                 'The intended OS version when running on a local device',
                 short: :none,

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -186,7 +186,8 @@ module Maze
             opt Option::OS,
                 'OS type to use ("ios", "android")',
                 short: :none,
-                type: :string
+                type: :string,
+                default: 'macos'
             opt Option::OS_VERSION,
                 'The intended OS version when running on a local device',
                 short: :none,
@@ -207,6 +208,11 @@ module Maze
                 'Apple UDID, required for local iOS testing. MAZE_UDID env var by default',
                 short: :none,
                 type: :string
+            opt Option::RECORD_SCREEN,
+                'Enable macOS screen recording for the duration of the test run',
+                type: :boolean,
+                short: :none,
+                default: false
 
             text ''
             text 'Logging options:'

--- a/lib/maze/option/processor.rb
+++ b/lib/maze/option/processor.rb
@@ -35,6 +35,9 @@ module Maze
           config.log_requests = options[Maze::Option::LOG_REQUESTS] || !ENV['BUILDKITE'].nil?
           config.always_log = options[Maze::Option::ALWAYS_LOG]
 
+          # Screen recording options
+          config.record_screen = options[Maze::Option::RECORD_SCREEN]
+
           # General appium options
           config.app = Maze::Helper.read_at_arg_file options[Maze::Option::APP]
           farm = options[Maze::Option::FARM]

--- a/test/e2e/macos-recording/Gemfile
+++ b/test/e2e/macos-recording/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'bugsnag-maze-runner', path: '../../..'

--- a/test/e2e/macos-recording/features/macos_recording.feature
+++ b/test/e2e/macos-recording/features/macos_recording.feature
@@ -1,0 +1,5 @@
+Feature: macOS browser recording
+
+  Scenario: Open browser, navigate to bugsnag.com, wait, and close
+    When I navigate to the URL "https://www.bugsnag.com"
+    Then I wait for 5 seconds


### PR DESCRIPTION
## Goal

Add support for screen recording on macOS during test runs to improve debugging capabilities when tests fail or when visibility into the full test execution is needed.

## Design

The implementation uses `ffmpeg` to record the screen throughout the entire test run:

- A new `--record-screen` CLI option enables/disables the feature (defaults to `false`)
- Screen recording starts in the `BeforeAll` hook and stops in the `AfterAll` hook, capturing the entire test suite execution
- Recordings are saved to `maze_output/recordings/` using `ffmpeg` with the AVFoundation framework
- The existing screenshot functionality has been renamed from `capture_screen` to `take_screenshot` for clarity
- Screenshots continue to be captured on scenario failure (when running on macOS)

The recording process runs as a detached background process and is gracefully terminated at the end of the run using `SIGTERM`.

## Documentation

This PR adds functionality:

- New CLI option: `--record-screen`
- New configuration attribute: `Maze.config.capture_screen`
- New public methods in `MacosUtils: start_screen_recording` and `stop_screen_recording`
- Renamed method: `capture_screen` → `take_screenshot`

Documentation updates may be needed for:

- CLI options reference
- macOS-specific testing features
- Requirement to install `ffmpeg` for screen recording

## Changeset

- Added `--record-screen` CLI option to enable screen recording - `lib/maze/option/parser.rb`
- Added `record_screen` configuration attribute - `lib/maze/configuration.rb`
- Implemented screen recording start/stop in BeforeAll/AfterAll hooks - `lib/features/support/internal_hooks.rb`
- Added `start_screen_recording` and `stop_screen_recording` methods to `MacosUtils` - `lib/maze/macos_utils.rb`
- Renamed `capture_screen` to `take_screenshot` in `MacosUtils` - `lib/maze/macos_utils.rb`
- Added `recording` method to `MazeOutput` for determining recording output folder `lib/maze/maze_output.rb`
- Set `record_screen` on `Maze.config` from parsed options `lib/maze/option/processor.rb`


## Tests

- Tested manually by setting `--record-screen` when running tests on macOS
- Verified a video was recorded and stored in `maze_ouput/recordings`
