### PR TITLE
PLAT-16006 Validate required args for list-devices and display valid error

### DIFF
--- a/bin/maze-runner
+++ b/bin/maze-runner
@@ -178,7 +178,7 @@ class MazeRunnerEntry
     paths.each { |path| @args << '-r' << path }
   end
 
-  # List devices for the given device farm, or all otherwise
+  # Main entrypoint for Maze Runner CLI invocation.
 
   def start(args)
     $logger.info "Maze Runner v#{Maze::VERSION}"
@@ -186,8 +186,22 @@ class MazeRunnerEntry
     # Parse args, processing any Maze Runner specific options
     @args = args.dup
     load_options_from_files
-    options = Maze::Option::Parser.parse @args
 
+    # Validate required args for list-devices before option parsing.
+    # This avoids parser-level failures and provides a clear user-facing error.
+    if @args.include?('--list-devices')
+      farm_arg = @args.find { |a| a.start_with?('--farm=') }
+      farm_value = farm_arg ? farm_arg.split('=', 2)[1] : nil
+      unless %w[bs bb].include?(farm_value)
+        puts "ERROR: A --farm option must be given when using --list-devices"
+        puts ""
+        puts "Valid usage:"
+        puts "  bundle exec maze-runner --farm=bs --list-devices"
+        puts "  bundle exec maze-runner --farm=bb --list-devices"
+        exit 1
+      end
+    end
+    options = Maze::Option::Parser.parse @args
     if options[Maze::Option::LIST_DEVICES]
       case options[Maze::Option::FARM].to_sym
       when :bs

--- a/lib/maze/option/parser.rb
+++ b/lib/maze/option/parser.rb
@@ -145,7 +145,7 @@ module Maze
                 short: :none,
                 type: :string
             opt Option::LIST_DEVICES,
-                'Lists the devices available for the configured device farm, or all devices if none are specified',
+                'Lists the devices available for the configured device farm (requires --farm=bs or --farm=bb)',
                 short: :none,
                 default: false
             opt Option::APP_BUNDLE_ID,


### PR DESCRIPTION
## Goal

--list-devices is used without a valid farm, Maze Runner exits with a clear error and usage guidance instead of an ugly parser crash.

## Tests

Manually verified —list-devices argument validation for missing/invalid --farm (--list-devices, --farm --list-devices, --farm=b1 --list-devices) returns a friendly error instead of parser failure.
Confirmed valid usage still works (--farm=bs --list-devices) and --help output remains correct.
