### PR TITLE
Replace deprecated bitbar macos version 13 to 14 for safari_18 browser capabilities

### DIFF
--- a/lib/maze/client/selenium/bb_browsers.yml
+++ b/lib/maze/client/selenium/bb_browsers.yml
@@ -46,7 +46,7 @@ edge_latest:
 
 safari_18:
   platformName: 'macOS'
-  osVersion: '13'
+  osVersion: '14'
   browserName: 'safari'
   browserVersion: '18'
   resolution: '2560x1920'


### PR DESCRIPTION
## Goal

Replace deprecated bitbar macos version 13 to 14 for safari_18 browser capabilities

## Tests

For local testing, the local maze-runner repo was linked into a bugsnag-js-performance repo inside test -> browser -> Gemfile, using a path so that the local changes are picked up without publishing and successfully ran maze-runner test cases locally with safari_18 
