### PR TITLE
Update the valid device mapping for ANDROID_13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+# v11.1.0 - 2026/04/13
+
 ## Enhancements
 
 - Update BrowserStack dashboard URLs for Appium and Selenium clients to use new dashboard direct build links instead of search links [830](https://github.com/bugsnag/maze-runner/pull/830)
+
+## Fixes
+
+- Update valid device mapping for ANDROID_13 on BrowserStack to use correct model identifier [831](https://github.com/bugsnag/maze-runner/pull/831)
 
 # v11.0.0 - 2026/02/09
 

--- a/lib/maze.rb
+++ b/lib/maze.rb
@@ -8,7 +8,7 @@ require_relative 'maze/timers'
 # providing an alternative to the proliferation of global variables or singletons.
 module Maze
 
-  VERSION = '11.0.0'
+  VERSION = '11.1.0'
 
   class << self
     attr_accessor :check, :driver, :internal_hooks, :mode, :start_time, :dynamic_retry, :public_address,

--- a/lib/maze/client/appium/bs_devices.rb
+++ b/lib/maze/client/appium/bs_devices.rb
@@ -74,7 +74,7 @@ module Maze
               'ANDROID_16' => make_android_hash('Google Pixel 9', '16.0'),
               'ANDROID_15' => make_android_hash('Google Pixel 9', '15.0'),
               'ANDROID_14' => make_android_hash('Google Pixel 8', '14.0'),
-              'ANDROID_13' => make_android_hash('Google Pixel 6 Pro', '13.0'),
+              'ANDROID_13' => make_android_hash('Google Pixel 7', '13.0'),
               'ANDROID_12' => make_android_hash('Google Pixel 6', '12.0'),
               'ANDROID_11' => make_android_hash('Samsung Galaxy S21', '11.0'),
               'ANDROID_10' => make_android_hash('Samsung Galaxy S20', '10.0'),


### PR DESCRIPTION
## Goal

Updated the device mapping for `ANDROID_13` from `Google Pixel 6 Pro` to `Google Pixel 7`, as the previous device is no longer valid on BrowserStack.


## Tests

- Cloned the Android repo and set the local Maze Runner path in the Gemfile.
- Ran a test with the device set to `ANDROID_13`.
- The test failed with the old mapping (`Google Pixel 6 Pro`).
- Updated the mapping to `Google Pixel 7`.
- Re-ran the test and it passed.