### PR TITLE
Update browserstack session dashboard links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Enhancements
+
+- Update BrowserStack dashboard URLs for Appium and Selenium clients to use new dashboard direct build links instead of search links [830](https://github.com/bugsnag/maze-runner/pull/830)
+
 # v11.0.0 - 2026/02/09
 
 ## Enhancements

--- a/lib/maze/client/appium/bs_client.rb
+++ b/lib/maze/client/appium/bs_client.rb
@@ -64,8 +64,10 @@ module Maze
         end
 
         def log_run_intro
+          project = project_name_capabilities[:project]
+          build_id = Maze.run_uuid
           # Log a link to the BrowserStack session search dashboard
-          url = "https://app-automate.browserstack.com/dashboard/v2/search?query=#{Maze.run_uuid}&type=builds"
+          url = "https://app-automate.browserstack.com/projects/#{project}/builds/#{build_id}/1"
           $logger.info Maze::Loggers::LogUtil.linkify(url, 'BrowserStack session(s)')
         end
 

--- a/lib/maze/client/selenium/bs_client.rb
+++ b/lib/maze/client/selenium/bs_client.rb
@@ -69,12 +69,12 @@ module Maze
             build: Maze.run_uuid
           }
         end
-
+        
         def log_session_info
           project = project_name_capabilities[:project]
           build_id = Maze.run_uuid
           # Log a link to the BrowserStack session search dashboard
-          url = "https://app-automate.browserstack.com/projects/#{project}/builds/#{build_id}/1"
+          url = "https://automate.browserstack.com/projects/#{project}/builds/#{build_id}/1"
           $logger.info Maze::Loggers::LogUtil.linkify url, 'BrowserStack session(s)'
         end
       end

--- a/lib/maze/client/selenium/bs_client.rb
+++ b/lib/maze/client/selenium/bs_client.rb
@@ -71,8 +71,10 @@ module Maze
         end
 
         def log_session_info
+          project = project_name_capabilities[:project]
+          build_id = Maze.run_uuid
           # Log a link to the BrowserStack session search dashboard
-          url = "https://automate.browserstack.com/dashboard/v2/search?query=#{Maze.run_uuid}"
+          url = "https://app-automate.browserstack.com/projects/#{project}/builds/#{build_id}/1"
           $logger.info Maze::Loggers::LogUtil.linkify url, 'BrowserStack session(s)'
         end
       end


### PR DESCRIPTION
## Goal

At the end of a BrowserStack test run, Maze Runner logs a link to dashboard page for the BrowserStack session(s), update the link that Maze Runner output to use this new DASHBOARD.

## Design

Updated the dashboard URL and generated the following link format:
https://app-automate.browserstack.com/projects/#project/builds/#build_id/1

## Tests

Performed basic manual checks to verify that the updated link format directs to a suitable page.
